### PR TITLE
feat: CIでbrew install時にパスワードを求められる問題の修正

### DIFF
--- a/scripts/java.sh
+++ b/scripts/java.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 set -euo pipefail
 
@@ -11,12 +11,11 @@ main() {
     # temurin@<バージョン>がインストールされていなければインストール
     if ! brew list --cask "temurin@${JDK_VERSION}" > /dev/null 2>&1; then
         echo "[INSTALL] temurin@${JDK_VERSION}"
-        local -a brew_install_cmd=(brew install --cask)
+        local brew_install_cmd=("brew" "install" "--cask")
         if [ "${IS_CI:-false}" = "true" ]; then
             brew_install_cmd+=("--no-quarantine")
         fi
 
-        # shellcheck disable=SC2086 # 配列展開で安全に実行
         if ! "${brew_install_cmd[@]}" "temurin@${JDK_VERSION}"; then
             echo "[ERROR] temurin@${JDK_VERSION} のインストールに失敗しました"
             exit 1

--- a/scripts/java.sh
+++ b/scripts/java.sh
@@ -11,7 +11,12 @@ main() {
     # temurin@<バージョン>がインストールされていなければインストール
     if ! brew list --cask "temurin@${JDK_VERSION}" > /dev/null 2>&1; then
         echo "[INSTALL] temurin@${JDK_VERSION}"
-        if ! brew install --cask "temurin@${JDK_VERSION}"; then
+        local brew_install_cmd="brew install --cask"
+        if [ "${IS_CI:-false}" = "true" ]; then
+            brew_install_cmd="${brew_install_cmd} --no-quarantine"
+        fi
+
+        if ! ${brew_install_cmd} "temurin@${JDK_VERSION}"; then
             echo "[ERROR] temurin@${JDK_VERSION} のインストールに失敗しました"
             exit 1
         fi

--- a/scripts/java.sh
+++ b/scripts/java.sh
@@ -11,12 +11,13 @@ main() {
     # temurin@<バージョン>がインストールされていなければインストール
     if ! brew list --cask "temurin@${JDK_VERSION}" > /dev/null 2>&1; then
         echo "[INSTALL] temurin@${JDK_VERSION}"
-        local brew_install_cmd="brew install --cask"
+        local -a brew_install_cmd=(brew install --cask)
         if [ "${IS_CI:-false}" = "true" ]; then
-            brew_install_cmd="${brew_install_cmd} --no-quarantine"
+            brew_install_cmd+=("--no-quarantine")
         fi
 
-        if ! ${brew_install_cmd} "temurin@${JDK_VERSION}"; then
+        # shellcheck disable=SC2086 # 配列展開で安全に実行
+        if ! "${brew_install_cmd[@]}" "temurin@${JDK_VERSION}"; then
             echo "[ERROR] temurin@${JDK_VERSION} のインストールに失敗しました"
             exit 1
         fi


### PR DESCRIPTION
CI環境で`brew install --cask`を実行する際に、GUIのパスワードプロンプトが表示されないように`--no-quarantine`オプションを追加しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * CI環境でのみ`--no-quarantine`フラグを付与してJDKのインストールコマンドを実行するように変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->