### PR TITLE
Feature/add macos backup items doc

### DIFF
--- a/.github/workflows/verify-backup-script.yml
+++ b/.github/workflows/verify-backup-script.yml
@@ -1,0 +1,32 @@
+name: Verify macOS Backup Script
+
+on:
+  push:
+    paths:
+      - 'config/macos/backup_settings.sh'
+  pull_request:
+    paths:
+      - 'config/macos/backup_settings.sh'
+
+jobs:
+  verify:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install ShellCheck
+        run: brew install shellcheck
+
+      - name: Grant execution permission
+        run: chmod +x config/macos/backup_settings.sh
+
+      - name: Run backup script
+        run: ./config/macos/backup_settings.sh
+
+      - name: Check if settings.sh is generated
+        run: test -f config/macos/settings.sh
+
+      - name: Lint generated settings.sh
+        run: shellcheck config/macos/settings.sh

--- a/config/macos/backup-items.md
+++ b/config/macos/backup-items.md
@@ -2,16 +2,12 @@
 
 このドキュメントは、`config/macos/backup_settings.sh` スクリプトでバックアップ可能な macOS の設定項目と、それに対応するコマンドの一覧です。
 
-### 一般・UI/UX
+### システム
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `defaults write NSGlobalDomain _HIHideMenuBar -bool true` | メニューバーの自動非表示 | `true`でメニューバーを自動的に隠します。 |
-| `defaults write com.apple.universalaccess reduceTransparency -bool true` | メニューバーの透明度 | `true`でメニューバーの透明度を下げ、視認性を向上させます。 |
 | `defaults write NSGlobalDomain AppleHighlightColor -string "R G B"` | アクセントカラー | `R G B` に `0.0`〜`1.0`の値をスペース区切りで指定し、クリックや選択範囲のハイライト色を変更します。 |
-| `defaults write NSGlobalDomain NSTableViewDefaultSizeMode -int 2` | サイドバーのアイコンサイズ | サイドバーに表示されるアイコンのサイズを指定します。（1: 小, 2: 中, 3: 大） |
 | `defaults write NSGlobalDomain AppleShowScrollBars -string "Always"` | スクロールバーの表示 | スクロールバーを常に表示するかどうかを指定します。（`WhenScrolling`, `Automatic`, `Always`） |
-| `defaults write NSGlobalDomain NSWindowResizeTime -float 0.001` | ウィンドウリサイズのアニメーション速度 | アプリケーションのウィンドウサイズを変更する際のアニメーション速度を調整します。（`0.001` など小さい値で高速化） |
 | `defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode -bool true` | 保存パネルのデフォルト展開 | `true`で保存ダイアログを常に詳細表示で開きます。 |
 | `defaults write NSGlobalDomain PMPrintingExpandedStateForPrint -bool true` | 印刷パネルのデフォルト展開 | `true`で印刷ダイアログを常に詳細表示で開きます。 |
 | `defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false` | 書類をiCloudに保存 | `false`で新規作成した書類をデフォルトでローカルディスクに保存します。 |
@@ -19,6 +15,15 @@
 | `defaults write com.apple.systempreferences NSQuitAlwaysKeepsWindows -bool false` | システムの復元機能（Resume） | `false`でアプリケーションを再起動した際に前回のウィンドウを復元する機能を無効化します。 |
 | `defaults write NSGlobalDomain NSDisableAutomaticTermination -bool true` | 非アクティブなアプリの自動終了 | `true`で、システムのメモリが圧迫された際に、OSが非アクティブと判断したアプリケーションを自動終了させる機能を無効化します。 |
 | `defaults write com.apple.CrashReporter DialogType -string "none"` | クラッシュレポーター | `none`に設定すると、アプリケーションのクラッシュ時に表示されるレポート送信ダイアログを無効化します。 |
+
+### UI/UX
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `defaults write NSGlobalDomain _HIHideMenuBar -bool true` | メニューバーの自動非表示 | `true`でメニューバーを自動的に隠します。 |
+| `defaults write com.apple.universalaccess reduceTransparency -bool true` | メニューバーの透明度 | `true`でメニューバーの透明度を下げ、視認性を向上させます。 |
+| `defaults write NSGlobalDomain NSTableViewDefaultSizeMode -int 2` | サイドバーのアイコンサイズ | サイドバーに表示されるアイコンのサイズを指定します。（1: 小, 2: 中, 3: 大） |
+| `defaults write NSGlobalDomain NSWindowResizeTime -float 0.001` | ウィンドウリサイズのアニメーション速度 | アプリケーションのウィンドウサイズを変更する際のアニメーション速度を調整します。（`0.001` など小さい値で高速化） |
 | `defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false` | 自動大文字入力 | `false`で文頭の自動的な大文字化を無効にします。 |
 | `defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false` | スマートダッシュ | `false`でハイフン2つ（--）がエムダッシュ（—）に自動変換されるのを防ぎます。 |
 | `defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false` | スマートクオート | `false`でストレートクオート（"）がタイポグラフィカルクオート（“”）に自動変換されるのを防ぎます。 |
@@ -40,7 +45,7 @@
 | `defaults write com.apple.dock launchanim -bool false` | アプリケーション起動時のアニメーション | `false`でDockからアプリケーションを起動する際のジャンプアニメーションを無効化します。 |
 | `defaults write com.apple.dock showhidden -bool true` | 非表示アプリのアイコンを半透明化 | `true`で非表示（Hidden）に設定されているアプリケーションのアイコンを半透明で表示します。 |
 
-### Finderとデスクトップ
+### Finder
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
@@ -56,12 +61,17 @@
 | `defaults write com.apple.finder WarnOnEmptyTrash -bool false` | ゴミ箱を空にする前の警告 | `false`でゴミ箱を空にする際の確認ダイアログを無効にします。 |
 | `defaults write com.apple.finder FXRemoveOldTrashItems -bool true` | 30日後にゴミ箱を空にする | `true`で30日以上ゴミ箱にある項目を自動的に削除します。 |
 | `defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true` | `.DS_Store`ファイルの生成抑制 | ネットワークドライブやUSBメモリで `.DS_Store` ファイルが自動生成されるのを防ぎます。 |
-| `defaults write com.apple.finder ShowExternalHardDrivesOnDesktop -bool true` | デスクトップアイコンの表示 | デスクトップに表示するアイコンの種類を制御します。（ハードドライブ、外部ディスク、リムーバブルメディア、サーバー） |
 | `defaults write com.apple.finder QuitMenuItem -bool true` | Finderの終了メニュー | `true`でFinderのメニューに「Finderを終了」の項目を追加します。 |
 | `defaults write com.apple.finder DisableAllAnimations -bool true` | Finderのアニメーション効果 | `true`でFinderのウィンドウアニメーションや情報表示のアニメーションを無効化します。 |
 | `defaults write NSGlobalDomain com.apple.springing.enabled -bool true` | スプリングローディング | ディレクトリ上でのドラッグ＆ドロップ操作におけるスプリングローディング（フォルダが自動で開く機能）を有効化・高速化します。 |
 
-### ミッションコントロールとホットコーナー
+### デスクトップ
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `defaults write com.apple.finder ShowExternalHardDrivesOnDesktop -bool true` | デスクトップアイコンの表示 | デスクトップに表示するアイコンの種類を制御します。（ハードドライブ、外部ディスク、リムーバブルメディア、サーバー） |
+
+### ミッションコントロール
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
@@ -71,9 +81,14 @@
 | `defaults write com.apple.dock workspaces-auto-swoosh -bool true` | アプリ切り替え時にスペースを移動 | `true`でアプリケーションのウィンドウが含まれる操作スペースに自動で切り替えます。 |
 | `defaults write com.apple.spaces spans-displays -bool true` | ディスプレイごとに個別の操作スペース | `true`で各ディスプレイに個別のメニューバーと操作スペースを持たせます。 |
 | `defaults write com.apple.dashboard mcx-disabled -bool true` | Dashboardの無効化 | `true`でDashboard機能を無効にします。 |
+
+### ホットコーナー
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
 | `defaults write com.apple.dock wvous-tl-corner -int 2` | ホットコーナーの設定 | 画面の四隅（tl:左上, tr:右上, bl:左下, br:右下）にカーソルを移動したときのアクションを割り当てます。 |
 
-### キーボードとマウス・トラックパッド
+### キーボード
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
@@ -83,9 +98,19 @@
 | `defaults write NSGlobalDomain AppleKeyboardUIMode -int 3` | フルキーボードアクセス | モーダルダイアログ内のすべてのコントロール（ボタンなど）をTabキーで移動できるようにします。 |
 | `defaults write NSGlobalDomain com.apple.swipescrolldirection -bool false` | 「自然な」スクロール | `false`でコンテンツと指の動きが連動しない、従来のスクロール方向にします。 |
 | `defaults write com.apple.keyboard.fnState -bool true` | ファンクションキーの動作 | `true`でF1, F2などのキーを標準のファンクションキーとして使用します。 |
+
+### マウス
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
 | `defaults write -g com.apple.mouse.scaling -float 3.0` | マウスの移動速度 | マウスカーソルの移動速度を調整します。 |
 | `defaults write .GlobalPreferences com.apple.mouse.scaling -1` | マウス加速の無効化 | `-1` を設定することでマウスの加速を無効にし、リニアな動きにします。 |
 | `defaults write com.apple.Terminal FocusFollowsMouse -bool true` | マウスカーソル追従フォーカス | `true`でマウスカーソルをウィンドウ上に移動するだけでそのウィンドウをアクティブにします。（クリック不要） |
+
+### トラックパッド
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
 | `defaults write -g com.apple.trackpad.scaling -float 1.5` | トラックパッドの移動速度 | トラックパッドでのカーソル移動速度を調整します。 |
 | `defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true` | タップでクリック | `true`でトラックパッドをタップしてクリックできるようにします。 |
 | `defaults write com.apple.AppleMultitouchTrackpad Dragging -bool true` | タップでドラッグ | `true`でダブルタップから指を離さずにドラッグ操作ができるようにします。 |
@@ -95,7 +120,7 @@
 | `defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerTapGesture -int 2` | 3本指タップ | 3本指タップの動作を割り当てます。（0: 無効, 2: 辞書で調べる） |
 | `defaults write com.apple.AppleMultitouchTrackpad TrackpadRightClick -bool true` | 2本指で右クリック | `true`で2本指でのクリックまたはタップを右クリックとして扱います。 |
 
