### PR TITLE
feat: Add displayplacer to backup script

### DIFF
--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -311,7 +311,7 @@ fi
 
 if [[ -n "$DISPLAY_COMMAND" ]]; then
     DISPLAY_SETTINGS_COMMANDS=$(cat << EOF
-displayplacer "$DISPLAY_COMMAND"
+displayplacer $DISPLAY_COMMAND
 EOF
 )
     add_setting "ディスプレイ" "$DISPLAY_SETTINGS_COMMANDS"

--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -299,6 +299,24 @@ add_setting "トラックパッド" "$TRACKPAD_COMMANDS"
 add_setting "サウンド" "$SOUND_COMMANDS"
 add_setting "スクリーンショット" "$SCREENSHOT_COMMANDS"
 
+# ディスプレイ設定を取得
+DISPLAY_COMMAND=""
+if command -v displayplacer >/dev/null 2>&1; then
+    # displayplacerの出力から現在の設定を抽出（解像度、リフレッシュレート、配置など）
+    DISPLAY_OUTPUT=$(displayplacer list 2>/dev/null | grep "^displayplacer")
+    if [[ -n "$DISPLAY_OUTPUT" ]]; then
+        DISPLAY_COMMAND=$(echo "$DISPLAY_OUTPUT" | sed 's/displayplacer //')
+    fi
+fi
+
+if [[ -n "$DISPLAY_COMMAND" ]]; then
+    DISPLAY_SETTINGS_COMMANDS=$(cat << EOF
+displayplacer "$DISPLAY_COMMAND"
+EOF
+)
+    add_setting "ディスプレイ" "$DISPLAY_SETTINGS_COMMANDS"
+fi
+
 
 # 実行権限を付与
 chmod +x "$OUTPUT_FILE"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 現在のmacOSディスプレイ設定をバックアップスクリプトに追加し、再適用できるコマンドとして保存する機能を追加しました（displayplacer利用）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->