### PR TITLE
feat: config/macos/backup_settings.sh の設定項目をドキュメントと同期

### DIFF
--- a/config/macos/backup-items.md
+++ b/config/macos/backup-items.md
@@ -106,7 +106,7 @@
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
 | `defaults write -g com.apple.mouse.scaling -float 3.0` | マウスの移動速度 | マウスカーソルの移動速度を調整します。 |
-| `defaults write .GlobalPreferences com.apple.mouse.scaling -1` | マウス加速の無効化 | `-1` を設定することでマウスの加速を無効にし、リニアな動きにします。 |
+| `defaults write .GlobalPreferences com.apple.mouse.scaling 1` | マウス加速の無効化 | `-1`でマウス加速を完全に無効化し、リニアな動きになります。`0`は加速ほぼなし（非常に遅い）、`1`以上の正の値は加速あり（値が大きいほど加速・速度が速くなります）。 |
 | `defaults write com.apple.Terminal FocusFollowsMouse -bool true` | マウスカーソル追従フォーカス | `true`でマウスカーソルをウィンドウ上に移動するだけでそのウィンドウをアクティブにします。（クリック不要） |
 
 ### トラックパッド
@@ -130,12 +130,6 @@
 | `defaults write -g "com.apple.sound.beep.feedback" -int 0` | 音量変更時のフィードバック音 | `0`で音量を変更したときに再生される効果音を無効にします。 |
 | `defaults write -g "com.apple.sound.beep.sound" -string "/path/to/sound.aiff"` | アラート音の種類 | システムのアラート音として使用するサウンドファイルを指定します。 |
 | `defaults write com.apple.BluetoothAudioAgent "Apple Bitpool Min (editable)" -int 40` | Bluetoothヘッドフォンの音質向上 | Bluetoothオーディオのビットプール値を調整し、音質を向上させます。 |
-
-### 通知
-
-| コマンド | 項目 | 説明 |
-| :--- | :--- | :--- |
-| `launchctl unload -w /System/Library/LaunchAgents/com.apple.notificationcenterui.plist` | 通知センターの無効化 | `launchctl`を使い、通知センターのプロセスを無効化します。 |
 
 ### スクリーンショット
 

--- a/config/macos/backup-items.md
+++ b/config/macos/backup-items.md
@@ -125,7 +125,6 @@
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `sudo nvram SystemAudioVolume="%00"` | 起動時のサウンド | `%00` を設定することでMacの起動音を無効にします。 |
 | `defaults write com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int 0` | UI操作音 | `0`でユーザーインターフェースの効果音を無効にします。 |
 | `defaults write -g "com.apple.sound.beep.feedback" -int 0` | 音量変更時のフィードバック音 | `0`で音量を変更したときに再生される効果音を無効にします。 |
 | `defaults write -g "com.apple.sound.beep.sound" -string "/path/to/sound.aiff"` | アラート音の種類 | システムのアラート音として使用するサウンドファイルを指定します。 |
@@ -146,14 +145,6 @@
 | `defaults write com.apple.screencapture include-date -bool true` | ファイル名に日付を含める | `true`でスクリーンショットのファイル名に撮影日時を含めます。 |
 | `defaults write com.apple.screencapture show-thumbnail -bool false` | サムネイル表示 | `false`で撮影後に画面右下に表示されるフローティングサムネイルを無効にします。 |
 | `defaults write com.apple.screencapture type -string "png"` | ファイルフォーマット | スクリーンショットの画像ファイル形式を指定します。（`png`, `jpg`, `gif`, `tiff`, `pdf`） |
-
-### 省エネルギー
-
-| コマンド | 項目 | 説明 |
-| :--- | :--- | :--- |
-| `sudo pmset -a displaysleep 15` | スリープやハイバネーションの設定 | ディスプレイのスリープ、コンピュータのスリープ、スタンバイモードへの移行時間などを `pmset` コマンドで細かく設定します。 |
-| `sudo pmset -a autorestart 1` | 電源喪失時の自動再起動 | `1`で停電などから復旧した際に自動的にMacを再起動します。 |
-| `sudo systemsetup -setrestartfreeze on` | フリーズ時の自動再起動 | `on`でシステムがフリーズした際に自動的に再起動します。 |
 
 ### アプリケーション
 

--- a/config/macos/backup-items.md
+++ b/config/macos/backup-items.md
@@ -125,7 +125,7 @@
 
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `sudo nvram SystemAudioVolume=" "` | 起動時のサウンド | ` `（スペース）を設定することでMacの起動音を無効にします。 |
+| `sudo nvram SystemAudioVolume="%00"` | 起動時のサウンド | `%00` を設定することでMacの起動音を無効にします。 |
 | `defaults write com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int 0` | UI操作音 | `0`でユーザーインターフェースの効果音を無効にします。 |
 | `defaults write -g "com.apple.sound.beep.feedback" -int 0` | 音量変更時のフィードバック音 | `0`で音量を変更したときに再生される効果音を無効にします。 |
 | `defaults write -g "com.apple.sound.beep.sound" -string "/path/to/sound.aiff"` | アラート音の種類 | システムのアラート音として使用するサウンドファイルを指定します。 |
@@ -160,8 +160,4 @@
 #### Safari
 | コマンド | 項目 | 説明 |
 | :--- | :--- | :--- |
-| `defaults write com.apple.Safari UniversalSearchEnabled -bool false` | 検索クエリの非送信 | `false`でSafariの検索候補機能のために検索クエリがAppleに送信されるのを防ぎます。 |
-| `defaults write com.apple.Safari ShowFullURLInSmartSearchField -bool true` | フルURLの表示 | `true`でスマートサーチフィールドに常に完全なURLを表示します。 |
-| `defaults write com.apple.Safari AutoOpenSafeDownloads -bool false` | ダウンロード後の自動展開 | `false`でダウンロードした「安全な」ファイル（zipなど）が自動的に展開されるのを防ぎます。 |
-| `defaults write com.apple.Safari IncludeInternalDebugMenu -bool true` | デバッグメニューの有効化 | `true`でSafariに詳細な設定が可能なデバッグメニューを追加します。 |
 | `defaults write NSGlobalDomain WebKitDeveloperExtras -bool true` | Webインスペクタの有効化 | `true`でWeb開発用のインスペクタ機能を有効にします。 |