-### サウンドと通知
+### サウンド
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
@@ -104,6 +129,11 @@
 | `defaults write -g "com.apple.sound.beep.feedback" -int 0` | 音量変更時のフィードバック音 | `0`で音量を変更したときに再生される効果音を無効にします。 |
 | `defaults write -g "com.apple.sound.beep.sound" -string "/path/to/sound.aiff"` | アラート音の種類 | システムのアラート音として使用するサウンドファイルを指定します。 |
 | `defaults write com.apple.BluetoothAudioAgent "Apple Bitpool Min (editable)" -int 40` | Bluetoothヘッドフォンの音質向上 | Bluetoothオーディオのビットプール値を調整し、音質を向上させます。 |
+
+### 通知
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
 | `launchctl unload -w /System/Library/LaunchAgents/com.apple.notificationcenterui.plist` | 通知センターの無効化 | `launchctl`を使い、通知センターのプロセスを無効化します。 |
 
 ### スクリーンショット
@@ -124,7 +154,7 @@
 | `sudo pmset -a autorestart 1` | 電源喪失時の自動再起動 | `1`で停電などから復旧した際に自動的にMacを再起動します。 |
 | `sudo systemsetup -setrestartfreeze on` | フリーズ時の自動再起動 | `on`でシステムがフリーズした際に自動的に再起動します。 |
 
-### アプリケーション別設定
+### アプリケーション
 
 #### Safari
 | コマンド | 項目 | 説明 |

