### PR TITLE
feat(macos): NSAutomaticPeriodSubstitutionEnabledを追加しdashboardを削除

### DIFF
--- a/config/macos/backup-items.md
+++ b/config/macos/backup-items.md
@@ -25,6 +25,7 @@
 | `defaults write NSGlobalDomain NSWindowResizeTime -float 0.001` | ウィンドウリサイズのアニメーション速度 | アプリケーションのウィンドウサイズを変更する際のアニメーション速度を調整します。（`0.01` など小さい値で高速化） |
 | `defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false` | 自動大文字入力 | `false`で文頭の自動的な大文字化を無効にします。 |
 | `defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false` | スマートダッシュ | `false`でハイフン2つ（--）がエムダッシュ（—）に自動変換されるのを防ぎます。 |
+| `defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false` | 自動ピリオド入力 | `false`でスペース2回でピリオドが自動入力されるのを防ぎます。 |
 | `defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false` | スマートクオート | `false`でストレートクオート（"）がタイポグラフィカルクオート（“”）に自動変換されるのを防ぎます。 |
 | `defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false` | 自動スペル修正 | `false`で入力中の自動的なスペル修正を無効にします。 |
 | `defaults write NSGlobalDomain WebKitDeveloperExtras -bool true` | Webインスペクタの有効化 | `true`でWeb開発用のインスペクタ機能を有効にします。 |
@@ -81,7 +82,6 @@
 | `defaults write com.apple.dock expose-group-by-app -bool false` | アプリごとにウィンドウをグループ化 | `false`でミッションコントロールでウィンドウをアプリケーションごとにグループ化しないようにします。（旧Exposéの挙動） |
 | `defaults write com.apple.dock workspaces-auto-swoosh -bool true` | アプリ切り替え時にスペースを移動 | `true`でアプリケーションのウィンドウが含まれる操作スペースに自動で切り替えます。 |
 | `defaults write com.apple.spaces spans-displays -bool true` | ディスプレイごとに個別の操作スペース | `true`で各ディスプレイに個別のメニューバーと操作スペースを持たせます。 |
-| `defaults write com.apple.dashboard mcx-disabled -bool true` | Dashboardの無効化 | `true`でDashboard機能を無効にします。 |
 
 ### ホットコーナー
 

--- a/config/macos/backup_settings.sh
+++ b/config/macos/backup_settings.sh
@@ -96,6 +96,7 @@ SIDEBAR_ICON_SIZE=$(get_default_value "NSGlobalDomain" "NSTableViewDefaultSizeMo
 WINDOW_RESIZE_TIME=$(get_default_value "NSGlobalDomain" "NSWindowResizeTime" "0.001")
 AUTO_CAPITALIZATION=$(get_default_value "NSGlobalDomain" "NSAutomaticCapitalizationEnabled" "true")
 SMART_DASHES=$(get_default_value "NSGlobalDomain" "NSAutomaticDashSubstitutionEnabled" "true")
+AUTO_PERIOD_SUBSTITUTION=$(get_default_value "NSGlobalDomain" "NSAutomaticPeriodSubstitutionEnabled" "true")
 SMART_QUOTES=$(get_default_value "NSGlobalDomain" "NSAutomaticQuoteSubstitutionEnabled" "true")
 AUTO_SPELLING_CORRECTION=$(get_default_value "NSGlobalDomain" "NSAutomaticSpellingCorrectionEnabled" "true")
 WEBKIT_DEVELOPER_EXTRAS=$(get_default_value "NSGlobalDomain" "WebKitDeveloperExtras" "false")
@@ -140,7 +141,6 @@ MC_AUTO_REARRANGE=$(get_default_value "com.apple.dock" "mru-spaces" "true")
 MC_GROUP_BY_APP=$(get_default_value "com.apple.dock" "expose-group-by-app" "true")
 MC_AUTO_SWOOSH=$(get_default_value "com.apple.dock" "workspaces-auto-swoosh" "false")
 MC_SPANS_DISPLAYS=$(get_default_value "com.apple.spaces" "spans-displays" "false")
-MC_DASHBOARD_DISABLED=$(get_default_value "com.apple.dashboard" "mcx-disabled" "false")
 
 # --- ホットコーナー ---
 HOT_CORNER_TL=$(get_default_value "com.apple.dock" "wvous-tl-corner" "1")
@@ -211,6 +211,7 @@ defaults write NSGlobalDomain NSTableViewDefaultSizeMode -int $SIDEBAR_ICON_SIZE
 defaults write NSGlobalDomain NSWindowResizeTime -float $WINDOW_RESIZE_TIME
 defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool $(format_bool_value $AUTO_CAPITALIZATION)
 defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool $(format_bool_value $SMART_DASHES)
+defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool $(format_bool_value $AUTO_PERIOD_SUBSTITUTION)
 defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool $(format_bool_value $SMART_QUOTES)
 defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool $(format_bool_value $AUTO_SPELLING_CORRECTION)
 defaults write NSGlobalDomain WebKitDeveloperExtras -bool $(format_bool_value $WEBKIT_DEVELOPER_EXTRAS)
@@ -276,7 +277,6 @@ defaults write com.apple.dock mru-spaces -bool $(format_bool_value $MC_AUTO_REAR
 defaults write com.apple.dock expose-group-by-app -bool $(format_bool_value $MC_GROUP_BY_APP)
 defaults write com.apple.dock workspaces-auto-swoosh -bool $(format_bool_value $MC_AUTO_SWOOSH)
 defaults write com.apple.spaces spans-displays -bool $(format_bool_value $MC_SPANS_DISPLAYS)
-defaults write com.apple.dashboard mcx-disabled -bool $(format_bool_value $MC_DASHBOARD_DISABLED)
 EOF
 )
 

--- a/config/macos/macos-settings.sh
+++ b/config/macos/macos-settings.sh
@@ -18,9 +18,9 @@ defaults write NSGlobalDomain NSTableViewDefaultSizeMode -int 2
 defaults write NSGlobalDomain NSWindowResizeTime -float 0.01
 defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
 defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
+defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
 defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool true
 defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
-defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
 defaults write NSGlobalDomain WebKitDeveloperExtras -bool true
 
 # Dock
@@ -63,7 +63,6 @@ defaults write com.apple.dock mru-spaces -bool true
 defaults write com.apple.dock expose-group-by-app -bool true
 defaults write com.apple.dock workspaces-auto-swoosh -bool false
 defaults write com.apple.spaces spans-displays -bool false
-defaults write com.apple.dashboard mcx-disabled -bool false
 
 # ホットコーナー
 defaults write com.apple.dock wvous-tl-corner -int 1


### PR DESCRIPTION
- NSAutomaticPeriodSubstitutionEnabledをmacosバックアップスクリプトとドキュメントのUI/UXの方に追加
- com.apple.dashboard の設定はmacOS Mojave(10.14)以降不要なため削除