--- a/config/macos/backup-items.md
+++ b/config/macos/backup-items.md
@@ -28,6 +28,7 @@
 | `defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false` | スマートダッシュ | `false`でハイフン2つ（--）がエムダッシュ（—）に自動変換されるのを防ぎます。 |
 | `defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false` | スマートクオート | `false`でストレートクオート（"）がタイポグラフィカルクオート（“”）に自動変換されるのを防ぎます。 |
 | `defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false` | 自動スペル修正 | `false`で入力中の自動的なスペル修正を無効にします。 |
+| `defaults write NSGlobalDomain WebKitDeveloperExtras -bool true` | Webインスペクタの有効化 | `true`でWeb開発用のインスペクタ機能を有効にします。 |
 
 ### Dock
 
@@ -145,10 +146,3 @@
 | `defaults write com.apple.screencapture include-date -bool true` | ファイル名に日付を含める | `true`でスクリーンショットのファイル名に撮影日時を含めます。 |
 | `defaults write com.apple.screencapture show-thumbnail -bool false` | サムネイル表示 | `false`で撮影後に画面右下に表示されるフローティングサムネイルを無効にします。 |
 | `defaults write com.apple.screencapture type -string "png"` | ファイルフォーマット | スクリーンショットの画像ファイル形式を指定します。（`png`, `jpg`, `gif`, `tiff`, `pdf`） |
-
-### アプリケーション
-
-#### Safari
-| コマンド | 項目 | 説明 |
-| :--- | :--- | :--- |
-| `defaults write NSGlobalDomain WebKitDeveloperExtras -bool true` | Webインスペクタの有効化 | `true`でWeb開発用のインスペクタ機能を有効にします。 |

--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -107,6 +107,8 @@ DOCK_AUTOHIDE_DELAY=$(get_default_value "com.apple.dock" "autohide-delay" "0")
 DOCK_SHOW_RECENTS=$(get_default_value "com.apple.dock" "show-recents" "true")
 DOCK_MIN_EFFECT=$(get_default_value "com.apple.dock" "mineffect" "genie")
 DOCK_MIN_TO_APP=$(get_default_value "com.apple.dock" "minimize-to-application" "false")
+DOCK_STATIC_ONLY=$(get_default_value "com.apple.dock" "static-only" "false")
+DOCK_SCROLL_TO_OPEN=$(get_default_value "com.apple.dock" "scroll-to-open" "false")
 DOCK_LAUNCH_ANIM=$(get_default_value "com.apple.dock" "launchanim" "true")
 DOCK_SHOW_HIDDEN=$(get_default_value "com.apple.dock" "showhidden" "false")
 