--- a/config/macos/backup-items.md
+++ b/config/macos/backup-items.md
@@ -6,131 +6,131 @@
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `NSGlobalDomain _HIHideMenuBar -bool true` | メニューバーの自動非表示 | `true`でメニューバーを自動的に隠します。 |
-| `com.apple.universalaccess reduceTransparency -bool true` | メニューバーの透明度 | `true`でメニューバーの透明度を下げ、視認性を向上させます。 |
-| `NSGlobalDomain AppleHighlightColor -string "R G B"` | アクセントカラー | `R G B` に `0.0`〜`1.0`の値をスペース区切りで指定し、クリックや選択範囲のハイライト色を変更します。 |
-| `NSGlobalDomain NSTableViewDefaultSizeMode -int 2` | サイドバーのアイコンサイズ | サイドバーに表示されるアイコンのサイズを指定します。（1: 小, 2: 中, 3: 大） |
-| `NSGlobalDomain AppleShowScrollBars -string "Always"` | スクロールバーの表示 | スクロールバーを常に表示するかどうかを指定します。（`WhenScrolling`, `Automatic`, `Always`） |
-| `NSGlobalDomain NSWindowResizeTime -float 0.001` | ウィンドウリサイズのアニメーション速度 | アプリケーションのウィンドウサイズを変更する際のアニメーション速度を調整します。（`0.001` など小さい値で高速化） |
-| `NSGlobalDomain NSNavPanelExpandedStateForSaveMode -bool true` | 保存パネルのデフォルト展開 | `true`で保存ダイアログを常に詳細表示で開きます。 |
-| `NSGlobalDomain PMPrintingExpandedStateForPrint -bool true` | 印刷パネルのデフォルト展開 | `true`で印刷ダイアログを常に詳細表示で開きます。 |
-| `NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false` | 書類をiCloudに保存 | `false`で新規作成した書類をデフォルトでローカルディスクに保存します。 |
-| `com.apple.LaunchServices LSQuarantine -bool false` | アプリケーション起動時の確認ダイアログ | `false`で初回起動時に表示される「〜を開いてもよろしいですか？」の確認を無効化します。 |
-| `com.apple.systempreferences NSQuitAlwaysKeepsWindows -bool false` | システムの復元機能（Resume） | `false`でアプリケーションを再起動した際に前回のウィンドウを復元する機能を無効化します。 |
-| `NSGlobalDomain NSDisableAutomaticTermination -bool true` | 非アクティブなアプリの自動終了 | `true`でメモリが少ない場合に、長時間使用していないアプリケーションを自動的に終了させる機能を無効化します。 |
-| `com.apple.CrashReporter DialogType -string "none"` | クラッシュレポーター | `none`に設定すると、アプリケーションのクラッシュ時に表示されるレポート送信ダイアログを無効化します。 |
-| `NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false` | 自動大文字入力 | `false`で文頭の自動的な大文字化を無効にします。 |
-| `NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false` | スマートダッシュ | `false`でハイフン2つ（--）がエムダッシュ（—）に自動変換されるのを防ぎます。 |
-| `NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false` | スマートクオート | `false`でストレートクオート（"）がタイポグラフィカルクオート（“”）に自動変換されるのを防ぎます。 |
-| `NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false` | 自動スペル修正 | `false`で入力中の自動的なスペル修正を無効にします。 |
+| `defaults write NSGlobalDomain _HIHideMenuBar -bool true` | メニューバーの自動非表示 | `true`でメニューバーを自動的に隠します。 |
+| `defaults write com.apple.universalaccess reduceTransparency -bool true` | メニューバーの透明度 | `true`でメニューバーの透明度を下げ、視認性を向上させます。 |
+| `defaults write NSGlobalDomain AppleHighlightColor -string "R G B"` | アクセントカラー | `R G B` に `0.0`〜`1.0`の値をスペース区切りで指定し、クリックや選択範囲のハイライト色を変更します。 |
+| `defaults write NSGlobalDomain NSTableViewDefaultSizeMode -int 2` | サイドバーのアイコンサイズ | サイドバーに表示されるアイコンのサイズを指定します。（1: 小, 2: 中, 3: 大） |
+| `defaults write NSGlobalDomain AppleShowScrollBars -string "Always"` | スクロールバーの表示 | スクロールバーを常に表示するかどうかを指定します。（`WhenScrolling`, `Automatic`, `Always`） |
+| `defaults write NSGlobalDomain NSWindowResizeTime -float 0.001` | ウィンドウリサイズのアニメーション速度 | アプリケーションのウィンドウサイズを変更する際のアニメーション速度を調整します。（`0.001` など小さい値で高速化） |
+| `defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode -bool true` | 保存パネルのデフォルト展開 | `true`で保存ダイアログを常に詳細表示で開きます。 |
+| `defaults write NSGlobalDomain PMPrintingExpandedStateForPrint -bool true` | 印刷パネルのデフォルト展開 | `true`で印刷ダイアログを常に詳細表示で開きます。 |
+| `defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false` | 書類をiCloudに保存 | `false`で新規作成した書類をデフォルトでローカルディスクに保存します。 |
+| `defaults write com.apple.LaunchServices LSQuarantine -bool false` | アプリケーション起動時の確認ダイアログ | `false`で初回起動時に表示される「〜を開いてもよろしいですか？」の確認を無効化します。 |
+| `defaults write com.apple.systempreferences NSQuitAlwaysKeepsWindows -bool false` | システムの復元機能（Resume） | `false`でアプリケーションを再起動した際に前回のウィンドウを復元する機能を無効化します。 |
+| `defaults write NSGlobalDomain NSDisableAutomaticTermination -bool true` | 非アクティブなアプリの自動終了 | `true`で、システムのメモリが圧迫された際に、OSが非アクティブと判断したアプリケーションを自動終了させる機能を無効化します。 |
+| `defaults write com.apple.CrashReporter DialogType -string "none"` | クラッシュレポーター | `none`に設定すると、アプリケーションのクラッシュ時に表示されるレポート送信ダイアログを無効化します。 |
+| `defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false` | 自動大文字入力 | `false`で文頭の自動的な大文字化を無効にします。 |
+| `defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false` | スマートダッシュ | `false`でハイフン2つ（--）がエムダッシュ（—）に自動変換されるのを防ぎます。 |
+| `defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false` | スマートクオート | `false`でストレートクオート（"）がタイポグラフィカルクオート（“”）に自動変換されるのを防ぎます。 |
+| `defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false` | 自動スペル修正 | `false`で入力中の自動的なスペル修正を無効にします。 |
 
 ### Dock
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `com.apple.dock tilesize -int 50` | Dockのサイズ | Dockに表示されるアイコンのサイズをピクセル単位で指定します。 |
-| `com.apple.dock autohide -bool true` | Dockの自動非表示 | `true`でDockを自動的に隠します。 |
-| `com.apple.dock autohide-time-modifier -float 0` | 自動非表示のアニメーション時間 | Dockが隠れたり表示されたりする際のアニメーション時間を秒単位で指定します。`0`でアニメーションを無効化します。 |
-| `com.apple.dock autohide-delay -float 0` | 自動非表示の遅延 | マウスカーソルが画面端に達してからDockが表示されるまでの遅延を秒単位で指定します。 |
-| `com.apple.dock show-recents -bool false` | 最近使用したアプリの表示 | `false`でDockに最近使用したアプリケーションのセクションを非表示にします。 |
-| `com.apple.dock mineffect -string "scale"` | 最小化エフェクト | ウィンドウを最小化する際のアニメーションを指定します。（`genie` または `scale`） |
-| `com.apple.dock minimize-to-application -bool true` | ウィンドウをアプリアイコンに最小化 | `true`でウィンドウを個別のサムネイルではなく、アプリケーションのアイコンに最小化します。 |
-| `com.apple.dock static-only -bool true` | アクティブなアプリのみ表示 | `true`で起動中のアプリケーションのみをDockに表示します。 |
-| `com.apple.dock scroll-to-open -bool true` | スクロールでExposé | `true`でDockのアイコン上でスクロールすると、そのアプリのExposé（App Exposé）を起動します。 |
-| `com.apple.dock launchanim -bool false` | アプリケーション起動時のアニメーション | `false`でDockからアプリケーションを起動する際のジャンプアニメーションを無効化します。 |
-| `com.apple.dock showhidden -bool true` | 非表示アプリのアイコンを半透明化 | `true`で非表示（Hidden）に設定されているアプリケーションのアイコンを半透明で表示します。 |
+| `defaults write com.apple.dock tilesize -int 50` | Dockのサイズ | Dockに表示されるアイコンのサイズをピクセル単位で指定します。 |
+| `defaults write com.apple.dock autohide -bool true` | Dockの自動非表示 | `true`でDockを自動的に隠します。 |
+| `defaults write com.apple.dock autohide-time-modifier -float 0` | 自動非表示のアニメーション時間 | Dockが隠れたり表示されたりする際のアニメーション時間を秒単位で指定します。`0`でアニメーションを無効化します。 |
+| `defaults write com.apple.dock autohide-delay -float 0` | 自動非表示の遅延 | マウスカーソルが画面端に達してからDockが表示されるまでの遅延を秒単位で指定します。 |
+| `defaults write com.apple.dock show-recents -bool false` | 最近使用したアプリの表示 | `false`でDockに最近使用したアプリケーションのセクションを非表示にします。 |
+| `defaults write com.apple.dock mineffect -string "scale"` | 最小化エフェクト | ウィンドウを最小化する際のアニメーションを指定します。（`genie` または `scale`） |
+| `defaults write com.apple.dock minimize-to-application -bool true` | ウィンドウをアプリアイコンに最小化 | `true`でウィンドウを個別のサムネイルではなく、アプリケーションのアイコンに最小化します。 |
+| `defaults write com.apple.dock static-only -bool true` | アクティブなアプリのみ表示 | `true`で起動中のアプリケーションのみをDockに表示します。 |
+| `defaults write com.apple.dock scroll-to-open -bool true` | スクロールでExposé | `true`でDockのアイコン上でスクロールすると、そのアプリのExposé（App Exposé）を起動します。 |
+| `defaults write com.apple.dock launchanim -bool false` | アプリケーション起動時のアニメーション | `false`でDockからアプリケーションを起動する際のジャンプアニメーションを無効化します。 |
+| `defaults write com.apple.dock showhidden -bool true` | 非表示アプリのアイコンを半透明化 | `true`で非表示（Hidden）に設定されているアプリケーションのアイコンを半透明で表示します。 |
 
 ### Finderとデスクトップ
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `com.apple.finder ShowPathbar -bool true` | パスバーの表示 | `true`でFinderウィンドウ下部にファイルパスを表示するパスバーを有効にします。 |
-| `com.apple.finder ShowStatusBar -bool true` | ステータスバーの表示 | `true`でFinderウィンドウ下部に空き容量や項目数を表示するステータスバーを有効にします。 |
-| `com.apple.finder AppleShowAllFiles -bool true` | 隠しファイルの表示 | `true`で全ての隠しファイル・フォルダを表示します。 |
-| `NSGlobalDomain AppleShowAllExtensions -bool true` | 全ての拡張子を表示 | `true`で全てのファイルの拡張子を表示します。 |
-| `com.apple.finder _FXShowPosixPathInTitle -bool true` | ウィンドウタイトルにフルパス表示 | `true`でFinderウィンドウのタイトルバーに現在表示しているフォルダのフルパスを表示します。 |
-| `com.apple.finder FXPreferredViewStyle -string "Nlsv"` | デフォルトの表示スタイル | Finderのデフォルト表示形式を指定します。（`icnv`: アイコン, `Nlsv`: リスト, `clmv`: カラム, `glyv`: ギャラリー） |
-| `com.apple.finder _FXSortFoldersFirst -bool true` | フォルダを常に先頭に表示 | `true`でウィンドウ内およびデスクトップでフォルダをファイルより常に上に表示します。 |
-| `com.apple.finder FXDefaultSearchScope -string "SCcf"` | デフォルトの検索範囲 | Finderでの検索時にデフォルトで検索する範囲を指定します。（`SCcf`: 現在のフォルダ, `SCev`: このMac） |
-| `com.apple.finder FXEnableExtensionChangeWarning -bool false` | 拡張子変更時の警告 | `false`でファイル拡張子を変更する際の警告を無効にします。 |
-| `com.apple.finder WarnOnEmptyTrash -bool false` | ゴミ箱を空にする前の警告 | `false`でゴミ箱を空にする際の確認ダイアログを無効にします。 |
-| `com.apple.finder FXRemoveOldTrashItems -bool true` | 30日後にゴミ箱を空にする | `true`で30日以上ゴミ箱にある項目を自動的に削除します。 |
-| `com.apple.desktopservices DSDontWriteNetworkStores -bool true` | `.DS_Store`ファイルの生成抑制 | ネットワークドライブやUSBメモリで `.DS_Store` ファイルが自動生成されるのを防ぎます。 |
-| `com.apple.finder ShowExternalHardDrivesOnDesktop -bool true` | デスクトップアイコンの表示 | デスクトップに表示するアイコンの種類を制御します。（ハードドライブ、外部ディスク、リムーバブルメディア、サーバー） |
-| `com.apple.finder QuitMenuItem -bool true` | Finderの終了メニュー | `true`でFinderのメニューに「Finderを終了」の項目を追加します。 |
-| `com.apple.finder DisableAllAnimations -bool true` | Finderのアニメーション効果 | `true`でFinderのウィンドウアニメーションや情報表示のアニメーションを無効化します。 |
-| `NSGlobalDomain com.apple.springing.enabled -bool true` | スプリングローディング | ディレクトリ上でのドラッグ＆ドロップ操作におけるスプリングローディング（フォルダが自動で開く機能）を有効化・高速化します。 |
+| `defaults write com.apple.finder ShowPathbar -bool true` | パスバーの表示 | `true`でFinderウィンドウ下部にファイルパスを表示するパスバーを有効にします。 |
+| `defaults write com.apple.finder ShowStatusBar -bool true` | ステータスバーの表示 | `true`でFinderウィンドウ下部に空き容量や項目数を表示するステータスバーを有効にします。 |
+| `defaults write com.apple.finder AppleShowAllFiles -bool true` | 隠しファイルの表示 | `true`で全ての隠しファイル・フォルダを表示します。 |
+| `defaults write NSGlobalDomain AppleShowAllExtensions -bool true` | 全ての拡張子を表示 | `true`で全てのファイルの拡張子を表示します。 |
+| `defaults write com.apple.finder _FXShowPosixPathInTitle -bool true` | ウィンドウタイトルにフルパス表示 | `true`でFinderウィンドウのタイトルバーに現在表示しているフォルダのフルパスを表示します。 |
+| `defaults write com.apple.finder FXPreferredViewStyle -string "Nlsv"` | デフォルトの表示スタイル | Finderのデフォルト表示形式を指定します。（`icnv`: アイコン, `Nlsv`: リスト, `clmv`: カラム, `glyv`: ギャラリー） |
+| `defaults write com.apple.finder _FXSortFoldersFirst -bool true` | フォルダを常に先頭に表示 | `true`でウィンドウ内およびデスクトップでフォルダをファイルより常に上に表示します。 |
+| `defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"` | デフォルトの検索範囲 | Finderでの検索時にデフォルトで検索する範囲を指定します。（`SCcf`: 現在のフォルダ, `SCev`: このMac） |
+| `defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false` | 拡張子変更時の警告 | `false`でファイル拡張子を変更する際の警告を無効にします。 |
+| `defaults write com.apple.finder WarnOnEmptyTrash -bool false` | ゴミ箱を空にする前の警告 | `false`でゴミ箱を空にする際の確認ダイアログを無効にします。 |
+| `defaults write com.apple.finder FXRemoveOldTrashItems -bool true` | 30日後にゴミ箱を空にする | `true`で30日以上ゴミ箱にある項目を自動的に削除します。 |
+| `defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true` | `.DS_Store`ファイルの生成抑制 | ネットワークドライブやUSBメモリで `.DS_Store` ファイルが自動生成されるのを防ぎます。 |
+| `defaults write com.apple.finder ShowExternalHardDrivesOnDesktop -bool true` | デスクトップアイコンの表示 | デスクトップに表示するアイコンの種類を制御します。（ハードドライブ、外部ディスク、リムーバブルメディア、サーバー） |
+| `defaults write com.apple.finder QuitMenuItem -bool true` | Finderの終了メニュー | `true`でFinderのメニューに「Finderを終了」の項目を追加します。 |
+| `defaults write com.apple.finder DisableAllAnimations -bool true` | Finderのアニメーション効果 | `true`でFinderのウィンドウアニメーションや情報表示のアニメーションを無効化します。 |
+| `defaults write NSGlobalDomain com.apple.springing.enabled -bool true` | スプリングローディング | ディレクトリ上でのドラッグ＆ドロップ操作におけるスプリングローディング（フォルダが自動で開く機能）を有効化・高速化します。 |
 
 ### ミッションコントロールとホットコーナー
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `com.apple.dock expose-animation-duration -float 0.1` | アニメーションの高速化 | ミッションコントロールの表示・非表示アニメーションの速度を調整します。 |
-| `com.apple.dock mru-spaces -bool false` | 操作スペースの自動並べ替え | `false`で最近使った操作スペースに基づいて自動的に並べ替える機能を無効にします。 |
-| `com.apple.dock expose-group-by-app -bool false` | アプリごとにウィンドウをグループ化 | `false`でミッションコントロールでウィンドウをアプリケーションごとにグループ化しないようにします。（旧Exposéの挙動） |
-| `com.apple.dock workspaces-auto-swoosh -bool true` | アプリ切り替え時にスペースを移動 | `true`でアプリケーションのウィンドウが含まれる操作スペースに自動で切り替えます。 |
-| `com.apple.spaces spans-displays -bool true` | ディスプレイごとに個別の操作スペース | `true`で各ディスプレイに個別のメニューバーと操作スペースを持たせます。 |
-| `com.apple.dashboard mcx-disabled -bool true` | Dashboardの無効化 | `true`でDashboard機能を無効にします。 |
-| `com.apple.dock wvous-tl-corner -int 2` | ホットコーナーの設定 | 画面の四隅（tl:左上, tr:右上, bl:左下, br:右下）にカーソルを移動したときのアクションを割り当てます。 |
+| `defaults write com.apple.dock expose-animation-duration -float 0.1` | アニメーションの高速化 | ミッションコントロールの表示・非表示アニメーションの速度を調整します。 |
+| `defaults write com.apple.dock mru-spaces -bool false` | 操作スペースの自動並べ替え | `false`で最近使った操作スペースに基づいて自動的に並べ替える機能を無効にします。 |
+| `defaults write com.apple.dock expose-group-by-app -bool false` | アプリごとにウィンドウをグループ化 | `false`でミッションコントロールでウィンドウをアプリケーションごとにグループ化しないようにします。（旧Exposéの挙動） |
+| `defaults write com.apple.dock workspaces-auto-swoosh -bool true` | アプリ切り替え時にスペースを移動 | `true`でアプリケーションのウィンドウが含まれる操作スペースに自動で切り替えます。 |
+| `defaults write com.apple.spaces spans-displays -bool true` | ディスプレイごとに個別の操作スペース | `true`で各ディスプレイに個別のメニューバーと操作スペースを持たせます。 |
+| `defaults write com.apple.dashboard mcx-disabled -bool true` | Dashboardの無効化 | `true`でDashboard機能を無効にします。 |
+| `defaults write com.apple.dock wvous-tl-corner -int 2` | ホットコーナーの設定 | 画面の四隅（tl:左上, tr:右上, bl:左下, br:右下）にカーソルを移動したときのアクションを割り当てます。 |
 
 ### キーボードとマウス・トラックパッド
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `NSGlobalDomain KeyRepeat -int 1` | キーリピート速度 | キーを押し続けたときのリピート速度を調整します。（速いほど値が小さい） |
-| `NSGlobalDomain InitialKeyRepeat -int 10` | キーリピート開始までの時間 | キーを押し続けてからリピートが開始されるまでの時間を調整します。（短いほど値が小さい） |
-| `NSGlobalDomain ApplePressAndHoldEnabled -bool false` | キー長押しでのアクセント文字入力 | `false`でキーの長押しによるアクセント文字の入力を無効にし、キーリピートを有効にします。 |
-| `NSGlobalDomain AppleKeyboardUIMode -int 3` | フルキーボードアクセス | モーダルダイアログ内のすべてのコントロール（ボタンなど）をTabキーで移動できるようにします。 |
-| `NSGlobalDomain com.apple.swipescrolldirection -bool false` | 「自然な」スクロール | `false`でコンテンツと指の動きが連動しない、従来のスクロール方向にします。 |
-| `com.apple.keyboard.fnState -bool true` | ファンクションキーの動作 | `true`でF1, F2などのキーを標準のファンクションキーとして使用します。 |
-| `-g com.apple.mouse.scaling -float 3.0` | マウスの移動速度 | マウスカーソルの移動速度を調整します。 |
-| `.GlobalPreferences com.apple.mouse.scaling -1` | マウス加速の無効化 | `-1` を設定することでマウスの加速を無効にし、リニアな動きにします。 |
-| `com.apple.Terminal FocusFollowsMouse -bool true` | マウスカーソル追従フォーカス | `true`でマウスカーソルをウィンドウ上に移動するだけでそのウィンドウをアクティブにします。（クリック不要） |
-| `-g com.apple.trackpad.scaling -float 1.5` | トラックパッドの移動速度 | トラックパッドでのカーソル移動速度を調整します。 |
-| `com.apple.AppleMultitouchTrackpad Clicking -bool true` | タップでクリック | `true`でトラックパッドをタップしてクリックできるようにします。 |
-| `com.apple.AppleMultitouchTrackpad Dragging -bool true` | タップでドラッグ | `true`でダブルタップから指を離さずにドラッグ操作ができるようにします。 |
-| `com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool true` | 3本指でドラッグ | `true`で3本指でウィンドウやオブジェクトをドラッグできるようにします。 |
-| `com.apple.AppleMultitouchTrackpad FirstClickThreshold -int 1` | クリックの強さ | クリックに必要な圧力を調整します。（0: 弱い, 1: 中, 2: 強い） |
-| `com.apple.AppleMultitouchTrackpad ForceSuppressed -bool true` | Force Touch | `true`で感圧タッチ（Force Touch）を無効にします。 |
-| `com.apple.AppleMultitouchTrackpad TrackpadThreeFingerTapGesture -int 2` | 3本指タップ | 3本指タップの動作を割り当てます。（0: 無効, 2: 辞書で調べる） |
-| `com.apple.AppleMultitouchTrackpad TrackpadRightClick -bool true` | 2本指で右クリック | `true`で2本指でのクリックまたはタップを右クリックとして扱います。 |
+| `defaults write NSGlobalDomain KeyRepeat -int 1` | キーリピート速度 | キーを押し続けたときのリピート速度を調整します。（速いほど値が小さい） |
+| `defaults write NSGlobalDomain InitialKeyRepeat -int 10` | キーリピート開始までの時間 | キーを押し続けてからリピートが開始されるまでの時間を調整します。（短いほど値が小さい） |
+| `defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false` | キー長押しでのアクセント文字入力 | `false`でキーの長押しによるアクセント文字の入力を無効にし、キーリピートを有効にします。 |
+| `defaults write NSGlobalDomain AppleKeyboardUIMode -int 3` | フルキーボードアクセス | モーダルダイアログ内のすべてのコントロール（ボタンなど）をTabキーで移動できるようにします。 |
+| `defaults write NSGlobalDomain com.apple.swipescrolldirection -bool false` | 「自然な」スクロール | `false`でコンテンツと指の動きが連動しない、従来のスクロール方向にします。 |
+| `defaults write com.apple.keyboard.fnState -bool true` | ファンクションキーの動作 | `true`でF1, F2などのキーを標準のファンクションキーとして使用します。 |
+| `defaults write -g com.apple.mouse.scaling -float 3.0` | マウスの移動速度 | マウスカーソルの移動速度を調整します。 |
+| `defaults write .GlobalPreferences com.apple.mouse.scaling -1` | マウス加速の無効化 | `-1` を設定することでマウスの加速を無効にし、リニアな動きにします。 |
+| `defaults write com.apple.Terminal FocusFollowsMouse -bool true` | マウスカーソル追従フォーカス | `true`でマウスカーソルをウィンドウ上に移動するだけでそのウィンドウをアクティブにします。（クリック不要） |
+| `defaults write -g com.apple.trackpad.scaling -float 1.5` | トラックパッドの移動速度 | トラックパッドでのカーソル移動速度を調整します。 |
+| `defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true` | タップでクリック | `true`でトラックパッドをタップしてクリックできるようにします。 |
+| `defaults write com.apple.AppleMultitouchTrackpad Dragging -bool true` | タップでドラッグ | `true`でダブルタップから指を離さずにドラッグ操作ができるようにします。 |
+| `defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool true` | 3本指でドラッグ | `true`で3本指でウィンドウやオブジェクトをドラッグできるようにします。 |
+| `defaults write com.apple.AppleMultitouchTrackpad FirstClickThreshold -int 1` | クリックの強さ | クリックに必要な圧力を調整します。（0: 弱い, 1: 中, 2: 強い） |
+| `defaults write com.apple.AppleMultitouchTrackpad ForceSuppressed -bool true` | Force Touch | `true`で感圧タッチ（Force Touch）を無効にします。 |
+| `defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerTapGesture -int 2` | 3本指タップ | 3本指タップの動作を割り当てます。（0: 無効, 2: 辞書で調べる） |
+| `defaults write com.apple.AppleMultitouchTrackpad TrackpadRightClick -bool true` | 2本指で右クリック | `true`で2本指でのクリックまたはタップを右クリックとして扱います。 |
 
 ### サウンドと通知
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `nvram SystemAudioVolume=" "` | 起動時のサウンド | ` `（スペース）を設定することでMacの起動音を無効にします。 |
-| `com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int 0` | UI操作音 | `0`でユーザーインターフェースの効果音を無効にします。 |
-| `-g "com.apple.sound.beep.feedback" -int 0` | 音量変更時のフィードバック音 | `0`で音量を変更したときに再生される効果音を無効にします。 |
-| `-g "com.apple.sound.beep.sound" -string "/path/to/sound.aiff"` | アラート音の種類 | システムのアラート音として使用するサウンドファイルを指定します。 |
-| `com.apple.BluetoothAudioAgent "Apple Bitpool Min (editable)" -int 40` | Bluetoothヘッドフォンの音質向上 | Bluetoothオーディオのビットプール値を調整し、音質を向上させます。 |
+| `sudo nvram SystemAudioVolume=" "` | 起動時のサウンド | ` `（スペース）を設定することでMacの起動音を無効にします。 |
+| `defaults write com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int 0` | UI操作音 | `0`でユーザーインターフェースの効果音を無効にします。 |
+| `defaults write -g "com.apple.sound.beep.feedback" -int 0` | 音量変更時のフィードバック音 | `0`で音量を変更したときに再生される効果音を無効にします。 |
+| `defaults write -g "com.apple.sound.beep.sound" -string "/path/to/sound.aiff"` | アラート音の種類 | システムのアラート音として使用するサウンドファイルを指定します。 |
+| `defaults write com.apple.BluetoothAudioAgent "Apple Bitpool Min (editable)" -int 40` | Bluetoothヘッドフォンの音質向上 | Bluetoothオーディオのビットプール値を調整し、音質を向上させます。 |
 | `launchctl unload -w /System/Library/LaunchAgents/com.apple.notificationcenterui.plist` | 通知センターの無効化 | `launchctl`を使い、通知センターのプロセスを無効化します。 |
 
 ### スクリーンショット
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `com.apple.screencapture location ~/Desktop` | 保存場所 | スクリーンショットが保存されるデフォルトの場所を指定します。 |
-| `com.apple.screencapture disable-shadow -bool true` | 影を無効化 | `true`でウィンドウのスクリーンショットを撮る際に影を含めないようにします。 |
-| `com.apple.screencapture include-date -bool true` | ファイル名に日付を含める | `true`でスクリーンショットのファイル名に撮影日時を含めます。 |
-| `com.apple.screencapture show-thumbnail -bool false` | サムネイル表示 | `false`で撮影後に画面右下に表示されるフローティングサムネイルを無効にします。 |
-| `com.apple.screencapture type -string "png"` | ファイルフォーマット | スクリーンショットの画像ファイル形式を指定します。（`png`, `jpg`, `gif`, `tiff`, `pdf`） |
+| `defaults write com.apple.screencapture location ~/Desktop` | 保存場所 | スクリーンショットが保存されるデフォルトの場所を指定します。 |
+| `defaults write com.apple.screencapture disable-shadow -bool true` | 影を無効化 | `true`でウィンドウのスクリーンショットを撮る際に影を含めないようにします。 |
+| `defaults write com.apple.screencapture include-date -bool true` | ファイル名に日付を含める | `true`でスクリーンショットのファイル名に撮影日時を含めます。 |
+| `defaults write com.apple.screencapture show-thumbnail -bool false` | サムネイル表示 | `false`で撮影後に画面右下に表示されるフローティングサムネイルを無効にします。 |
+| `defaults write com.apple.screencapture type -string "png"` | ファイルフォーマット | スクリーンショットの画像ファイル形式を指定します。（`png`, `jpg`, `gif`, `tiff`, `pdf`） |
 
 ### 省エネルギー
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `pmset -a displaysleep 15` | スリープやハイバネーションの設定 | ディスプレイのスリープ、コンピュータのスリープ、スタンバイモードへの移行時間などを `pmset` コマンドで細かく設定します。 |
-| `pmset -a autorestart 1` | 電源喪失時の自動再起動 | `1`で停電などから復旧した際に自動的にMacを再起動します。 |
-| `systemsetup -setrestartfreeze on` | フリーズ時の自動再起動 | `on`でシステムがフリーズした際に自動的に再起動します。 |
+| `sudo pmset -a displaysleep 15` | スリープやハイバネーションの設定 | ディスプレイのスリープ、コンピュータのスリープ、スタンバイモードへの移行時間などを `pmset` コマンドで細かく設定します。 |
+| `sudo pmset -a autorestart 1` | 電源喪失時の自動再起動 | `1`で停電などから復旧した際に自動的にMacを再起動します。 |
+| `sudo systemsetup -setrestartfreeze on` | フリーズ時の自動再起動 | `on`でシステムがフリーズした際に自動的に再起動します。 |
 
 ### アプリケーション別設定
 
 #### Safari
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `com.apple.Safari UniversalSearchEnabled -bool false` | 検索クエリの非送信 | `false`でSafariの検索候補機能のために検索クエリがAppleに送信されるのを防ぎます。 |
-| `com.apple.Safari ShowFullURLInSmartSearchField -bool true` | フルURLの表示 | `true`でスマートサーチフィールドに常に完全なURLを表示します。 |
-| `com.apple.Safari AutoOpenSafeDownloads -bool false` | ダウンロード後の自動展開 | `false`でダウンロードした「安全な」ファイル（zipなど）が自動的に展開されるのを防ぎます。 |
-| `com.apple.Safari IncludeInternalDebugMenu -bool true` | デバッグメニューの有効化 | `true`でSafariに詳細な設定が可能なデバッグメニューを追加します。 |
-| `NSGlobalDomain WebKitDeveloperExtras -bool true` | Webインスペクタの有効化 | `true`でWeb開発用のインスペクタ機能を有効にします。 |
+| `defaults write com.apple.Safari UniversalSearchEnabled -bool false` | 検索クエリの非送信 | `false`でSafariの検索候補機能のために検索クエリがAppleに送信されるのを防ぎます。 |
+| `defaults write com.apple.Safari ShowFullURLInSmartSearchField -bool true` | フルURLの表示 | `true`でスマートサーチフィールドに常に完全なURLを表示します。 |
+| `defaults write com.apple.Safari AutoOpenSafeDownloads -bool false` | ダウンロード後の自動展開 | `false`でダウンロードした「安全な」ファイル（zipなど）が自動的に展開されるのを防ぎます。 |
+| `defaults write com.apple.Safari IncludeInternalDebugMenu -bool true` | デバッグメニューの有効化 | `true`でSafariに詳細な設定が可能なデバッグメニューを追加します。 |
+| `defaults write NSGlobalDomain WebKitDeveloperExtras -bool true` | Webインスペクタの有効化 | `true`でWeb開発用のインスペクタ機能を有効にします。 |

