### PR TITLE
feat: Gitの個人設定を自動化する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 # Git user settings
-username="Your Name"
-email="your.email@example.com"
+GIT_USERNAME=YourName
+GIT_EMAIL=your.email@example.com

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Git user settings
+username="Your Name"
+email="your.email@example.com"

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # Cursor
 .cursor/
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -119,12 +119,15 @@ environment/
 
 4.  **Gitの個人設定**
 
-    `~/.gitconfig` に `user.name` と `user.email` を設定してください。
+    リポジトリのルートにある`.env.example`をコピーして`.env`ファイルを作成します。
+    その後、`.env`ファイル内の`username`と`email`をご自身のものに編集してください。
 
     ```sh
-    git config --global user.name "Your Name"
-    git config --global user.email "your.email@example.com"
+    cp .env.example .env
+    # .env ファイルを編集して、username と email を設定します
     ```
+
+    `./install.sh` または `./installers/scripts/git.sh` を実行すると、`.env`ファイルの情報が自動的にGitのグローバル設定に反映されます。
 
 5.  **macOSとシェルの設定を適用**
 


### PR DESCRIPTION
手動で行う必要があったGitのuser.nameとuser.emailの設定を、.envファイルを用いて自動化しました。

変更点:
- .gitignoreに.envを追加
- .env.exampleファイルを追加し、設定項目を明記
- installers/scripts/git.shを修正し、.envファイルが存在する場合にその内容を読み込んでgit configを自動設定する機能を追加
- README.mdを更新し、新しい設定方法を記載

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **新機能**
  * Gitユーザー設定（ユーザー名とメールアドレス）を`.env`ファイルで管理できるようになりました。
  * `.env.example`ファイルを追加し、必要な環境変数のサンプルを提供しました。

* **ドキュメント**
  * READMEのGit設定手順を、`.env`ファイル経由の自動化方法に更新しました。

* **その他**
  * `.env`ファイルを`.gitignore`に追加し、バージョン管理から除外しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->