### PR TITLE
feat(node): nvmを使用して特定のLTSバージョンのNode.jsをインストールするように変更

### DIFF
--- a/config/brew/Brewfile
+++ b/config/brew/Brewfile
@@ -3,7 +3,7 @@
 # brew "gh" # installed by scripts/git.sh
 
 ## Development Tools
-# brew "node" # installed by scripts/node.sh
+# brew "nvm" # installed by scripts/node.sh
 # brew "jq"   # installed by scripts/node.sh
 brew "go"
 # tap "leoafarias/fvm" # installed by scripts/flutter.sh

--- a/config/shell/.zprofile
+++ b/config/shell/.zprofile
@@ -40,10 +40,9 @@ if command -v rbenv 1>/dev/null 2>&1; then
 fi
 
 # nvm 初期化
-export NVM_DIR="$HOME/.nvm"
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
   . "$(brew --prefix nvm)/nvm.sh" --no-use # スクリプト読み込み時に use しない
-  # nvm use default # 新しいシェルで常にデフォルトを使う場合
 fi
 
 # JAVA_HOME 設定

--- a/config/shell/.zprofile
+++ b/config/shell/.zprofile
@@ -39,6 +39,13 @@ if command -v rbenv 1>/dev/null 2>&1; then
   eval "$(rbenv init -)"
 fi
 
+# nvm 初期化
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
+  . "$(brew --prefix nvm)/nvm.sh" --no-use # スクリプト読み込み時に use しない
+  # nvm use default # 新しいシェルで常にデフォルトを使う場合
+fi
+
 # JAVA_HOME 設定
 if ! command -v /usr/libexec/java_home >/dev/null 2>&1; then
     echo "Error: /usr/libexec/java_home is not installed." >&2

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -27,6 +27,7 @@ install_dependencies() {
 
 # nvmを初期化
 source_nvm() {
+    export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
     if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
         # shellcheck source=/dev/null
         . "$(brew --prefix nvm)/nvm.sh"

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -36,8 +36,8 @@ source_nvm() {
     fi
 }
 
-# 特定のNode.jsバージョンをインストールしてデフォルトに設定
-install_and_set_default_node() {
+# 特定のNode.jsバージョンをインストール
+install_node() {
     source_nvm
     local changed=false
 
@@ -55,20 +55,6 @@ install_and_set_default_node() {
         echo "[INSTALLED] Node.js $NODE_VERSION はすでにインストールされています"
     fi
 
-    # デフォルトバージョンとして設定
-    if [[ "$(nvm alias default)" != *"$NODE_VERSION"* ]]; then
-        echo "[CONFIGURING] Node.js $NODE_VERSION をデフォルトバージョンに設定します"
-        if nvm alias default "$NODE_VERSION"; then
-            echo "[SUCCESS] デフォルトバージョンを $NODE_VERSION に設定しました"
-            changed=true
-        else
-            echo "[ERROR] デフォルトバージョンの設定に失敗しました"
-            exit 1
-        fi
-    else
-        echo "[CONFIGURED] Node.js $NODE_VERSION はすでにデフォルトバージョンです"
-    fi
-
     if [ "$changed" = true ]; then
         echo "IDEMPOTENCY_VIOLATION" >&2
     fi
@@ -79,12 +65,12 @@ main() {
     install_dependencies
     echo "[Start] Node.js のセットアップを開始します..."
 
-    # nvm経由でNode.jsをインストール・設定
-    install_and_set_default_node
+    # nvm経由でNode.jsをインストール
+    install_node
 
     # nvm環境を読み込む
     source_nvm
-    nvm use default > /dev/null # ターミナルの出力なし
+    nvm use "$NODE_VERSION" > /dev/null # ターミナルの出力なし
 
     # npm のインストール確認
     if ! command -v npm &> /dev/null; then

--- a/scripts/node.sh
+++ b/scripts/node.sh
@@ -44,7 +44,6 @@ install_node() {
 
     # 特定のバージョンがインストールされているか確認
     if ! nvm ls "$NODE_VERSION" | grep -q "$NODE_VERSION"; then
-        echo "[INSTALLING] Node.js $NODE_VERSION をインストールします..."
         if nvm install "$NODE_VERSION"; then
             echo "[SUCCESS] Node.js $NODE_VERSION のインストールが完了しました"
             changed=true
@@ -125,7 +124,6 @@ install_global_packages() {
         # バージョンが 'latest' の場合は単純な存在チェックにフォールバック
         if [ "$required_version" == "latest" ]; then
             if [ -z "$installed_version" ]; then
-                echo "[INSTALLING] $pkg_full"
                 if npm install -g "$pkg_full"; then
                     echo "[SUCCESS] $pkg_name のインストールが完了しました"
                     changed=true
@@ -138,7 +136,6 @@ install_global_packages() {
             fi
         # バージョンが指定されていて、インストールされているバージョンと異なる場合
         elif [ "$installed_version" != "$required_version" ]; then
-            echo "[UPDATING] $pkg_full (found: $installed_version)"
             if npm install -g "$pkg_full"; then
                 echo "[SUCCESS] $pkg_name の更新が完了しました"
                 changed=true


### PR DESCRIPTION
`scripts/node.sh` を修正し、nvm（Node Version Manager）を使用して特定のLTS（Long Term Support）バージョン（22.17.1）をインストールし、グローバルに設定するように変更しました。

主な変更点:
- `scripts/node.sh` が `brew install nvm jq` を実行して依存関係をインストールします。
- 特定のNode.jsバージョン（22.17.1）をスクリプト内に固定で指定し、そのバージョンのみをインストールします。
- `nvm alias default` を使用して、固定したバージョンをデフォルトに設定します。これにより、意図しないバージョンの更新を防ぎます。
- `config/brew/Brewfile` を更新し、`nvm` と `jq` が `node.sh` によってインストールされることを示すようにコメントアウトしました。
- これにより、Node.jsのバージョン管理が安定的になり、プロジェクトの既存の流儀にも準拠します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Node.jsのバージョン管理がnvm（Node Version Manager）を利用する方式に変更されました。
  * 指定されたNode.jsバージョンが自動的にインストール・設定されるようになりました。
  * シェル起動時にnvmが初期化されるようになりました。

* **改善**
  * 依存関係のインストールがnvmとjqに更新されました。
  * エラーハンドリングが強化され、依存関係のインストールや環境確認がより堅牢になりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->