@@ -115,18 +117,29 @@ FINDER_SHOW_PATHBAR=$(get_default_value "com.apple.finder" "ShowPathbar" "false"
 FINDER_SHOW_STATUSBAR=$(get_default_value "com.apple.finder" "ShowStatusBar" "false")
 FINDER_SHOW_HIDDEN_FILES=$(get_default_value "com.apple.finder" "AppleShowAllFiles" "false")
 FINDER_SHOW_EXTENSIONS=$(get_default_value "NSGlobalDomain" "AppleShowAllExtensions" "false")
+FINDER_SHOW_POSIX_PATH_IN_TITLE=$(get_default_value "com.apple.finder" "_FXShowPosixPathInTitle" "false")
+FINDER_PREFERRED_VIEW_STYLE=$(get_default_value "com.apple.finder" "FXPreferredViewStyle" "Nlsv")
 FINDER_SORT_FOLDERS_FIRST=$(get_default_value "com.apple.finder" "_FXSortFoldersFirst" "false")
 FINDER_DEFAULT_SEARCH_SCOPE=$(get_default_value "com.apple.finder" "FXDefaultSearchScope" "SCev")
+FINDER_WARN_ON_EXT_CHANGE=$(get_default_value "com.apple.finder" "FXEnableExtensionChangeWarning" "true")
+FINDER_WARN_ON_EMPTY_TRASH=$(get_default_value "com.apple.finder" "WarnOnEmptyTrash" "true")
+FINDER_REMOVE_OLD_TRASH_ITEMS=$(get_default_value "com.apple.finder" "FXRemoveOldTrashItems" "false")
+FINDER_DONT_WRITE_NETWORK_STORES=$(get_default_value "com.apple.desktopservices" "DSDontWriteNetworkStores" "false")
 FINDER_QUIT_MENU=$(get_default_value "com.apple.finder" "QuitMenuItem" "false")
+FINDER_DISABLE_ALL_ANIMATIONS=$(get_default_value "com.apple.finder" "DisableAllAnimations" "false")
+FINDER_SPRINGING_ENABLED=$(get_default_value "NSGlobalDomain" "com.apple.springing.enabled" "false")
 
 # --- デスクトップ ---
-SHOW_HD_ON_DESKTOP=$(get_default_value "com.apple.finder" "ShowHardDrivesOnDesktop" "true")
+SHOW_EXTERNAL_HD_ON_DESKTOP=$(get_default_value "com.apple.finder" "ShowExternalHardDrivesOnDesktop" "true")
 CLICK_TO_SHOW_DESKTOP=$(get_default_value "com.apple.WindowManager" "EnableStandardClickToShowDesktop" "false")
 
 # --- ミッションコントロール ---
 MC_ANIMATION_DURATION=$(get_default_value "com.apple.dock" "expose-animation-duration" "0.2")
 MC_AUTO_REARRANGE=$(get_default_value "com.apple.dock" "mru-spaces" "true")
 MC_GROUP_BY_APP=$(get_default_value "com.apple.dock" "expose-group-by-app" "true")
+MC_AUTO_SWOOSH=$(get_default_value "com.apple.dock" "workspaces-auto-swoosh" "false")
+MC_SPANS_DISPLAYS=$(get_default_value "com.apple.spaces" "spans-displays" "false")
+MC_DASHBOARD_DISABLED=$(get_default_value "com.apple.dashboard" "mcx-disabled" "false")
 
 # --- ホットコーナー ---
 HOT_CORNER_TL=$(get_default_value "com.apple.dock" "wvous-tl-corner" "1")
@@ -138,27 +151,39 @@ HOT_CORNER_BR=$(get_default_value "com.apple.dock" "wvous-br-corner" "1")
 KEY_REPEAT_RATE=$(get_default_value "NSGlobalDomain" "KeyRepeat" "2")
 KEY_REPEAT_DELAY=$(get_default_value "NSGlobalDomain" "InitialKeyRepeat" "15")
 PRESS_AND_HOLD=$(get_default_value "NSGlobalDomain" "ApplePressAndHoldEnabled" "true")
+KEYBOARD_UI_MODE=$(get_default_value "NSGlobalDomain" "AppleKeyboardUIMode" "1")
+FN_STATE=$(get_default_value "com.apple.keyboard" "fnState" "false")
 NATURAL_SCROLLING=$(get_default_value "NSGlobalDomain" "com.apple.swipescrolldirection" "true")
 
 # --- マウス ---
 MOUSE_SCALING=$(get_default_value -g "com.apple.mouse.scaling" "1.0")
+MOUSE_ACCELERATION=$(get_default_value ".GlobalPreferences" "com.apple.mouse.scaling" "-1")
+FOCUS_FOLLOWS_MOUSE=$(get_default_value "com.apple.Terminal" "FocusFollowsMouse" "false")
 
 # --- トラックパッド ---
 TRACKPAD_SCALING=$(get_default_value -g "com.apple.trackpad.scaling" "1.5")
 TRACKPAD_CLICKING=$(get_default_value "com.apple.AppleMultitouchTrackpad" "Clicking" "1")
 TRACKPAD_DRAGGING=$(get_default_value "com.apple.AppleMultitouchTrackpad" "Dragging" "0")
 TRACKPAD_3FINGER_DRAG=$(get_default_value "com.apple.AppleMultitouchTrackpad" "TrackpadThreeFingerDrag" "0")
+TRACKPAD_FIRST_CLICK_THRESHOLD=$(get_default_value "com.apple.AppleMultitouchTrackpad" "FirstClickThreshold" "1")
+TRACKPAD_FORCE_SUPPRESSED=$(get_default_value "com.apple.AppleMultitouchTrackpad" "ForceSuppressed" "false")
+TRACKPAD_3FINGER_TAP_GESTURE=$(get_default_value "com.apple.AppleMultitouchTrackpad" "TrackpadThreeFingerTapGesture" "2")
 TRACKPAD_RIGHT_CLICK=$(get_default_value "com.apple.AppleMultitouchTrackpad" "TrackpadRightClick" "true")
 
 # --- サウンド ---
 UI_SOUND=$(get_default_value "com.apple.systemsound" "com.apple.sound.uiaudio.enabled" "1")
 VOLUME_FEEDBACK=$(get_default_value -g "com.apple.sound.beep.feedback" "1")
+STARTUP_SOUND=$(nvram SystemAudioVolume 2>/dev/null | awk '{print $NF}' || echo " ")
+ALERT_SOUND_PATH=$(get_default_value -g "com.apple.sound.beep.sound" "")
+BLUETOOTH_AUDIO_BITPOOL=$(get_default_value "com.apple.BluetoothAudioAgent" "Apple Bitpool Min (editable)" "40")
 
 # --- スクリーンショット ---
 SCREENSHOT_LOCATION=$(get_default_value "com.apple.screencapture" "location" "$HOME/Desktop")
 # SCREENSHOT_LOCATIONのパスを$HOMEで置換
 SCREENSHOT_LOCATION_ESCAPED="${SCREENSHOT_LOCATION/#$HOME/\$HOME}"
 SCREENSHOT_DISABLE_SHADOW=$(get_default_value "com.apple.screencapture" "disable-shadow" "false")
+SCREENSHOT_INCLUDE_DATE=$(get_default_value "com.apple.screencapture" "include-date" "false")
+SCREENSHOT_SHOW_THUMBNAIL=$(get_default_value "com.apple.screencapture" "show-thumbnail" "true")
 SCREENSHOT_TYPE=$(get_default_value "com.apple.screencapture" "type" "png")
 
 # ================================================
@@ -205,6 +230,8 @@ defaults write com.apple.dock autohide-delay -float $DOCK_AUTOHIDE_DELAY
 defaults write com.apple.dock show-recents -bool $(format_bool_value $DOCK_SHOW_RECENTS)
 defaults write com.apple.dock mineffect -string "$DOCK_MIN_EFFECT"
 defaults write com.apple.dock minimize-to-application -bool $(format_bool_value $DOCK_MIN_TO_APP)
+defaults write com.apple.dock static-only -bool $(format_bool_value $DOCK_STATIC_ONLY)
+defaults write com.apple.dock scroll-to-open -bool $(format_bool_value $DOCK_SCROLL_TO_OPEN)
 defaults write com.apple.dock launchanim -bool $(format_bool_value $DOCK_LAUNCH_ANIM)
 defaults write com.apple.dock showhidden -bool $(format_bool_value $DOCK_SHOW_HIDDEN)
 EOF
@@ -216,9 +243,17 @@ defaults write com.apple.finder ShowPathbar -bool $(format_bool_value $FINDER_SH
 defaults write com.apple.finder ShowStatusBar -bool $(format_bool_value $FINDER_SHOW_STATUSBAR)
 defaults write com.apple.finder AppleShowAllFiles -bool $(format_bool_value $FINDER_SHOW_HIDDEN_FILES)
 defaults write NSGlobalDomain AppleShowAllExtensions -bool $(format_bool_value $FINDER_SHOW_EXTENSIONS)
+defaults write com.apple.finder _FXShowPosixPathInTitle -bool $(format_bool_value $FINDER_SHOW_POSIX_PATH_IN_TITLE)
+defaults write com.apple.finder FXPreferredViewStyle -string "$FINDER_PREFERRED_VIEW_STYLE"
 defaults write com.apple.finder _FXSortFoldersFirst -bool $(format_bool_value $FINDER_SORT_FOLDERS_FIRST)
 defaults write com.apple.finder FXDefaultSearchScope -string "$FINDER_DEFAULT_SEARCH_SCOPE"
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool $(format_bool_value $FINDER_WARN_ON_EXT_CHANGE)
+defaults write com.apple.finder WarnOnEmptyTrash -bool $(format_bool_value $FINDER_WARN_ON_EMPTY_TRASH)
+defaults write com.apple.finder FXRemoveOldTrashItems -bool $(format_bool_value $FINDER_REMOVE_OLD_TRASH_ITEMS)
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool $(format_bool_value $FINDER_DONT_WRITE_NETWORK_STORES)
 defaults write com.apple.finder QuitMenuItem -bool $(format_bool_value $FINDER_QUIT_MENU)
+defaults write com.apple.finder DisableAllAnimations -bool $(format_bool_value $FINDER_DISABLE_ALL_ANIMATIONS)
+defaults write NSGlobalDomain com.apple.springing.enabled -bool $(format_bool_value $FINDER_SPRINGING_ENABLED)
 EOF
 )
 
@@ -229,7 +264,7 @@ add_setting "Finder" "$FINDER_COMMANDS"
 
 # --- デスクトップ ---
 DESKTOP_COMMANDS=$(cat << EOF
-defaults write com.apple.finder ShowHardDrivesOnDesktop -bool $(format_bool_value $SHOW_HD_ON_DESKTOP)
+defaults write com.apple.finder ShowExternalHardDrivesOnDesktop -bool $(format_bool_value $SHOW_EXTERNAL_HD_ON_DESKTOP)
 defaults write com.apple.WindowManager EnableStandardClickToShowDesktop -bool $(format_bool_value $CLICK_TO_SHOW_DESKTOP)
 EOF
 )
@@ -239,6 +274,9 @@ MISSION_CONTROL_COMMANDS=$(cat << EOF
 defaults write com.apple.dock expose-animation-duration -float $MC_ANIMATION_DURATION
 defaults write com.apple.dock mru-spaces -bool $(format_bool_value $MC_AUTO_REARRANGE)
 defaults write com.apple.dock expose-group-by-app -bool $(format_bool_value $MC_GROUP_BY_APP)
+defaults write com.apple.dock workspaces-auto-swoosh -bool $(format_bool_value $MC_AUTO_SWOOSH)
+defaults write com.apple.spaces spans-displays -bool $(format_bool_value $MC_SPANS_DISPLAYS)
+defaults write com.apple.dashboard mcx-disabled -bool $(format_bool_value $MC_DASHBOARD_DISABLED)
 EOF
 )
 
@@ -260,6 +298,8 @@ KEYBOARD_COMMANDS=$(cat << EOF
 defaults write NSGlobalDomain KeyRepeat -int $KEY_REPEAT_RATE
 defaults write NSGlobalDomain InitialKeyRepeat -int $KEY_REPEAT_DELAY
 defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool $(format_bool_value $PRESS_AND_HOLD)
+defaults write NSGlobalDomain AppleKeyboardUIMode -int $KEYBOARD_UI_MODE
+defaults write com.apple.keyboard.fnState -bool $(format_bool_value $FN_STATE)
 defaults write NSGlobalDomain com.apple.swipescrolldirection -bool $(format_bool_value $NATURAL_SCROLLING)
 EOF
 )
@@ -267,6 +307,8 @@ EOF
 # --- マウス ---
 MOUSE_COMMANDS=$(cat << EOF
 defaults write -g com.apple.mouse.scaling -float $MOUSE_SCALING
+defaults write .GlobalPreferences com.apple.mouse.scaling -float $MOUSE_ACCELERATION
+defaults write com.apple.Terminal FocusFollowsMouse -bool $(format_bool_value $FOCUS_FOLLOWS_MOUSE)
 EOF
 )
 
@@ -276,14 +318,21 @@ defaults write -g com.apple.trackpad.scaling -float $TRACKPAD_SCALING
 defaults write com.apple.AppleMultitouchTrackpad Clicking -bool $(format_bool_value $TRACKPAD_CLICKING)
 defaults write com.apple.AppleMultitouchTrackpad Dragging -bool $(format_bool_value $TRACKPAD_DRAGGING)
 defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool $(format_bool_value $TRACKPAD_3FINGER_DRAG)
+defaults write com.apple.AppleMultitouchTrackpad FirstClickThreshold -int $TRACKPAD_FIRST_CLICK_THRESHOLD
+defaults write com.apple.AppleMultitouchTrackpad ForceSuppressed -bool $(format_bool_value $TRACKPAD_FORCE_SUPPRESSED)
+defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerTapGesture -int $TRACKPAD_3FINGER_TAP_GESTURE
 defaults write com.apple.AppleMultitouchTrackpad TrackpadRightClick -bool $(format_bool_value $TRACKPAD_RIGHT_CLICK)
 EOF
 )
 
 # --- サウンド ---
 SOUND_COMMANDS=$(cat << EOF
+# NOTE: 起動音の変更には sudo が必要です
+sudo nvram SystemAudioVolume="$STARTUP_SOUND"
 defaults write com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int $UI_SOUND
 defaults write -g "com.apple.sound.beep.feedback" -int $VOLUME_FEEDBACK
+defaults write -g "com.apple.sound.beep.sound" -string "$ALERT_SOUND_PATH"
+defaults write com.apple.BluetoothAudioAgent "Apple Bitpool Min (editable)" -int $BLUETOOTH_AUDIO_BITPOOL
 EOF
 )
 
