### PR TITLE
Refactor: Address nitpick comments in configuration files

### DIFF
--- a/.github/workflows/setup-shell.yml
+++ b/.github/workflows/setup-shell.yml
@@ -11,7 +11,15 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Create symbolic links for MacBook shell configuration
-        run: make link-shell CONFIG_DIR=config/macbook-only
+        env:
+          HOME: ${{ runner.temp }}/home-macbook
+        run: |
+          mkdir -p "$HOME"
+          make link-shell CONFIG_DIR=config/macbook-only
 
       - name: Create symbolic links for Mac mini shell configuration
-        run: make link-shell CONFIG_DIR=config/mac-mini-only
+        env:
+          HOME: ${{ runner.temp }}/home-mac-mini
+        run: |
+          mkdir -p "$HOME"
+          make link-shell CONFIG_DIR=config/mac-mini-only

--- a/config/mac-mini-only/shell/.zprofile
+++ b/config/mac-mini-only/shell/.zprofile
@@ -4,11 +4,6 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 # poppler のパス
 export PATH="/opt/homebrew/opt/poppler/bin:$PATH"
 
-# ユーザーローカルの bin ディレクトリ
-if [ -d "$HOME/bin" ] && [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
-    export PATH="$HOME/bin:$PATH"
-fi
-
 # pipx/poetry 用のパス
 export PATH="$HOME/.local/bin:$PATH"
 
@@ -56,10 +51,15 @@ else
   echo "Warning: /usr/libexec/java_home not available. Skipping JAVA_HOME setup." >&2
 fi
 
-# Android SDK
-export ANDROID_HOME=$HOME/Library/Android/sdk
-export PATH=$PATH:$ANDROID_HOME/emulator
-export PATH=$PATH:$ANDROID_HOME/platform-tools
+# Android SDK (追加PATHのみ)
+if [ -n "$ANDROID_HOME" ]; then
+  if [ -d "$ANDROID_HOME/emulator" ] && [[ ":$PATH:" != *":$ANDROID_HOME/emulator:"* ]]; then
+    export PATH="$PATH:$ANDROID_HOME/emulator"
+  fi
+  if [ -d "$ANDROID_HOME/platform-tools" ] && [[ ":$PATH:" != *":$ANDROID_HOME/platform-tools:"* ]]; then
+    export PATH="$PATH:$ANDROID_HOME/platform-tools"
+  fi
+fi
 
 # FVM 用 PATH 設定
 if [ -d "$HOME/fvm/default/bin" ] && [[ ":$PATH:" != *":$HOME/fvm/default/bin:"* ]]; then

--- a/config/mac-mini-only/shell/.zshrc
+++ b/config/mac-mini-only/shell/.zshrc
@@ -76,7 +76,7 @@ alias as="osascript"
 alias rel="source ~/.zshrc"
 alias op="open"
 alias op-f="open ."
-alias op-s="open -a 'System Preferences'"
+alias op-s="open -b com.apple.systempreferences"
 alias op-st="open -a 'Stickies'"
 alias op-o="open -a 'Obsidian'"
 alias op-as="open -a 'Android Studio'"
@@ -88,6 +88,14 @@ alias op-cg="open -a 'Google Chrome' 'https://github.com/akitorahayashi'"
 alias op-cj="open -a 'Google Chrome' 'https://jules.google.com/task'"
 
 md2pdf() {
+  if ! command -v pandoc >/dev/null 2>&1; then
+    echo "Error: pandoc is not installed." >&2
+    return 1
+  fi
+  if ! command -v lualatex >/dev/null 2>&1; then
+    echo "Error: lualatex (TeX Live) is not installed." >&2
+    return 1
+  fi
   pandoc "$1" -o "$2" --pdf-engine=lualatex \
     -V documentclass=ltjarticle \
     -V mainfont="Hiragino Mincho ProN" \

--- a/config/macbook-only/shell/.zprofile
+++ b/config/macbook-only/shell/.zprofile
@@ -4,11 +4,6 @@ eval "$(/opt/homebrew/bin/brew shellenv)"
 # poppler のパス
 export PATH="/opt/homebrew/opt/poppler/bin:$PATH"
 
-# ユーザーローカルの bin ディレクトリ
-if [ -d "$HOME/bin" ] && [[ ":$PATH:" != *":$HOME/bin:"* ]]; then
-    export PATH="$HOME/bin:$PATH"
-fi
-
 # pipx/poetry 用のパス
 export PATH="$HOME/.local/bin:$PATH"
 
@@ -56,10 +51,15 @@ else
   echo "Warning: /usr/libexec/java_home not available. Skipping JAVA_HOME setup." >&2
 fi
 
-# Android SDK
-export ANDROID_HOME=$HOME/Library/Android/sdk
-export PATH=$PATH:$ANDROID_HOME/emulator
-export PATH=$PATH:$ANDROID_HOME/platform-tools
+# Android SDK (追加PATHのみ)
+if [ -n "$ANDROID_HOME" ]; then
+  if [ -d "$ANDROID_HOME/emulator" ] && [[ ":$PATH:" != *":$ANDROID_HOME/emulator:"* ]]; then
+    export PATH="$PATH:$ANDROID_HOME/emulator"
+  fi
+  if [ -d "$ANDROID_HOME/platform-tools" ] && [[ ":$PATH:" != *":$ANDROID_HOME/platform-tools:"* ]]; then
+    export PATH="$PATH:$ANDROID_HOME/platform-tools"
+  fi
+fi
 
 # FVM 用 PATH 設定
 if [ -d "$HOME/fvm/default/bin" ] && [[ ":$PATH:" != *":$HOME/fvm/default/bin:"* ]]; then

--- a/config/macbook-only/shell/.zshrc
+++ b/config/macbook-only/shell/.zshrc
@@ -76,7 +76,7 @@ alias as="osascript"
 alias rel="source ~/.zshrc"
 alias op="open"
 alias op-f="open ."
-alias op-s="open -a 'System Preferences'"
+alias op-s="open -b com.apple.systempreferences"
 alias op-st="open -a 'Stickies'"
 alias op-o="open -a 'Obsidian'"
 alias op-as="open -a 'Android Studio'"
@@ -88,6 +88,14 @@ alias op-cg="open -a 'Google Chrome' 'https://github.com/akitorahayashi'"
 alias op-cj="open -a 'Google Chrome' 'https://jules.google.com/task'"
 
 md2pdf() {
+  if ! command -v pandoc >/dev/null 2>&1; then
+    echo "Error: pandoc is not installed." >&2
+    return 1
+  fi
+  if ! command -v lualatex >/dev/null 2>&1; then
+    echo "Error: lualatex (TeX Live) is not installed." >&2
+    return 1
+  fi
   pandoc "$1" -o "$2" --pdf-engine=lualatex \
     -V documentclass=ltjarticle \
     -V mainfont="Hiragino Mincho ProN" \


### PR DESCRIPTION
This commit addresses several nitpick comments to improve the robustness and consistency of the shell configuration and GitHub Actions workflow.

- **GitHub Workflow (`.github/workflows/setup-shell.yml`):**
  - Isolated the `make link-shell` calls for MacBook and Mac mini configurations by using separate `HOME` directories. This prevents conflicts and ensures independent validation of each configuration.

- **Zsh Profile (`.zprofile`):**
  - Refactored the Android SDK environment variable settings in both `macbook-only` and `mac-mini-only` configurations to avoid redundant `ANDROID_HOME` exports and prevent duplicate entries in the `PATH`.
  - Removed the user-local bin directory PATH export from both configurations as requested.

- **Zsh RC (`.zshrc`):**
  - Updated the `op-s` alias to use `open -b com.apple.systempreferences` for better compatibility with modern macOS versions.
  - Enhanced the `md2pdf` function with dependency checks for `pandoc` and `lualatex` to provide clearer error messages.