--- a/config/macos/backup-items.md
+++ b/config/macos/backup-items.md
@@ -1,0 +1,136 @@
+## 概要
+
+このドキュメントは、`config/macos/backup_settings.sh` スクリプトでバックアップ可能な macOS の設定項目と、それに対応するコマンドの一覧です。
+
+### 一般・UI/UX
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `NSGlobalDomain _HIHideMenuBar -bool true` | メニューバーの自動非表示 | `true`でメニューバーを自動的に隠します。 |
+| `com.apple.universalaccess reduceTransparency -bool true` | メニューバーの透明度 | `true`でメニューバーの透明度を下げ、視認性を向上させます。 |
+| `NSGlobalDomain AppleHighlightColor -string "R G B"` | アクセントカラー | `R G B` に `0.0`〜`1.0`の値をスペース区切りで指定し、クリックや選択範囲のハイライト色を変更します。 |
+| `NSGlobalDomain NSTableViewDefaultSizeMode -int 2` | サイドバーのアイコンサイズ | サイドバーに表示されるアイコンのサイズを指定します。（1: 小, 2: 中, 3: 大） |
+| `NSGlobalDomain AppleShowScrollBars -string "Always"` | スクロールバーの表示 | スクロールバーを常に表示するかどうかを指定します。（`WhenScrolling`, `Automatic`, `Always`） |
+| `NSGlobalDomain NSWindowResizeTime -float 0.001` | ウィンドウリサイズのアニメーション速度 | アプリケーションのウィンドウサイズを変更する際のアニメーション速度を調整します。（`0.001` など小さい値で高速化） |
+| `NSGlobalDomain NSNavPanelExpandedStateForSaveMode -bool true` | 保存パネルのデフォルト展開 | `true`で保存ダイアログを常に詳細表示で開きます。 |
+| `NSGlobalDomain PMPrintingExpandedStateForPrint -bool true` | 印刷パネルのデフォルト展開 | `true`で印刷ダイアログを常に詳細表示で開きます。 |
+| `NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false` | 書類をiCloudに保存 | `false`で新規作成した書類をデフォルトでローカルディスクに保存します。 |
+| `com.apple.LaunchServices LSQuarantine -bool false` | アプリケーション起動時の確認ダイアログ | `false`で初回起動時に表示される「〜を開いてもよろしいですか？」の確認を無効化します。 |
+| `com.apple.systempreferences NSQuitAlwaysKeepsWindows -bool false` | システムの復元機能（Resume） | `false`でアプリケーションを再起動した際に前回のウィンドウを復元する機能を無効化します。 |
+| `NSGlobalDomain NSDisableAutomaticTermination -bool true` | 非アクティブなアプリの自動終了 | `true`でメモリが少ない場合に、長時間使用していないアプリケーションを自動的に終了させる機能を無効化します。 |
+| `com.apple.CrashReporter DialogType -string "none"` | クラッシュレポーター | `none`に設定すると、アプリケーションのクラッシュ時に表示されるレポート送信ダイアログを無効化します。 |
+| `NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false` | 自動大文字入力 | `false`で文頭の自動的な大文字化を無効にします。 |
+| `NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false` | スマートダッシュ | `false`でハイフン2つ（--）がエムダッシュ（—）に自動変換されるのを防ぎます。 |
+| `NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false` | スマートクオート | `false`でストレートクオート（"）がタイポグラフィカルクオート（“”）に自動変換されるのを防ぎます。 |
+| `NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false` | 自動スペル修正 | `false`で入力中の自動的なスペル修正を無効にします。 |
+
+### Dock
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `com.apple.dock tilesize -int 50` | Dockのサイズ | Dockに表示されるアイコンのサイズをピクセル単位で指定します。 |
+| `com.apple.dock autohide -bool true` | Dockの自動非表示 | `true`でDockを自動的に隠します。 |
+| `com.apple.dock autohide-time-modifier -float 0` | 自動非表示のアニメーション時間 | Dockが隠れたり表示されたりする際のアニメーション時間を秒単位で指定します。`0`でアニメーションを無効化します。 |
+| `com.apple.dock autohide-delay -float 0` | 自動非表示の遅延 | マウスカーソルが画面端に達してからDockが表示されるまでの遅延を秒単位で指定します。 |
+| `com.apple.dock show-recents -bool false` | 最近使用したアプリの表示 | `false`でDockに最近使用したアプリケーションのセクションを非表示にします。 |
+| `com.apple.dock mineffect -string "scale"` | 最小化エフェクト | ウィンドウを最小化する際のアニメーションを指定します。（`genie` または `scale`） |
+| `com.apple.dock minimize-to-application -bool true` | ウィンドウをアプリアイコンに最小化 | `true`でウィンドウを個別のサムネイルではなく、アプリケーションのアイコンに最小化します。 |
+| `com.apple.dock static-only -bool true` | アクティブなアプリのみ表示 | `true`で起動中のアプリケーションのみをDockに表示します。 |
+| `com.apple.dock scroll-to-open -bool true` | スクロールでExposé | `true`でDockのアイコン上でスクロールすると、そのアプリのExposé（App Exposé）を起動します。 |
+| `com.apple.dock launchanim -bool false` | アプリケーション起動時のアニメーション | `false`でDockからアプリケーションを起動する際のジャンプアニメーションを無効化します。 |
+| `com.apple.dock showhidden -bool true` | 非表示アプリのアイコンを半透明化 | `true`で非表示（Hidden）に設定されているアプリケーションのアイコンを半透明で表示します。 |
+
+### Finderとデスクトップ
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `com.apple.finder ShowPathbar -bool true` | パスバーの表示 | `true`でFinderウィンドウ下部にファイルパスを表示するパスバーを有効にします。 |
+| `com.apple.finder ShowStatusBar -bool true` | ステータスバーの表示 | `true`でFinderウィンドウ下部に空き容量や項目数を表示するステータスバーを有効にします。 |
+| `com.apple.finder AppleShowAllFiles -bool true` | 隠しファイルの表示 | `true`で全ての隠しファイル・フォルダを表示します。 |
+| `NSGlobalDomain AppleShowAllExtensions -bool true` | 全ての拡張子を表示 | `true`で全てのファイルの拡張子を表示します。 |
+| `com.apple.finder _FXShowPosixPathInTitle -bool true` | ウィンドウタイトルにフルパス表示 | `true`でFinderウィンドウのタイトルバーに現在表示しているフォルダのフルパスを表示します。 |
+| `com.apple.finder FXPreferredViewStyle -string "Nlsv"` | デフォルトの表示スタイル | Finderのデフォルト表示形式を指定します。（`icnv`: アイコン, `Nlsv`: リスト, `clmv`: カラム, `glyv`: ギャラリー） |
+| `com.apple.finder _FXSortFoldersFirst -bool true` | フォルダを常に先頭に表示 | `true`でウィンドウ内およびデスクトップでフォルダをファイルより常に上に表示します。 |
+| `com.apple.finder FXDefaultSearchScope -string "SCcf"` | デフォルトの検索範囲 | Finderでの検索時にデフォルトで検索する範囲を指定します。（`SCcf`: 現在のフォルダ, `SCev`: このMac） |
+| `com.apple.finder FXEnableExtensionChangeWarning -bool false` | 拡張子変更時の警告 | `false`でファイル拡張子を変更する際の警告を無効にします。 |
+| `com.apple.finder WarnOnEmptyTrash -bool false` | ゴミ箱を空にする前の警告 | `false`でゴミ箱を空にする際の確認ダイアログを無効にします。 |
+| `com.apple.finder FXRemoveOldTrashItems -bool true` | 30日後にゴミ箱を空にする | `true`で30日以上ゴミ箱にある項目を自動的に削除します。 |
+| `com.apple.desktopservices DSDontWriteNetworkStores -bool true` | `.DS_Store`ファイルの生成抑制 | ネットワークドライブやUSBメモリで `.DS_Store` ファイルが自動生成されるのを防ぎます。 |
+| `com.apple.finder ShowExternalHardDrivesOnDesktop -bool true` | デスクトップアイコンの表示 | デスクトップに表示するアイコンの種類を制御します。（ハードドライブ、外部ディスク、リムーバブルメディア、サーバー） |
+| `com.apple.finder QuitMenuItem -bool true` | Finderの終了メニュー | `true`でFinderのメニューに「Finderを終了」の項目を追加します。 |
+| `com.apple.finder DisableAllAnimations -bool true` | Finderのアニメーション効果 | `true`でFinderのウィンドウアニメーションや情報表示のアニメーションを無効化します。 |
+| `NSGlobalDomain com.apple.springing.enabled -bool true` | スプリングローディング | ディレクトリ上でのドラッグ＆ドロップ操作におけるスプリングローディング（フォルダが自動で開く機能）を有効化・高速化します。 |
+
+### ミッションコントロールとホットコーナー
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `com.apple.dock expose-animation-duration -float 0.1` | アニメーションの高速化 | ミッションコントロールの表示・非表示アニメーションの速度を調整します。 |
+| `com.apple.dock mru-spaces -bool false` | 操作スペースの自動並べ替え | `false`で最近使った操作スペースに基づいて自動的に並べ替える機能を無効にします。 |
+| `com.apple.dock expose-group-by-app -bool false` | アプリごとにウィンドウをグループ化 | `false`でミッションコントロールでウィンドウをアプリケーションごとにグループ化しないようにします。（旧Exposéの挙動） |
+| `com.apple.dock workspaces-auto-swoosh -bool true` | アプリ切り替え時にスペースを移動 | `true`でアプリケーションのウィンドウが含まれる操作スペースに自動で切り替えます。 |
+| `com.apple.spaces spans-displays -bool true` | ディスプレイごとに個別の操作スペース | `true`で各ディスプレイに個別のメニューバーと操作スペースを持たせます。 |
+| `com.apple.dashboard mcx-disabled -bool true` | Dashboardの無効化 | `true`でDashboard機能を無効にします。 |
+| `com.apple.dock wvous-tl-corner -int 2` | ホットコーナーの設定 | 画面の四隅（tl:左上, tr:右上, bl:左下, br:右下）にカーソルを移動したときのアクションを割り当てます。 |
+
+### キーボードとマウス・トラックパッド
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `NSGlobalDomain KeyRepeat -int 1` | キーリピート速度 | キーを押し続けたときのリピート速度を調整します。（速いほど値が小さい） |
+| `NSGlobalDomain InitialKeyRepeat -int 10` | キーリピート開始までの時間 | キーを押し続けてからリピートが開始されるまでの時間を調整します。（短いほど値が小さい） |
+| `NSGlobalDomain ApplePressAndHoldEnabled -bool false` | キー長押しでのアクセント文字入力 | `false`でキーの長押しによるアクセント文字の入力を無効にし、キーリピートを有効にします。 |
+| `NSGlobalDomain AppleKeyboardUIMode -int 3` | フルキーボードアクセス | モーダルダイアログ内のすべてのコントロール（ボタンなど）をTabキーで移動できるようにします。 |
+| `NSGlobalDomain com.apple.swipescrolldirection -bool false` | 「自然な」スクロール | `false`でコンテンツと指の動きが連動しない、従来のスクロール方向にします。 |
+| `com.apple.keyboard.fnState -bool true` | ファンクションキーの動作 | `true`でF1, F2などのキーを標準のファンクションキーとして使用します。 |
+| `-g com.apple.mouse.scaling -float 3.0` | マウスの移動速度 | マウスカーソルの移動速度を調整します。 |
+| `.GlobalPreferences com.apple.mouse.scaling -1` | マウス加速の無効化 | `-1` を設定することでマウスの加速を無効にし、リニアな動きにします。 |
+| `com.apple.Terminal FocusFollowsMouse -bool true` | マウスカーソル追従フォーカス | `true`でマウスカーソルをウィンドウ上に移動するだけでそのウィンドウをアクティブにします。（クリック不要） |
+| `-g com.apple.trackpad.scaling -float 1.5` | トラックパッドの移動速度 | トラックパッドでのカーソル移動速度を調整します。 |
+| `com.apple.AppleMultitouchTrackpad Clicking -bool true` | タップでクリック | `true`でトラックパッドをタップしてクリックできるようにします。 |
+| `com.apple.AppleMultitouchTrackpad Dragging -bool true` | タップでドラッグ | `true`でダブルタップから指を離さずにドラッグ操作ができるようにします。 |
+| `com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool true` | 3本指でドラッグ | `true`で3本指でウィンドウやオブジェクトをドラッグできるようにします。 |
+| `com.apple.AppleMultitouchTrackpad FirstClickThreshold -int 1` | クリックの強さ | クリックに必要な圧力を調整します。（0: 弱い, 1: 中, 2: 強い） |
+| `com.apple.AppleMultitouchTrackpad ForceSuppressed -bool true` | Force Touch | `true`で感圧タッチ（Force Touch）を無効にします。 |
+| `com.apple.AppleMultitouchTrackpad TrackpadThreeFingerTapGesture -int 2` | 3本指タップ | 3本指タップの動作を割り当てます。（0: 無効, 2: 辞書で調べる） |
+| `com.apple.AppleMultitouchTrackpad TrackpadRightClick -bool true` | 2本指で右クリック | `true`で2本指でのクリックまたはタップを右クリックとして扱います。 |
+
+### サウンドと通知
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `nvram SystemAudioVolume=" "` | 起動時のサウンド | ` `（スペース）を設定することでMacの起動音を無効にします。 |
+| `com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int 0` | UI操作音 | `0`でユーザーインターフェースの効果音を無効にします。 |
+| `-g "com.apple.sound.beep.feedback" -int 0` | 音量変更時のフィードバック音 | `0`で音量を変更したときに再生される効果音を無効にします。 |
+| `-g "com.apple.sound.beep.sound" -string "/path/to/sound.aiff"` | アラート音の種類 | システムのアラート音として使用するサウンドファイルを指定します。 |
+| `com.apple.BluetoothAudioAgent "Apple Bitpool Min (editable)" -int 40` | Bluetoothヘッドフォンの音質向上 | Bluetoothオーディオのビットプール値を調整し、音質を向上させます。 |
+| `launchctl unload -w /System/Library/LaunchAgents/com.apple.notificationcenterui.plist` | 通知センターの無効化 | `launchctl`を使い、通知センターのプロセスを無効化します。 |
+
+### スクリーンショット
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `com.apple.screencapture location ~/Desktop` | 保存場所 | スクリーンショットが保存されるデフォルトの場所を指定します。 |
+| `com.apple.screencapture disable-shadow -bool true` | 影を無効化 | `true`でウィンドウのスクリーンショットを撮る際に影を含めないようにします。 |
+| `com.apple.screencapture include-date -bool true` | ファイル名に日付を含める | `true`でスクリーンショットのファイル名に撮影日時を含めます。 |
+| `com.apple.screencapture show-thumbnail -bool false` | サムネイル表示 | `false`で撮影後に画面右下に表示されるフローティングサムネイルを無効にします。 |
+| `com.apple.screencapture type -string "png"` | ファイルフォーマット | スクリーンショットの画像ファイル形式を指定します。（`png`, `jpg`, `gif`, `tiff`, `pdf`） |
+
+### 省エネルギー
+
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `pmset -a displaysleep 15` | スリープやハイバネーションの設定 | ディスプレイのスリープ、コンピュータのスリープ、スタンバイモードへの移行時間などを `pmset` コマンドで細かく設定します。 |
+| `pmset -a autorestart 1` | 電源喪失時の自動再起動 | `1`で停電などから復旧した際に自動的にMacを再起動します。 |
+| `systemsetup -setrestartfreeze on` | フリーズ時の自動再起動 | `on`でシステムがフリーズした際に自動的に再起動します。 |
+
+### アプリケーション別設定
+
+#### Safari
+| コマンド | 項目 | 説明 |
+| :--- | :--- | :--- |
+| `com.apple.Safari UniversalSearchEnabled -bool false` | 検索クエリの非送信 | `false`でSafariの検索候補機能のために検索クエリがAppleに送信されるのを防ぎます。 |
+| `com.apple.Safari ShowFullURLInSmartSearchField -bool true` | フルURLの表示 | `true`でスマートサーチフィールドに常に完全なURLを表示します。 |
+| `com.apple.Safari AutoOpenSafeDownloads -bool false` | ダウンロード後の自動展開 | `false`でダウンロードした「安全な」ファイル（zipなど）が自動的に展開されるのを防ぎます。 |
+| `com.apple.Safari IncludeInternalDebugMenu -bool true` | デバッグメニューの有効化 | `true`でSafariに詳細な設定が可能なデバッグメニューを追加します。 |
+| `NSGlobalDomain WebKitDeveloperExtras -bool true` | Webインスペクタの有効化 | `true`でWeb開発用のインスペクタ機能を有効にします。 |