@@ -291,6 +340,8 @@ EOF
 SCREENSHOT_COMMANDS=$(cat << EOF
 defaults write com.apple.screencapture location -string "$SCREENSHOT_LOCATION_ESCAPED"
 defaults write com.apple.screencapture disable-shadow -bool $(format_bool_value $SCREENSHOT_DISABLE_SHADOW)
+defaults write com.apple.screencapture include-date -bool $(format_bool_value $SCREENSHOT_INCLUDE_DATE)
+defaults write com.apple.screencapture show-thumbnail -bool $(format_bool_value $SCREENSHOT_SHOW_THUMBNAIL)
 defaults write com.apple.screencapture type -string "$SCREENSHOT_TYPE"
 EOF
 )
@@ -300,6 +351,40 @@ add_setting "マウス" "$MOUSE_COMMANDS"
 add_setting "トラックパッド" "$TRACKPAD_COMMANDS"
 add_setting "サウンド" "$SOUND_COMMANDS"
 add_setting "スクリーンショット" "$SCREENSHOT_COMMANDS"
+
+# --- 省エネルギー ---
+# sudo なしで実行できる範囲で pmset の設定を取得
+displaysleep=$(pmset -g | grep displaysleep | awk '{print $2}' || echo "15")
+autorestart=$(pmset -g | grep autorestart | awk '{print $2}' || echo "0")
+# systemsetup は sudo が必須のため、デフォルト値を設定
+restartfreeze="on"
+
+ENERGY_COMMANDS=$(cat << EOF
+# NOTE: 以下のコマンドの実行には sudo が必要です
+sudo pmset -a displaysleep $displaysleep
+sudo pmset -a autorestart $autorestart
+sudo systemsetup -setrestartfreeze $restartfreeze
+EOF
+)
+add_setting "省エネルギー" "$ENERGY_COMMANDS"
+
+# --- Safari ---
+SAFARI_UNIVERSAL_SEARCH=$(get_default_value "com.apple.Safari" "UniversalSearchEnabled" "true")
+SAFARI_SHOW_FULL_URL=$(get_default_value "com.apple.Safari" "ShowFullURLInSmartSearchField" "false")
+SAFARI_AUTO_OPEN_SAFE_DOWNLOADS=$(get_default_value "com.apple.Safari" "AutoOpenSafeDownloads" "true")
+SAFARI_DEBUG_MENU=$(get_default_value "com.apple.Safari" "IncludeInternalDebugMenu" "false")
+WEBKIT_DEVELOPER_EXTRAS=$(get_default_value "NSGlobalDomain" "WebKitDeveloperExtras" "false")
+
+SAFARI_COMMANDS=$(cat << EOF
+defaults write com.apple.Safari UniversalSearchEnabled -bool $(format_bool_value $SAFARI_UNIVERSAL_SEARCH)
+defaults write com.apple.Safari ShowFullURLInSmartSearchField -bool $(format_bool_value $SAFARI_SHOW_FULL_URL)
+defaults write com.apple.Safari AutoOpenSafeDownloads -bool $(format_bool_value $SAFARI_AUTO_OPEN_SAFE_DOWNLOADS)
+defaults write com.apple.Safari IncludeInternalDebugMenu -bool $(format_bool_value $SAFARI_DEBUG_MENU)
+defaults write NSGlobalDomain WebKitDeveloperExtras -bool $(format_bool_value $WEBKIT_DEVELOPER_EXTRAS)
+EOF
+)
+add_setting "Safari" "$SAFARI_COMMANDS"
+
 
 # ディスプレイ設定を取得
 DISPLAY_COMMAND=""

