### PR TITLE
fix: java.shでbashを利用しつつzshのプロファイルを読み込むように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ environment/
 │   ├── flutter.sh
 │   ├── git.sh
 │   ├── homebrew.sh
+│   ├── java.sh
 │   ├── macos.sh
 │   ├── node.sh
+│   ├── python.sh
 │   ├── ruby.sh
 │   ├── shell.sh
 │   └── vscode.sh
@@ -192,11 +194,4 @@ $ pyenv install 3.12.4
 
 # グローバルに設定
 $ pyenv global 3.12.4
-```
-
-## Java Development Environment
-
-```bash
-# インストールされたJavaのバージョンを確認
-$ /usr/libexec/java_home -V
 ```

--- a/scripts/java.sh
+++ b/scripts/java.sh
@@ -28,16 +28,17 @@ main() {
     echo "[SUCCESS] Java環境のセットアップが完了しました"
 
 
-    # .zprofileをsourceして環境変数を反映（zsh前提）
-    if [ -f "$HOME/.zprofile" ]; then
-        source "$HOME/.zprofile"
-    fi
-
     verify_java_setup
 }
 
 verify_java_setup() {
     echo "==== Start: Java環境を検証中..."
+
+    # .zprofileをsourceして環境変数を反映
+    if [ -f "$HOME/.zprofile" ]; then
+        # zshの設定ファイルをbashで読み込む
+        eval "$(zsh -c 'source $HOME/.zprofile; export -p')"
+    fi
 
     # temurinがインストールされているか確認
     if ! brew list --cask "temurin@${JDK_VERSION}" > /dev/null 2>&1; then

--- a/scripts/java.sh
+++ b/scripts/java.sh
@@ -34,12 +34,6 @@ main() {
 verify_java_setup() {
     echo "==== Start: Java環境を検証中..."
 
-    # .zprofileをsourceして環境変数を反映
-    if [ -f "$HOME/.zprofile" ]; then
-        # zshの設定ファイルをbashで読み込む
-        eval "$(zsh -c 'source $HOME/.zprofile; export -p')"
-    fi
-
     # temurinがインストールされているか確認
     if ! brew list --cask "temurin@${JDK_VERSION}" > /dev/null 2>&1; then
         echo "[ERROR] temurin@${JDK_VERSION} がインストールされていません"
@@ -50,10 +44,17 @@ verify_java_setup() {
 
     # JAVA_HOMEが設定されているか確認
     if [ -z "${JAVA_HOME:-}" ]; then
-        echo "[ERROR] JAVA_HOME が設定されていません"
+        echo "[INFO] JAVA_HOME が設定されていないため、.zprofile を読み込みます"
+        if [ -f "$HOME/.zprofile" ]; then
+            eval "$(zsh -c '{ source "$HOME/.zprofile" >/dev/null 2>&1; export -p; }')"
+        fi
+    fi
+
+    if [ -z "${JAVA_HOME:-}" ] || [ ! -d "$JAVA_HOME" ]; then
+        echo "[ERROR] JAVA_HOME が設定されていないか、無効なパスです"
         exit 1
     else
-        echo "[SUCCESS] JAVA_HOME は設定されています: $JAVA_HOME"
+        echo "[SUCCESS] JAVA_HOME は正しく設定されています: $JAVA_HOME"
     fi
 
     # javaコマンドが実行できるか確認


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `.zprofile`で定義された環境変数が正しく読み込まれ、Javaセットアップの検証時に反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->