### PR TITLE
feat: nvmを使用してNode.jsをインストールするように変更

### DIFF
--- a/config/brew/Brewfile
+++ b/config/brew/Brewfile
@@ -3,7 +3,7 @@
 # brew "gh" # installed by scripts/git.sh
 
 ## Development Tools
-# brew "node" # installed by scripts/node.sh
+# brew "nvm" # installed by scripts/node.sh
 # brew "jq"   # installed by scripts/node.sh
 brew "go"
 # tap "leoafarias/fvm" # installed by scripts/flutter.sh

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -43,10 +43,21 @@ install_homebrew_binary() {
     
     # インストールスクリプト実行後、現在のシェルセッションにPATHを設定
     # これにより、次のcommand -v brewが正しく機能するようになる
-    if [[ "$(uname -m)" == "arm64" ]]; then
-        eval "$(/opt/homebrew/bin/brew shellenv)"
+    local brew_path=""
+    if [[ "$(uname)" == "Darwin" ]]; then # macOS
+        if [[ "$(uname -m)" == "arm64" ]]; then # Apple Silicon
+            brew_path="/opt/homebrew/bin/brew"
+        else # Intel
+            brew_path="/usr/local/bin/brew"
+        fi
+    elif [[ "$(uname)" == "Linux" ]]; then # Linux
+        brew_path="/home/linuxbrew/.linuxbrew/bin/brew"
+    fi
+
+    if [ -n "$brew_path" ] && [ -f "$brew_path" ]; then
+        eval "$($brew_path shellenv)"
     else
-        eval "$(/usr/local/bin/brew shellenv)"
+        echo "[ERROR] brewコマンドのパスを設定できませんでした。"
     fi
     
     # インストール結果確認 (この時点でbrewコマンドが利用可能になっているはず)
@@ -84,11 +95,15 @@ verify_brew_path() {
     BREW_PATH=$(which brew)
     local expected_path=""
     
-    # アーキテクチャに応じた期待値
-    if [[ "$(uname -m)" == "arm64" ]]; then
-        expected_path="/opt/homebrew/bin/brew"
-    else
-        expected_path="/usr/local/bin/brew"
+    # OSとアーキテクチャに応じた期待値
+    if [[ "$(uname)" == "Darwin" ]]; then # macOS
+        if [[ "$(uname -m)" == "arm64" ]]; then # Apple Silicon
+            expected_path="/opt/homebrew/bin/brew"
+        else # Intel
+            expected_path="/usr/local/bin/brew"
+        fi
+    elif [[ "$(uname)" == "Linux" ]]; then # Linux
+        expected_path="/home/linuxbrew/.linuxbrew/bin/brew"
     fi
     
     if [[ "$BREW_PATH" != "$expected_path" ]]; then

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -8,7 +8,8 @@ REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
 install_dependencies() {
     echo "[INFO] 依存関係をチェック・インストールします: nvm, jq"
     local changed=false
-    if ! command -v nvm &> /dev/null; then
+    # Homebrew フォーミュラの有無で判定する
+    if ! brew list nvm &> /dev/null; then
         brew install nvm
         changed=true
     fi
@@ -24,17 +25,8 @@ install_dependencies() {
 
 # nvm を使って Node.js をインストール
 install_node_with_nvm() {
-    local node_version="22.17.1"
+    local node_version="22.7.1"
     local changed=false
-
-    # nvm の初期化
-    if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
-        # shellcheck source=/dev/null
-        . "$(brew --prefix nvm)/nvm.sh"
-    else
-        echo "[ERROR] nvm.sh が見つかりません。nvmが正しくインストールされているか確認してください。"
-        exit 1
-    fi
 
     # Node.js のインストール
     if ! nvm ls "$node_version" &> /dev/null; then
@@ -46,7 +38,7 @@ install_node_with_nvm() {
     fi
 
     # グローバルバージョンの設定
-    if [ "$(nvm current)" != "$node_version" ]; then
+    if [ "$(nvm current)" != "v$node_version" ]; then
         nvm use "$node_version"
         nvm alias default "$node_version"
         changed=true
@@ -61,6 +53,16 @@ install_node_with_nvm() {
 
 main() {
     install_dependencies
+
+    # nvm の初期化
+    if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
+        # shellcheck source=/dev/null
+        . "$(brew --prefix nvm)/nvm.sh"
+    else
+        echo "[ERROR] nvm.sh が見つかりません。nvmが正しくインストールされているか確認してください。"
+        exit 1
+    fi
+
     install_node_with_nvm
     echo "[Start] Node.js のセットアップを開始します..."
 
@@ -80,12 +82,6 @@ main() {
 }
 
 install_global_packages() {
-    # nvm の初期化
-    if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
-        # shellcheck source=/dev/null
-        . "$(brew --prefix nvm)/nvm.sh"
-    fi
-
     local packages_file="$REPO_ROOT/config/node/global-packages.json"
     
     if [ ! -f "$packages_file" ]; then
@@ -151,12 +147,6 @@ install_global_packages() {
 }
 
 verify_node_setup() {
-    # nvm の初期化
-    if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
-        # shellcheck source=/dev/null
-        . "$(brew --prefix nvm)/nvm.sh"
-    fi
-
     echo ""
     echo "==== Start: Node.js 環境を検証中... ===="
     local verification_failed=false
@@ -178,12 +168,6 @@ verify_node_setup() {
 }
 
 verify_global_packages() {
-    # nvm の初期化
-    if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
-        # shellcheck source=/dev/null
-        . "$(brew --prefix nvm)/nvm.sh"
-    fi
-
     local packages_file="$REPO_ROOT/config/node/global-packages.json"
     
     if [ ! -f "$packages_file" ]; then

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # 現在のスクリプトディレクトリを取得
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_ROOT="$( cd "$SCRIPT_DIR/.." && pwd )"
@@ -25,7 +27,7 @@ install_dependencies() {
 
 # nvm を使って Node.js をインストール
 install_node_with_nvm() {
-    local node_version="22.7.1"
+    local node_version="20.15.1"
     local changed=false
 
     # Node.js のインストール


### PR DESCRIPTION
Output:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Node.jsの管理方法がHomebrewからnvm（Node Version Manager）に変更されました。これにより、指定バージョンのNode.jsをnvm経由で自動的にインストール・設定します。
  * Homebrewのインストールおよびパス設定がmacOSだけでなくLinuxにも対応しました。

* **改善**
  * nvm環境の初期化やエラーハンドリングが強化され、Node.jsセットアップの信頼性が向上しました。
  * Node.jsとnvmのバージョン情報が確認時に表示されるようになりました。
  * Homebrewのパス検証ロジックがOSとアーキテクチャに応じて統一されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->