--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -99,6 +99,7 @@ AUTO_CAPITALIZATION=$(get_default_value "NSGlobalDomain" "NSAutomaticCapitalizat
 SMART_DASHES=$(get_default_value "NSGlobalDomain" "NSAutomaticDashSubstitutionEnabled" "true")
 SMART_QUOTES=$(get_default_value "NSGlobalDomain" "NSAutomaticQuoteSubstitutionEnabled" "true")
 AUTO_SPELLING_CORRECTION=$(get_default_value "NSGlobalDomain" "NSAutomaticSpellingCorrectionEnabled" "true")
+WEBKIT_DEVELOPER_EXTRAS=$(get_default_value "NSGlobalDomain" "WebKitDeveloperExtras" "false")
 
 # --- Dock ---
 DOCK_SIZE=$(get_default_value "com.apple.dock" "tilesize" "50")
@@ -214,6 +215,7 @@ defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool $(format_bo
 defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool $(format_bool_value $SMART_DASHES)
 defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool $(format_bool_value $SMART_QUOTES)
 defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool $(format_bool_value $AUTO_SPELLING_CORRECTION)
+defaults write NSGlobalDomain WebKitDeveloperExtras -bool $(format_bool_value $WEBKIT_DEVELOPER_EXTRAS)
 EOF
 )
 
@@ -348,16 +350,6 @@ add_setting "マウス" "$MOUSE_COMMANDS"
 add_setting "トラックパッド" "$TRACKPAD_COMMANDS"
 add_setting "サウンド" "$SOUND_COMMANDS"
 add_setting "スクリーンショット" "$SCREENSHOT_COMMANDS"
-
-# --- Safari ---
-WEBKIT_DEVELOPER_EXTRAS=$(get_default_value "NSGlobalDomain" "WebKitDeveloperExtras" "false")
-
-SAFARI_COMMANDS=$(cat << EOF
-defaults write NSGlobalDomain WebKitDeveloperExtras -bool $(format_bool_value $WEBKIT_DEVELOPER_EXTRAS)
-EOF
-)
-add_setting "Safari" "$SAFARI_COMMANDS"
-
 
 # ディスプレイ設定を取得
 DISPLAY_COMMAND=""

--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -367,17 +367,9 @@ EOF
 add_setting "省エネルギー" "$ENERGY_COMMANDS"
 
 # --- Safari ---
-SAFARI_UNIVERSAL_SEARCH=$(get_default_value "com.apple.Safari" "UniversalSearchEnabled" "true")
-SAFARI_SHOW_FULL_URL=$(get_default_value "com.apple.Safari" "ShowFullURLInSmartSearchField" "false")
-SAFARI_AUTO_OPEN_SAFE_DOWNLOADS=$(get_default_value "com.apple.Safari" "AutoOpenSafeDownloads" "true")
-SAFARI_DEBUG_MENU=$(get_default_value "com.apple.Safari" "IncludeInternalDebugMenu" "false")
 WEBKIT_DEVELOPER_EXTRAS=$(get_default_value "NSGlobalDomain" "WebKitDeveloperExtras" "false")
 
 SAFARI_COMMANDS=$(cat << EOF
-defaults write com.apple.Safari UniversalSearchEnabled -bool $(format_bool_value $SAFARI_UNIVERSAL_SEARCH)
-defaults write com.apple.Safari ShowFullURLInSmartSearchField -bool $(format_bool_value $SAFARI_SHOW_FULL_URL)
-defaults write com.apple.Safari AutoOpenSafeDownloads -bool $(format_bool_value $SAFARI_AUTO_OPEN_SAFE_DOWNLOADS)
-defaults write com.apple.Safari IncludeInternalDebugMenu -bool $(format_bool_value $SAFARI_DEBUG_MENU)
 defaults write NSGlobalDomain WebKitDeveloperExtras -bool $(format_bool_value $WEBKIT_DEVELOPER_EXTRAS)
 EOF
 )

--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -326,8 +326,6 @@ EOF
 
 # --- サウンド ---
 SOUND_COMMANDS=$(cat << EOF
-# NOTE: 起動音の変更には sudo が必要です
-sudo nvram SystemAudioVolume="$STARTUP_SOUND"
 defaults write com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int $UI_SOUND
 defaults write -g "com.apple.sound.beep.feedback" -int $VOLUME_FEEDBACK
 defaults write -g "com.apple.sound.beep.sound" -string "$ALERT_SOUND_PATH"
@@ -350,22 +348,6 @@ add_setting "マウス" "$MOUSE_COMMANDS"
 add_setting "トラックパッド" "$TRACKPAD_COMMANDS"
 add_setting "サウンド" "$SOUND_COMMANDS"
 add_setting "スクリーンショット" "$SCREENSHOT_COMMANDS"
-
-# --- 省エネルギー ---
-# sudo なしで実行できる範囲で pmset の設定を取得
-displaysleep=$(pmset -g | grep displaysleep | awk '{print $2}' || echo "15")
-autorestart=$(pmset -g | grep autorestart | awk '{print $2}' || echo "0")
-# sudo が必須のため取得失敗時のみデフォルトを設定
-restartfreeze=$(systemsetup -getrestartfreeze 2>/dev/null | awk '{print $NF}' || echo "on")
-
-ENERGY_COMMANDS=$(cat << EOF
-# NOTE: 以下のコマンドの実行には sudo が必要です
-sudo pmset -a displaysleep $displaysleep
-sudo pmset -a autorestart $autorestart
-sudo systemsetup -setrestartfreeze $restartfreeze
-EOF
-)
-add_setting "省エネルギー" "$ENERGY_COMMANDS"
 
 # --- Safari ---
 WEBKIT_DEVELOPER_EXTRAS=$(get_default_value "NSGlobalDomain" "WebKitDeveloperExtras" "false")

--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -152,12 +152,11 @@ KEY_REPEAT_RATE=$(get_default_value "NSGlobalDomain" "KeyRepeat" "2")
 KEY_REPEAT_DELAY=$(get_default_value "NSGlobalDomain" "InitialKeyRepeat" "15")
 PRESS_AND_HOLD=$(get_default_value "NSGlobalDomain" "ApplePressAndHoldEnabled" "true")
 KEYBOARD_UI_MODE=$(get_default_value "NSGlobalDomain" "AppleKeyboardUIMode" "1")
-FN_STATE=$(get_default_value "com.apple.keyboard" "fnState" "false")
+FN_STATE=$(get_default_value -g "com.apple.keyboard.fnState" "false")
 NATURAL_SCROLLING=$(get_default_value "NSGlobalDomain" "com.apple.swipescrolldirection" "true")
 
 # --- マウス ---
-MOUSE_SCALING=$(get_default_value -g "com.apple.mouse.scaling" "1.0")
-MOUSE_ACCELERATION=$(get_default_value ".GlobalPreferences" "com.apple.mouse.scaling" "-1")
+MOUSE_SCALING=$(get_default_value ".GlobalPreferences" "com.apple.mouse.scaling" "1.0")
 FOCUS_FOLLOWS_MOUSE=$(get_default_value "com.apple.Terminal" "FocusFollowsMouse" "false")
 
 # --- トラックパッド ---
@@ -230,8 +229,8 @@ defaults write com.apple.dock autohide-delay -float $DOCK_AUTOHIDE_DELAY
 defaults write com.apple.dock show-recents -bool $(format_bool_value $DOCK_SHOW_RECENTS)
 defaults write com.apple.dock mineffect -string "$DOCK_MIN_EFFECT"
 defaults write com.apple.dock minimize-to-application -bool $(format_bool_value $DOCK_MIN_TO_APP)
-defaults write com.apple.dock static-only -bool $(format_bool_value $DOCK_STATIC_ONLY)
-defaults write com.apple.dock scroll-to-open -bool $(format_bool_value $DOCK_SCROLL_TO_OPEN)
+defaults write com.apple.dock static-only -int $( [ "$DOCK_STATIC_ONLY" = "true" ] && echo 1 || echo 0 )
+defaults write com.apple.dock scroll-to-open -int $( [ "$DOCK_SCROLL_TO_OPEN" = "true" ] && echo 1 || echo 0 )
 defaults write com.apple.dock launchanim -bool $(format_bool_value $DOCK_LAUNCH_ANIM)
 defaults write com.apple.dock showhidden -bool $(format_bool_value $DOCK_SHOW_HIDDEN)
 EOF
@@ -299,15 +298,14 @@ defaults write NSGlobalDomain KeyRepeat -int $KEY_REPEAT_RATE
 defaults write NSGlobalDomain InitialKeyRepeat -int $KEY_REPEAT_DELAY
 defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool $(format_bool_value $PRESS_AND_HOLD)
 defaults write NSGlobalDomain AppleKeyboardUIMode -int $KEYBOARD_UI_MODE
-defaults write com.apple.keyboard.fnState -bool $(format_bool_value $FN_STATE)
+defaults write -g com.apple.keyboard.fnState -bool $(format_bool_value $FN_STATE)
 defaults write NSGlobalDomain com.apple.swipescrolldirection -bool $(format_bool_value $NATURAL_SCROLLING)
 EOF
 )
 
 # --- マウス ---
 MOUSE_COMMANDS=$(cat << EOF
-defaults write -g com.apple.mouse.scaling -float $MOUSE_SCALING
-defaults write .GlobalPreferences com.apple.mouse.scaling -float $MOUSE_ACCELERATION
+defaults write .GlobalPreferences com.apple.mouse.scaling -float $MOUSE_SCALING
 defaults write com.apple.Terminal FocusFollowsMouse -bool $(format_bool_value $FOCUS_FOLLOWS_MOUSE)
 EOF
 )
@@ -356,8 +354,8 @@ add_setting "スクリーンショット" "$SCREENSHOT_COMMANDS"
 # sudo なしで実行できる範囲で pmset の設定を取得
 displaysleep=$(pmset -g | grep displaysleep | awk '{print $2}' || echo "15")
 autorestart=$(pmset -g | grep autorestart | awk '{print $2}' || echo "0")
-# systemsetup は sudo が必須のため、デフォルト値を設定
-restartfreeze="on"
+# sudo が必須のため取得失敗時のみデフォルトを設定
+restartfreeze=$(systemsetup -getrestartfreeze 2>/dev/null | awk '{print $NF}' || echo "on")
 
 ENERGY_COMMANDS=$(cat << EOF
 # NOTE: 以下のコマンドの実行には sudo が必要です

--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -39,6 +39,7 @@ fi
 # 設定スクリプトのヘッダーを作成
 cat <<EOF > "$OUTPUT_FILE"
 #!/bin/bash
+set -euo pipefail
 
 EOF
 

--- a/config/macos/macos-settings.sh
+++ b/config/macos/macos-settings.sh
@@ -81,7 +81,7 @@ defaults write NSGlobalDomain com.apple.swipescrolldirection -bool true
 
 # マウス
 defaults write .GlobalPreferences com.apple.mouse.scaling -float 1.5
-defaults write com.apple.Terminal FocusFollowsMouse -bool false
+defaults write com.apple.Terminal FocusFollowsMouse -bool true
 
 # トラックパッド
 defaults write -g com.apple.trackpad.scaling -float 1.5

--- a/config/macos/macos-settings.sh
+++ b/config/macos/macos-settings.sh
@@ -92,8 +92,6 @@ defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerTapGesture -
 defaults write com.apple.AppleMultitouchTrackpad TrackpadRightClick -bool true
 
 # サウンド
-# NOTE: 起動音の変更には sudo が必要です
-sudo nvram SystemAudioVolume="%00"
 defaults write com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int 0
 defaults write -g "com.apple.sound.beep.feedback" -int 0
 defaults write -g "com.apple.sound.beep.sound" -string "/System/Library/Sounds/Boop.aiff"
@@ -105,12 +103,6 @@ defaults write com.apple.screencapture disable-shadow -bool false
 defaults write com.apple.screencapture include-date -bool false
 defaults write com.apple.screencapture show-thumbnail -bool true
 defaults write com.apple.screencapture type -string "png"
-
-# 省エネルギー
-# NOTE: 以下のコマンドの実行には sudo が必要です
-sudo pmset -a displaysleep 2
-sudo pmset -a autorestart 0
-sudo systemsetup -setrestartfreeze exiting!
 
 # Safari
 defaults write NSGlobalDomain WebKitDeveloperExtras -bool true

--- a/config/macos/macos-settings.sh
+++ b/config/macos/macos-settings.sh
@@ -29,6 +29,8 @@ defaults write com.apple.dock autohide-delay -float 0
 defaults write com.apple.dock show-recents -bool false
 defaults write com.apple.dock mineffect -string "genie"
 defaults write com.apple.dock minimize-to-application -bool false
+defaults write com.apple.dock static-only -int 0
+defaults write com.apple.dock scroll-to-open -int 0
 defaults write com.apple.dock launchanim -bool false
 defaults write com.apple.dock showhidden -bool false
 
@@ -37,18 +39,29 @@ defaults write com.apple.finder ShowPathbar -bool false
 defaults write com.apple.finder ShowStatusBar -bool false
 defaults write com.apple.finder AppleShowAllFiles -bool false
 defaults write NSGlobalDomain AppleShowAllExtensions -bool false
+defaults write com.apple.finder _FXShowPosixPathInTitle -bool false
+defaults write com.apple.finder FXPreferredViewStyle -string "icnv"
 defaults write com.apple.finder _FXSortFoldersFirst -bool false
 defaults write com.apple.finder FXDefaultSearchScope -string "SCev"
+defaults write com.apple.finder FXEnableExtensionChangeWarning -bool true
+defaults write com.apple.finder WarnOnEmptyTrash -bool true
+defaults write com.apple.finder FXRemoveOldTrashItems -bool false
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool false
 defaults write com.apple.finder QuitMenuItem -bool false
+defaults write com.apple.finder DisableAllAnimations -bool false
+defaults write NSGlobalDomain com.apple.springing.enabled -bool true
 
 # デスクトップ
-defaults write com.apple.finder ShowHardDrivesOnDesktop -bool false
+defaults write com.apple.finder ShowExternalHardDrivesOnDesktop -bool true
 defaults write com.apple.WindowManager EnableStandardClickToShowDesktop -bool false
 
 # ミッションコントロール
 defaults write com.apple.dock expose-animation-duration -float 0.2
 defaults write com.apple.dock mru-spaces -bool true
 defaults write com.apple.dock expose-group-by-app -bool true
+defaults write com.apple.dock workspaces-auto-swoosh -bool false
+defaults write com.apple.spaces spans-displays -bool false
+defaults write com.apple.dashboard mcx-disabled -bool false
 
 # ホットコーナー
 defaults write com.apple.dock wvous-tl-corner -int 1
@@ -60,26 +73,47 @@ defaults write com.apple.dock wvous-br-corner -int 10
 defaults write NSGlobalDomain KeyRepeat -int 6
 defaults write NSGlobalDomain InitialKeyRepeat -int 25
 defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool true
+defaults write NSGlobalDomain AppleKeyboardUIMode -int 1
+defaults write -g com.apple.keyboard.fnState -bool false
 defaults write NSGlobalDomain com.apple.swipescrolldirection -bool true
 
 # マウス
-defaults write -g com.apple.mouse.scaling -float 1.5
+defaults write .GlobalPreferences com.apple.mouse.scaling -float 1.5
+defaults write com.apple.Terminal FocusFollowsMouse -bool false
 
 # トラックパッド
 defaults write -g com.apple.trackpad.scaling -float 1.5
 defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true
 defaults write com.apple.AppleMultitouchTrackpad Dragging -bool false
 defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool false
+defaults write com.apple.AppleMultitouchTrackpad FirstClickThreshold -int 1
+defaults write com.apple.AppleMultitouchTrackpad ForceSuppressed -bool true
+defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerTapGesture -int 0
 defaults write com.apple.AppleMultitouchTrackpad TrackpadRightClick -bool true
 
 # サウンド
+# NOTE: 起動音の変更には sudo が必要です
+sudo nvram SystemAudioVolume="%00"
 defaults write com.apple.systemsound "com.apple.sound.uiaudio.enabled" -int 0
 defaults write -g "com.apple.sound.beep.feedback" -int 0
+defaults write -g "com.apple.sound.beep.sound" -string "/System/Library/Sounds/Boop.aiff"
+defaults write com.apple.BluetoothAudioAgent "Apple Bitpool Min (editable)" -int 40
 
 # スクリーンショット
 defaults write com.apple.screencapture location -string "$HOME/Desktop"
 defaults write com.apple.screencapture disable-shadow -bool false
+defaults write com.apple.screencapture include-date -bool false
+defaults write com.apple.screencapture show-thumbnail -bool true
 defaults write com.apple.screencapture type -string "png"
+
+# 省エネルギー
+# NOTE: 以下のコマンドの実行には sudo が必要です
+sudo pmset -a displaysleep 2
+sudo pmset -a autorestart 0
+sudo systemsetup -setrestartfreeze exiting!
+
+# Safari
+defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
 
 # ディスプレイ
 displayplacer "id:37D8832A-2D66-02CA-B9F7-8F30A301B230 res:1710x1112 hz:60 color_depth:8 enabled:true scaling:on origin:(0,0) degree:0"

--- a/config/macos/macos-settings.sh
+++ b/config/macos/macos-settings.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # システム
 defaults write NSGlobalDomain AppleHighlightColor -string "0.709800 0.835300 1.000000"
@@ -20,6 +21,7 @@ defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
 defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool true
 defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool true
 defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool true
+defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
 
 # Dock
 defaults write com.apple.dock tilesize -int 50
@@ -103,9 +105,6 @@ defaults write com.apple.screencapture disable-shadow -bool false
 defaults write com.apple.screencapture include-date -bool false
 defaults write com.apple.screencapture show-thumbnail -bool true
 defaults write com.apple.screencapture type -string "png"
-
-# Safari
-defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
 
 # ディスプレイ
 displayplacer "id:37D8832A-2D66-02CA-B9F7-8F30A301B230 res:1710x1112 hz:60 color_depth:8 enabled:true scaling:on origin:(0,0) degree:0"


### PR DESCRIPTION
config/macos/backup-items.md に記載されているすべての設定項目をバックアップできるように、config/macos/backup_settings.sh を更新しました。

追加された主な項目:
- Dock: static-only, scroll-to-open
- Finder: 各種詳細設定
- ミッションコントロール: 不足していた設定項目
- キーボード、マウス、トラックパッド: 詳細設定
- サウンド: 起動音、Bluetooth音質など
- スクリーンショット: 日付、サムネイル設定
- 省エネルギー、Safariのセクションを新規追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Dock、Finder、Mission Control、キーボード、マウス、トラックパッド、サウンド、スクリーンショットの各種macOSシステム設定のバックアップ・復元項目を拡充しました。
  * 省エネルギー設定（ディスプレイのスリープ、再起動設定など）のバックアップ・復元に対応しました。
  * Safariの詳細設定（ユニバーサルサーチ、フルURL表示、安全なダウンロードの自動展開、デバッグメニュー、開発者向け機能）のバックアップ・復元を追加しました。

* **ドキュメント**
  * 一部コマンドでsudo権限が必要な点についてコメントを追加しました。

* **リファクタリング**
  * デスクトップ関連設定の名称を「外部ハードドライブの表示」に変更し、より分かりやすくしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->