--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -36,7 +36,6 @@ fi
 cat <<EOF > "$OUTPUT_FILE"
 #!/bin/bash
 
-echo "Mac のシステム設定を適用中..."
 EOF
 
 # ================================================
@@ -75,94 +74,163 @@ add_setting() {
 # 現在の設定値を取得
 # ================================================
 
-# トラックパッドの設定値を取得
-TRACKPAD_SPEED=$(get_default_value -g com.apple.trackpad.scaling 1.5)          # トラックパッドのカーソル移動速度 (0.0-3.0)
-TAP_TO_CLICK=$(get_default_value com.apple.AppleMultitouchTrackpad Clicking 1) # タップでクリック (1:有効, 0:無効)
-DRAGGING=$(get_default_value com.apple.AppleMultitouchTrackpad Dragging 0)     # タップでドラッグ (1:有効, 0:無効)
-THREE_FINGER_DRAG=$(get_default_value com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag 0) # 3本指ドラッグ (1:有効, 0:無効)
-FIRST_CLICK_THRESHOLD=$(get_default_value com.apple.AppleMultitouchTrackpad FirstClickThreshold 1)  # クリック圧の強さ - 弱 (0:弱, 1:中, 2:強)
-SECOND_CLICK_THRESHOLD=$(get_default_value com.apple.AppleMultitouchTrackpad SecondClickThreshold 1) # クリック圧の強さ - 強 (0:弱, 1:中, 2:強)
-FORCE_SUPPRESSED=$(get_default_value com.apple.AppleMultitouchTrackpad ForceSuppressed false)       # Force Touch (false:有効, true:無効)
-THREE_FINGER_TAP=$(get_default_value com.apple.AppleMultitouchTrackpad TrackpadThreeFingerTapGesture 0) # 3本指タップ (0:無効, 2:有効)
-RIGHT_CLICK=$(get_default_value com.apple.AppleMultitouchTrackpad TrackpadRightClick true)          # 2本指クリックで右クリック (true:有効, false:無効)
+# --- システム ---
+ACCENT_COLOR=$(get_default_value "NSGlobalDomain" "AppleHighlightColor" "0.764700 0.976500 0.568600")
+SCROLL_BARS=$(get_default_value "NSGlobalDomain" "AppleShowScrollBars" "Automatic")
+SAVE_PANEL_EXPANDED=$(get_default_value "NSGlobalDomain" "NSNavPanelExpandedStateForSaveMode" "false")
+PRINT_PANEL_EXPANDED=$(get_default_value "NSGlobalDomain" "PMPrintingExpandedStateForPrint" "false")
+SAVE_TO_ICLOUD=$(get_default_value "NSGlobalDomain" "NSDocumentSaveNewDocumentsToCloud" "true")
+QUIT_ALWAYS_KEEPS_WINDOWS=$(get_default_value "com.apple.systempreferences" "NSQuitAlwaysKeepsWindows" "false")
+DISABLE_AUTO_TERMINATION=$(get_default_value "NSGlobalDomain" "NSDisableAutomaticTermination" "false")
 
-# システムサウンドの設定値を取得
-STARTUP_SOUND=$(get_default_value com.apple.systemsound "com.apple.sound.beep.flash" false)    # 起動時のサウンド (true:有効, false:無効)
-UI_SOUND=$(get_default_value com.apple.systemsound "com.apple.sound.uiaudio.enabled" false)    # UI操作音 (true:有効, false:無効)
-VOLUME_FEEDBACK=$(get_default_value -g "com.apple.sound.beep.feedback" false)                  # 音量変更時の効果音 (true:有効, false:無効)
-ALERT_SOUND=$(get_default_value -g "com.apple.sound.beep.sound" "/System/Library/Sounds/Boop.aiff") # アラート音の種類
+# --- UI/UX ---
+HIDE_MENU_BAR=$(get_default_value "NSGlobalDomain" "_HIHideMenuBar" "false")
+REDUCE_TRANSPARENCY=$(get_default_value "com.apple.universalaccess" "reduceTransparency" "false")
+SIDEBAR_ICON_SIZE=$(get_default_value "NSGlobalDomain" "NSTableViewDefaultSizeMode" "2")
+WINDOW_RESIZE_TIME=$(get_default_value "NSGlobalDomain" "NSWindowResizeTime" "0.001")
+AUTO_CAPITALIZATION=$(get_default_value "NSGlobalDomain" "NSAutomaticCapitalizationEnabled" "true")
+SMART_DASHES=$(get_default_value "NSGlobalDomain" "NSAutomaticDashSubstitutionEnabled" "true")
+SMART_QUOTES=$(get_default_value "NSGlobalDomain" "NSAutomaticQuoteSubstitutionEnabled" "true")
+AUTO_SPELLING_CORRECTION=$(get_default_value "NSGlobalDomain" "NSAutomaticSpellingCorrectionEnabled" "true")
 
-# Dockの設定値を取得
-DOCK_SIZE=$(get_default_value com.apple.dock tilesize 50)           # Dockのサイズ (ピクセル)
-DOCK_AUTOHIDE=$(get_default_value com.apple.dock autohide false)    # Dock自動非表示 (true:有効, false:無効)
-DOCK_RECENTS=$(get_default_value com.apple.dock show-recents false) # 最近使用したアプリの表示 (true:表示, false:非表示)
+# --- Dock ---
+DOCK_SIZE=$(get_default_value "com.apple.dock" "tilesize" "50")
+DOCK_AUTOHIDE=$(get_default_value "com.apple.dock" "autohide" "false")
+DOCK_AUTOHIDE_TIME=$(get_default_value "com.apple.dock" "autohide-time-modifier" "0.5")
+DOCK_AUTOHIDE_DELAY=$(get_default_value "com.apple.dock" "autohide-delay" "0")
+DOCK_SHOW_RECENTS=$(get_default_value "com.apple.dock" "show-recents" "true")
+DOCK_MIN_EFFECT=$(get_default_value "com.apple.dock" "mineffect" "genie")
+DOCK_MIN_TO_APP=$(get_default_value "com.apple.dock" "minimize-to-application" "false")
+DOCK_LAUNCH_ANIM=$(get_default_value "com.apple.dock" "launchanim" "true")
+DOCK_SHOW_HIDDEN=$(get_default_value "com.apple.dock" "showhidden" "false")
 
-# Finderの設定値を取得
-FINDER_PATHBAR=$(get_default_value com.apple.finder ShowPathbar false)      # パスバー表示 (true:表示, false:非表示)
-FINDER_STATUSBAR=$(get_default_value com.apple.finder ShowStatusBar false)  # ステータスバー表示 (true:表示, false:非表示)
-FINDER_SHOW_HIDDEN=$(get_default_value com.apple.finder AppleShowAllFiles false) # 隠しファイル表示 (true:表示, false:非表示)
+# --- Finder ---
+FINDER_SHOW_PATHBAR=$(get_default_value "com.apple.finder" "ShowPathbar" "false")
+FINDER_SHOW_STATUSBAR=$(get_default_value "com.apple.finder" "ShowStatusBar" "false")
+FINDER_SHOW_HIDDEN_FILES=$(get_default_value "com.apple.finder" "AppleShowAllFiles" "false")
+FINDER_SHOW_EXTENSIONS=$(get_default_value "NSGlobalDomain" "AppleShowAllExtensions" "false")
+FINDER_SORT_FOLDERS_FIRST=$(get_default_value "com.apple.finder" "_FXSortFoldersFirst" "false")
+FINDER_DEFAULT_SEARCH_SCOPE=$(get_default_value "com.apple.finder" "FXDefaultSearchScope" "SCev")
+FINDER_QUIT_MENU=$(get_default_value "com.apple.finder" "QuitMenuItem" "false")
 
-# ホットコーナーの設定値を取得
-HOT_CORNER_TL=$(get_default_value com.apple.dock wvous-tl-corner 1)   # 左上のホットコーナー (1:何もしない, 2:Mission Control, 3:アプリケーションウィンドウ, 4:デスクトップ, 5:スクリーンセーバー開始, 6:スクリーンセーバー無効, 7:Dashboard, 10:ディスプレイをスリープさせる, 11:Launchpad, 12:通知センター)
-HOT_CORNER_TR=$(get_default_value com.apple.dock wvous-tr-corner 1)   # 右上のホットコーナー
-HOT_CORNER_BL=$(get_default_value com.apple.dock wvous-bl-corner 1)   # 左下のホットコーナー
-HOT_CORNER_BR=$(get_default_value com.apple.dock wvous-br-corner 1)   # 右下のホットコーナー
+# --- デスクトップ ---
+SHOW_HD_ON_DESKTOP=$(get_default_value "com.apple.finder" "ShowHardDrivesOnDesktop" "true")
 
-# その他の設定値を取得
-MENU_BAR_HIDDEN=$(get_default_value NSGlobalDomain _HIHideMenuBar false)    # メニューバー自動非表示 (true:有効, false:無効)
-ACCENT_COLOR=$(get_default_value -g AppleAccentColor 0)                     # アクセントカラー (0:マルチカラー, 1:青, 2:紫, 3:ピンク, 4:赤, 5:オレンジ, 6:黄)
+# --- ミッションコントロール ---
+MC_ANIMATION_DURATION=$(get_default_value "com.apple.dock" "expose-animation-duration" "0.2")
+MC_AUTO_REARRANGE=$(get_default_value "com.apple.dock" "mru-spaces" "true")
+MC_GROUP_BY_APP=$(get_default_value "com.apple.dock" "expose-group-by-app" "true")
 
-# ディスプレイ設定を取得（displayplacerが利用可能な場合）
-DISPLAY_COMMAND=""
-if command -v displayplacer >/dev/null 2>&1; then
-    # displayplacerの出力から現在の設定を抽出（解像度、リフレッシュレート、配置など）
-    DISPLAY_OUTPUT=$(displayplacer list 2>/dev/null | grep "^displayplacer")
-    if [[ -n "$DISPLAY_OUTPUT" ]]; then
-        DISPLAY_COMMAND=$(echo "$DISPLAY_OUTPUT" | sed 's/displayplacer //')
-    fi
-fi
+# --- ホットコーナー ---
+HOT_CORNER_TL=$(get_default_value "com.apple.dock" "wvous-tl-corner" "1")
+HOT_CORNER_TR=$(get_default_value "com.apple.dock" "wvous-tr-corner" "1")
+HOT_CORNER_BL=$(get_default_value "com.apple.dock" "wvous-bl-corner" "1")
+HOT_CORNER_BR=$(get_default_value "com.apple.dock" "wvous-br-corner" "1")
+
+# --- キーボード ---
+KEY_REPEAT_RATE=$(get_default_value "NSGlobalDomain" "KeyRepeat" "2")
+KEY_REPEAT_DELAY=$(get_default_value "NSGlobalDomain" "InitialKeyRepeat" "15")
+PRESS_AND_HOLD=$(get_default_value "NSGlobalDomain" "ApplePressAndHoldEnabled" "true")
+NATURAL_SCROLLING=$(get_default_value "NSGlobalDomain" "com.apple.swipescrolldirection" "true")
+
+# --- マウス ---
+MOUSE_SCALING=$(get_default_value ".GlobalPreferences" "com.apple.mouse.scaling" "1.0")
+
+# --- トラックパッド ---
+TRACKPAD_SCALING=$(get_default_value -g "com.apple.trackpad.scaling" "1.5")
+TRACKPAD_CLICKING=$(get_default_value "com.apple.AppleMultitouchTrackpad" "Clicking" "1")
+TRACKPAD_DRAGGING=$(get_default_value "com.apple.AppleMultitouchTrackpad" "Dragging" "0")
+TRACKPAD_3FINGER_DRAG=$(get_default_value "com.apple.AppleMultitouchTrackpad" "TrackpadThreeFingerDrag" "0")
+TRACKPAD_RIGHT_CLICK=$(get_default_value "com.apple.AppleMultitouchTrackpad" "TrackpadRightClick" "true")
+
+# --- サウンド ---
+UI_SOUND=$(get_default_value "com.apple.systemsound" "com.apple.sound.uiaudio.enabled" "1")
+VOLUME_FEEDBACK=$(get_default_value -g "com.apple.sound.beep.feedback" "1")
+
+# --- スクリーンショット ---
+SCREENSHOT_LOCATION=$(get_default_value "com.apple.screencapture" "location" "~/Desktop")
+SCREENSHOT_DISABLE_SHADOW=$(get_default_value "com.apple.screencapture" "disable-shadow" "false")
+SCREENSHOT_TYPE=$(get_default_value "com.apple.screencapture" "type" "png")
 
 # ================================================
 # リストアスクリプトの生成
 # ================================================
 
-# トラックパッドの設定
-TRACKPAD_COMMANDS=$(cat << EOF
-defaults write -g com.apple.trackpad.scaling -float $TRACKPAD_SPEED
-defaults write com.apple.AppleMultitouchTrackpad FirstClickThreshold -int $FIRST_CLICK_THRESHOLD
-defaults write com.apple.AppleMultitouchTrackpad SecondClickThreshold -int $SECOND_CLICK_THRESHOLD
-defaults write com.apple.AppleMultitouchTrackpad Clicking -bool $(format_bool_value $TAP_TO_CLICK)
-defaults write com.apple.AppleMultitouchTrackpad Dragging -bool $(format_bool_value $DRAGGING)
-defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool $(format_bool_value $THREE_FINGER_DRAG)
+# --- システム ---
+SYSTEM_COMMANDS=$(cat << EOF
+defaults write NSGlobalDomain AppleHighlightColor -string "$ACCENT_COLOR"
+defaults write NSGlobalDomain AppleShowScrollBars -string "$SCROLL_BARS"
+defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode -bool $(format_bool_value $SAVE_PANEL_EXPANDED)
+defaults write NSGlobalDomain PMPrintingExpandedStateForPrint -bool $(format_bool_value $PRINT_PANEL_EXPANDED)
+defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool $(format_bool_value $SAVE_TO_ICLOUD)
+defaults write com.apple.systempreferences NSQuitAlwaysKeepsWindows -bool $(format_bool_value $QUIT_ALWAYS_KEEPS_WINDOWS)
+defaults write NSGlobalDomain NSDisableAutomaticTermination -bool $(format_bool_value $DISABLE_AUTO_TERMINATION)
 EOF
 )
 
-# システムサウンドの設定
-SOUND_COMMANDS=$(cat << EOF
-defaults write com.apple.systemsound com.apple.sound.beep.flash -bool $(format_bool_value $STARTUP_SOUND)
-defaults write com.apple.systemsound com.apple.sound.uiaudio.enabled -bool $(format_bool_value $UI_SOUND)
-defaults write -g com.apple.sound.beep.feedback -bool $(format_bool_value $VOLUME_FEEDBACK)
-defaults write -g com.apple.sound.beep.sound -string "$ALERT_SOUND"
+# --- UI/UX ---
+UIUX_COMMANDS=$(cat << EOF
+defaults write NSGlobalDomain _HIHideMenuBar -bool $(format_bool_value $HIDE_MENU_BAR)
+defaults write com.apple.universalaccess reduceTransparency -bool $(format_bool_value $REDUCE_TRANSPARENCY)
+defaults write NSGlobalDomain NSTableViewDefaultSizeMode -int $SIDEBAR_ICON_SIZE
+defaults write NSGlobalDomain NSWindowResizeTime -float $WINDOW_RESIZE_TIME
+defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool $(format_bool_value $AUTO_CAPITALIZATION)
+defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool $(format_bool_value $SMART_DASHES)
+defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool $(format_bool_value $SMART_QUOTES)
+defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool $(format_bool_value $AUTO_SPELLING_CORRECTION)
 EOF
 )
 
-# Dockの設定
+# ================================================
+# 設定の書き出し
+# ================================================
+
+# --- Dock ---
 DOCK_COMMANDS=$(cat << EOF
 defaults write com.apple.dock tilesize -int $DOCK_SIZE
 defaults write com.apple.dock autohide -bool $(format_bool_value $DOCK_AUTOHIDE)
-defaults write com.apple.dock show-recents -bool $(format_bool_value $DOCK_RECENTS)
+defaults write com.apple.dock autohide-time-modifier -float $DOCK_AUTOHIDE_TIME
+defaults write com.apple.dock autohide-delay -float $DOCK_AUTOHIDE_DELAY
+defaults write com.apple.dock show-recents -bool $(format_bool_value $DOCK_SHOW_RECENTS)
+defaults write com.apple.dock mineffect -string "$DOCK_MIN_EFFECT"
+defaults write com.apple.dock minimize-to-application -bool $(format_bool_value $DOCK_MIN_TO_APP)
+defaults write com.apple.dock launchanim -bool $(format_bool_value $DOCK_LAUNCH_ANIM)
+defaults write com.apple.dock showhidden -bool $(format_bool_value $DOCK_SHOW_HIDDEN)
 EOF
 )
 
-# Finderの設定
+# --- Finder ---
 FINDER_COMMANDS=$(cat << EOF
-defaults write com.apple.finder ShowPathbar -bool $(format_bool_value $FINDER_PATHBAR)
-defaults write com.apple.finder ShowStatusBar -bool $(format_bool_value $FINDER_STATUSBAR)
-defaults write com.apple.finder AppleShowAllFiles -bool $(format_bool_value $FINDER_SHOW_HIDDEN)
+defaults write com.apple.finder ShowPathbar -bool $(format_bool_value $FINDER_SHOW_PATHBAR)
+defaults write com.apple.finder ShowStatusBar -bool $(format_bool_value $FINDER_SHOW_STATUSBAR)
+defaults write com.apple.finder AppleShowAllFiles -bool $(format_bool_value $FINDER_SHOW_HIDDEN_FILES)
+defaults write NSGlobalDomain AppleShowAllExtensions -bool $(format_bool_value $FINDER_SHOW_EXTENSIONS)
+defaults write com.apple.finder _FXSortFoldersFirst -bool $(format_bool_value $FINDER_SORT_FOLDERS_FIRST)
+defaults write com.apple.finder FXDefaultSearchScope -string "$FINDER_DEFAULT_SEARCH_SCOPE"
+defaults write com.apple.finder QuitMenuItem -bool $(format_bool_value $FINDER_QUIT_MENU)
 EOF
 )
 
-# ホットコーナーの設定
+add_setting "システム" "$SYSTEM_COMMANDS"
+add_setting "UI/UX" "$UIUX_COMMANDS"
+add_setting "Dock" "$DOCK_COMMANDS"
+add_setting "Finder" "$FINDER_COMMANDS"
+
+# --- デスクトップ ---
+DESKTOP_COMMANDS=$(cat << EOF
+defaults write com.apple.finder ShowHardDrivesOnDesktop -bool $(format_bool_value $SHOW_HD_ON_DESKTOP)
+EOF
+)
+
+# --- ミッションコントロール ---
+MISSION_CONTROL_COMMANDS=$(cat << EOF
+defaults write com.apple.dock expose-animation-duration -float $MC_ANIMATION_DURATION
+defaults write com.apple.dock mru-spaces -bool $(format_bool_value $MC_AUTO_REARRANGE)
+defaults write com.apple.dock expose-group-by-app -bool $(format_bool_value $MC_GROUP_BY_APP)
+EOF
+)
+
+# --- ホットコーナー ---
 HOT_CORNER_COMMANDS=$(cat << EOF
 defaults write com.apple.dock wvous-tl-corner -int $HOT_CORNER_TL
 defaults write com.apple.dock wvous-tr-corner -int $HOT_CORNER_TR
@@ -171,27 +239,61 @@ defaults write com.apple.dock wvous-br-corner -int $HOT_CORNER_BR
 EOF
 )
 
-# その他の設定
-OTHER_COMMANDS=$(cat << EOF
-defaults write NSGlobalDomain _HIHideMenuBar -bool $(format_bool_value $MENU_BAR_HIDDEN)
-defaults write -g AppleAccentColor -int $ACCENT_COLOR
-defaults write com.apple.screencapture location "\$HOME/Desktop"
+add_setting "デスクトップ" "$DESKTOP_COMMANDS"
+add_setting "ミッションコントロール" "$MISSION_CONTROL_COMMANDS"
+add_setting "ホットコーナー" "$HOT_CORNER_COMMANDS"
+
+# --- キーボード ---
+KEYBOARD_COMMANDS=$(cat << EOF
+defaults write NSGlobalDomain KeyRepeat -int $KEY_REPEAT_RATE
+defaults write NSGlobalDomain InitialKeyRepeat -int $KEY_REPEAT_DELAY
+defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool $(format_bool_value $PRESS_AND_HOLD)
+defaults write NSGlobalDomain com.apple.swipescrolldirection -bool $(format_bool_value $NATURAL_SCROLLING)
 EOF
 )
 
-# ヘッダーの作成
-echo "#!/bin/bash" > "$OUTPUT_FILE"
+# --- マウス ---
+MOUSE_COMMANDS=$(cat << EOF
+defaults write .GlobalPreferences com.apple.mouse.scaling -float $MOUSE_SCALING
+EOF
+)
 
-# 設定の追加
+# --- トラックパッド ---
+TRACKPAD_COMMANDS=$(cat << EOF
+defaults write -g com.apple.trackpad.scaling -float $TRACKPAD_SCALING
+defaults write com.apple.AppleMultitouchTrackpad Clicking -bool $(format_bool_value $TRACKPAD_CLICKING)
+defaults write com.apple.AppleMultitouchTrackpad Dragging -bool $(format_bool_value $TRACKPAD_DRAGGING)
+defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool $(format_bool_value $TRACKPAD_3FINGER_DRAG)
+defaults write com.apple.AppleMultitouchTrackpad TrackpadRightClick -bool $(format_bool_value $TRACKPAD_RIGHT_CLICK)
+EOF
+)
+
+# --- サウンド ---
+SOUND_COMMANDS=$(cat << EOF
+defaults write com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int $UI_SOUND
+defaults write -g "com.apple.sound.beep.feedback" -int $VOLUME_FEEDBACK
+EOF
+)
+
+# --- スクリーンショット ---
+SCREENSHOT_COMMANDS=$(cat << EOF
+defaults write com.apple.screencapture location -string "$SCREENSHOT_LOCATION"
+defaults write com.apple.screencapture disable-shadow -bool $(format_bool_value $SCREENSHOT_DISABLE_SHADOW)
+defaults write com.apple.screencapture type -string "$SCREENSHOT_TYPE"
+EOF
+)
+
+add_setting "キーボード" "$KEYBOARD_COMMANDS"
+add_setting "マウス" "$MOUSE_COMMANDS"
 add_setting "トラックパッド" "$TRACKPAD_COMMANDS"
 add_setting "サウンド" "$SOUND_COMMANDS"
-add_setting "Dock" "$DOCK_COMMANDS"
-add_setting "Finder" "$FINDER_COMMANDS"
-add_setting "ホットコーナー" "$HOT_CORNER_COMMANDS"
-add_setting "その他" "$OTHER_COMMANDS"
+add_setting "スクリーンショット" "$SCREENSHOT_COMMANDS"
 
 # 設定の反映用コマンド
+echo "" >> "$OUTPUT_FILE"
+echo "# ================================================" >> "$OUTPUT_FILE"
 echo "# 設定の反映" >> "$OUTPUT_FILE"
+echo "# ================================================" >> "$OUTPUT_FILE"
 echo "killall Dock" >> "$OUTPUT_FILE"
 echo "killall Finder" >> "$OUTPUT_FILE"
 echo "killall SystemUIServer" >> "$OUTPUT_FILE"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * macOSの各種設定を`defaults`コマンド等で管理する方法をまとめた新しいリファレンスドキュメントを追加しました。システムやUI/UX、Dock、Finder、キーボード、電源管理など幅広いカテゴリの設定コマンドと説明が含まれています。

* **新機能**
  * macOS設定のバックアップスクリプトの検証を自動化するGitHub Actionsワークフローを追加しました。

* **改善**
  * macOS設定のバックアップスクリプトを大幅に拡充・整理し、より多くの設定項目を網羅的に取得・復元できるようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->