### PR TITLE
Refactor: Improve robustness and fix errors in installer scripts

### DIFF
--- a/installers/config/brew/Brewfile
+++ b/installers/config/brew/Brewfile
@@ -24,7 +24,7 @@ brew "mint"
 ## Utility
 brew "poppler"
 brew "pandoc"
-brew "openssl"
+# brew "openssl" # ruby-build dependency, installed via scripts/ruby.sh
 brew "ollama"
 # brew "displayplacer" # installed by scripts/macos.sh
 

--- a/installers/config/brew/Brewfile
+++ b/installers/config/brew/Brewfile
@@ -16,7 +16,7 @@ brew "mint"
 
 ## Ruby
 # brew "rbenv" # installed by scripts/ruby.sh
-# brew "ruby-build" # installed by scripts/ruby.sh
+# brew "openssl" # installed by scripts/ruby.sh
 
 ## Python
 # brew "pyenv" # installed by scripts/python.sh
@@ -24,7 +24,6 @@ brew "mint"
 ## Utility
 brew "poppler"
 brew "pandoc"
-# brew "openssl" # ruby-build dependency, installed via scripts/ruby.sh
 brew "ollama"
 # brew "displayplacer" # installed by scripts/macos.sh
 

--- a/installers/config/node/global-packages.json
+++ b/installers/config/node/global-packages.json
@@ -1,6 +1,6 @@
 {
     "globalPackages": {
         "npm": "latest",
-        "gemini-cli": "latest"
+        "@google/gemini-cli": "latest"
     }
 }

--- a/installers/scripts/node.sh
+++ b/installers/scripts/node.sh
@@ -70,7 +70,7 @@ current_default_target="$(nvm alias default 2>/dev/null | awk -F'->' 'NR==1{gsub
 if [[ "$current_default_target" != "$expected_default_target" ]]; then
     echo "[CONFIGURING] Node.js ${expected_default_target} をデフォルトバージョンに設定します"
     if nvm alias default "$expected_default_target"; then
-        echo "[SUCCESS] デフォルトバージョンを ${NODE_VERSION} に設定しました"
+        echo "[SUCCESS] デフォルトバージョンを ${expected_default_target} に設定しました"
         node_changed=true
     else
         echo "[ERROR] デフォルトバージョンの設定に失敗しました"

--- a/macos/scripts/apply-system-defaults.sh
+++ b/macos/scripts/apply-system-defaults.sh
@@ -37,9 +37,10 @@ if [[ ! -f "${SETTINGS_FILE}" ]]; then
     echo "[INFO] You can generate it by running 'make backup-defaults'."
 else
     echo "[INFO] Sourcing system defaults file: ${SETTINGS_FILE}"
-    # `source` を使用して設定を適用するが、エラーが発生しても続行
+    # shellcheck source=/dev/null
     if ! source "${SETTINGS_FILE}"; then
-        echo "[WARN] Some errors occurred while applying macOS system defaults, but continuing."
+        echo "[ERROR] Failed to apply macOS system defaults from ${SETTINGS_FILE}"
+        exit 1
     else
         echo "[SUCCESS] macOS system defaults have been applied."
     fi

--- a/macos/scripts/backup-system-defaults.sh
+++ b/macos/scripts/backup-system-defaults.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # ================================================
-# 現在の macOS の設定を取得し、system-defaults.sh を生成
+# 現在の macOS の system defaults を取得し、system-defaults.sh を生成
 # ================================================
 #
 # Usage:
@@ -11,7 +11,7 @@ set -euo pipefail
 # 2. Run the script:
 #    $ ./macos/scripts/backup-system-defaults.sh
 #
-# The script will create/update macos/config/system-defaults/system-defaults.sh with current macOS settings.
+# The script will create/update macos/config/system-defaults/system-defaults.sh with current macOS system defaults.
 #
 # ================================================
 


### PR DESCRIPTION
This commit addresses several issues across the installation and configuration scripts to improve error handling, path correctness, and idempotency.

- `macos/scripts/apply-system-defaults.sh`:
  - The script now exits with an error if sourcing the system defaults file fails, instead of just warning.
  - Added a `shellcheck` directive for the dynamic source.

- `macos/scripts/backup-system-defaults.sh`:
  - Updated outdated comments in the header to reflect the correct file names and paths.

- `installers/scripts/python.sh`:
  - Corrected the path to `pipx-tools.txt`.
  - The script now exits with an error if `pipx-tools.txt` is not found.

- `installers/scripts/node.sh`:
  - Corrected the path to `global-packages.json`.
  - The script now exits with an error if `global-packages.json` is not found.
  - Fixed the `nvm default` alias comparison to correctly handle version strings with and without a 'v' prefix.

- `installers/scripts/ruby.sh`:
  - Separated `readonly` and command substitution for improved ShellCheck compatibility.
  - Prioritized `openssl@3` when installing Ruby to improve stability on macOS.
  - Removed a duplicated `BUNDLER_VERSION` variable.
  - Added `rbenv rehash` after `ruby-build` installation to ensure the shell is updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - Ruby: OpenSSL優先ビルドを導入し、rbenv初期化/rehashとBundler検証を強化。
  - Node: デフォルトエイリアスの自動整合とグローバルパッケージの厳密なインストール／検証を追加。npmパッケージ名を公式スコープ版へ変更。
  - Python: pipxツールのインストール／検証フローを一貫化。
- 修正
  - macOS: system defaults 適用で失敗時に即中断し、エラーメッセージを明確化。
- ドキュメント/雑務
  - Brewfileからopensslの直接インストールを移動、スクリプトでの管理へ変更。
  - 設定ファイル配置を整理し、欠如時はエラー終了と冪等性検出を徹底。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->