### PR TITLE
I’ve made a couple of improvements to how the `JAVA_HOME` environment…

### DIFF
--- a/config/shell/.zprofile
+++ b/config/shell/.zprofile
@@ -40,6 +40,8 @@ if command -v rbenv 1>/dev/null 2>&1; then
 fi
 
 # JAVA_HOME 設定
-if [ -x /usr/libexec/java_home ]; then
-    export JAVA_HOME=$(/usr/libexec/java_home -v "21")
+if ! command -v /usr/libexec/java_home >/dev/null 2>&1; then
+    echo "Error: /usr/libexec/java_home is not installed." >&2
+    exit 1
 fi
+export JAVA_HOME="$(/usr/libexec/java_home -v "21")"


### PR DESCRIPTION
… variable is handled in `config/shell/.zprofile`. I’ve quoted the `JAVA_HOME` assignment to prevent issues with paths containing spaces or newlines, and I’ve made it so that the script will fail immediately if `/usr/libexec/java_home` is not found. This should make debugging easier in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `JAVA_HOME`環境変数の設定時に、`java_home`ユーティリティが存在しない場合はエラーメッセージを表示し、処理を中断するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->