### PR TITLE
refactor: シェル設定を共通化

### DIFF
--- a/config/common/shell/.zprofile
+++ b/config/common/shell/.zprofile
@@ -1,0 +1,67 @@
+# Apple Silicon 用 Homebrew の初期化
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
+# poppler のパス
+export PATH="/opt/homebrew/opt/poppler/bin:$PATH"
+
+# pipx/poetry 用のパス
+export PATH="$HOME/.local/bin:$PATH"
+
+# Android SDK 環境変数
+if [[ -z "$ANDROID_HOME" ]]; then
+    export ANDROID_HOME="$HOME/Library/Android/sdk"
+    export ANDROID_SDK_ROOT="$ANDROID_HOME"
+fi
+
+if [[ ":$PATH:" != *":$ANDROID_HOME/cmdline-tools/latest/bin:"* ]]; then
+    export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"
+fi
+
+# rbenv の初期化
+if command -v rbenv 1>/dev/null 2>&1; then
+  eval "$(rbenv init -)"
+fi
+
+# pyenv の初期化
+if command -v pyenv 1>/dev/null 2>&1; then
+  export PYENV_ROOT="$HOME/.pyenv"
+  export PATH="$PYENV_ROOT/bin:$PATH"
+  eval "$(pyenv init --path)"
+  eval "$(pyenv init -)"
+fi
+
+# ollama models のパス設定
+export OLLAMA_MODELS="$HOME/.ollama/models"
+
+# nvm の初期化
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
+  . "$(brew --prefix nvm)/nvm.sh"
+fi
+
+# JAVA_HOME の設定
+if command -v /usr/libexec/java_home >/dev/null 2>&1; then
+  JAVA_21="$(/usr/libexec/java_home -v "21" 2>/dev/null || true)"
+  if [ -n "$JAVA_21" ]; then
+    export JAVA_HOME="$JAVA_21"
+  else
+    echo "Warning: Java 21 not found. Skipping JAVA_HOME setup." >&2
+  fi
+else
+  echo "Warning: /usr/libexec/java_home not available. Skipping JAVA_HOME setup." >&2
+fi
+
+# Android SDK (追加PATHのみ)
+if [ -n "$ANDROID_HOME" ]; then
+  if [ -d "$ANDROID_HOME/emulator" ] && [[ ":$PATH:" != *":$ANDROID_HOME/emulator:"* ]]; then
+    export PATH="$PATH:$ANDROID_HOME/emulator"
+  fi
+  if [ -d "$ANDROID_HOME/platform-tools" ] && [[ ":$PATH:" != *":$ANDROID_HOME/platform-tools:"* ]]; then
+    export PATH="$PATH:$ANDROID_HOME/platform-tools"
+  fi
+fi
+
+# FVM 用 PATH 設定
+if [ -d "$HOME/fvm/default/bin" ] && [[ ":$PATH:" != *":$HOME/fvm/default/bin:"* ]]; then
+    export PATH="$HOME/fvm/default/bin:$PATH"
+fi

--- a/config/common/shell/.zprofile
+++ b/config/common/shell/.zprofile
@@ -27,7 +27,6 @@ if command -v pyenv 1>/dev/null 2>&1; then
   export PYENV_ROOT="$HOME/.pyenv"
   export PATH="$PYENV_ROOT/bin:$PATH"
   eval "$(pyenv init --path)"
-  eval "$(pyenv init -)"
 fi
 
 # ollama models のパス設定
@@ -40,8 +39,8 @@ if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
 fi
 
 # JAVA_HOME の設定
-if command -v /usr/libexec/java_home >/dev/null 2>&1; then
-  JAVA_21="$(/usr/libexec/java_home -v "21" 2>/dev/null || true)"
+if [ -x /usr/libexec/java_home ]; then
+  JAVA_21=$(/usr/libexec/java_home -v 21 2>/dev/null)
   if [ -n "$JAVA_21" ]; then
     export JAVA_HOME="$JAVA_21"
   else

--- a/config/common/shell/.zshrc
+++ b/config/common/shell/.zshrc
@@ -1,3 +1,7 @@
+if command -v pyenv 1>/dev/null 2>&1; then
+  eval "$(pyenv init -)"
+fi
+
 # Python
 alias poet-n="poetry new"
 alias poet-ini="poetry init"
@@ -42,7 +46,9 @@ aid-set() {
   export OLLAMA_API_BASE="$1"
 }
 aid-lch() {
-  aider --model "ollama/$1" --no-auto-commit --no-gitignore
+  local model="${1:?usage: aid-lch <model> [aider-args...]}"
+  shift
+  aider --model "ollama/$model" --no-auto-commit --no-gitignore "$@"
 }
 
 # Ruby
@@ -97,6 +103,15 @@ md2pdf() {
   if ! command -v lualatex >/dev/null 2>&1; then
     echo "Error: lualatex (TeX Live) is not installed." >&2
     return 1
+  fi
+  # 引数チェック
+  if [ $# -ne 2 ]; then
+    echo "Usage: md2pdf <input.md> <output.pdf>" >&2
+    return 2
+  fi
+  if [ ! -f "$1" ]; then
+    echo "Error: input file not found: $1" >&2
+    return 2
   fi
   pandoc "$1" -o "$2" --pdf-engine=lualatex \
     -V documentclass=ltjarticle \

--- a/config/common/shell/.zshrc
+++ b/config/common/shell/.zshrc
@@ -1,0 +1,108 @@
+# Python
+alias poet-n="poetry new"
+alias poet-ini="poetry init"
+alias poet-i="poetry install"
+alias poet-a="poetry add"
+alias poet-rm="poetry remove"
+alias poet-r="poetry run python"
+alias poet-u="poetry update"
+alias poet-ls="poetry list"
+alias poet-lock="poetry lock"
+alias poet-e="poetry export -f requirements.txt --output requirements.txt --without-hashes"
+alias poet-env="poetry env list"
+alias poet-env-d="poetry env remove"
+
+# pipx
+alias px="pipx"
+alias px-ls="pipx list"
+alias px-i="pipx install"
+alias px-ui="pipx uninstall"
+alias px-r="pipx run"
+
+# pip
+alias pl="pip list"
+alias pi="pip install"
+alias pu="python -m pip install --upgrade pip"
+alias pui="pip uninstall"
+alias pir="pip install -r requirements.txt"
+alias pif="pip freeze > requirements.txt"
+
+# Ollama
+alias ol="ollama"
+alias ol-ls="ollama list"
+alias ol-pl="ollama pull"
+alias ol-r="ollama run"
+alias ol-s="ollama serve"
+alias ol-sp="ollama stop"
+alias ol-c="ollama create"
+alias ol-d="ollama delete"
+
+# Aider
+aid-set() {
+  export OLLAMA_API_BASE="$1"
+}
+aid-lch() {
+  aider --model "ollama/$1" --no-auto-commit --no-gitignore
+}
+
+# Ruby
+alias be="bundle exec"
+alias be-f="bundle exec fastlane"
+alias bi="bundle install"
+
+# Node.js
+alias ni="npm install"
+alias nr="npm run"
+
+# Docker
+alias doc="docker"
+alias doc-b="docker build"
+alias doc-r="docker run"
+alias doc-i="docker images"
+alias doc-ps="docker ps"
+alias doc-st="docker stop"
+alias doc-rm="docker rm"
+
+# Mint
+alias mr="mint run"
+
+# Makefile
+alias mk="make"
+
+# AppleScript
+alias as="osascript"
+
+# Utility
+alias rel="source ~/.zshrc"
+alias gi="git"
+alias cl="clear"
+alias op="open"
+alias op-f="open ."
+alias op-s="open -b com.apple.systempreferences"
+alias op-st="open -a 'Stickies'"
+alias op-o="open -a 'Obsidian'"
+alias op-as="open -a 'Android Studio'"
+alias op-a="open -a 'Automator'"
+alias op-sc="open -a 'Script Editor'"
+alias op-t="open -na Terminal"
+alias op-c="open -a 'Google Chrome'"
+alias op-cg="open -a 'Google Chrome' 'https://github.com/akitorahayashi'"
+alias op-cj="open -a 'Google Chrome' 'https://jules.google.com/task'"
+
+md2pdf() {
+  if ! command -v pandoc >/dev/null 2>&1; then
+    echo "Error: pandoc is not installed." >&2
+    return 1
+  fi
+  if ! command -v lualatex >/dev/null 2>&1; then
+    echo "Error: lualatex (TeX Live) is not installed." >&2
+    return 1
+  fi
+  pandoc "$1" -o "$2" --pdf-engine=lualatex \
+    -V documentclass=ltjarticle \
+    -V mainfont="Hiragino Mincho ProN" \
+    -V sansfont="Hiragino Sans" \
+    -V monofont="Hiragino Kaku Gothic ProN" \
+    -V geometry:a4paper \
+    -V geometry:margin=2.5cm
+}

--- a/config/mac-mini-only/shell/.zprofile
+++ b/config/mac-mini-only/shell/.zprofile
@@ -1,23 +1,17 @@
 # This file is for machine-specific settings.
 # It sources the common .zprofile file.
 
-# When sourced, Zsh sets ${(%):-%N} to the path of the script.
-# This works even for symlinks.
-SOURCE_PATH=${(%):-%N}
-
-# If it's a symlink, resolve it to the actual file path in the repo.
-# $HOME/.zprofile -> /path/to/repo/config/mac-mini-only/shell/.zprofile
-if [[ -L "$SOURCE_PATH" ]]; then
-  SOURCE_PATH=$(readlink "$SOURCE_PATH")
-fi
+# When sourced, Zsh sets ${(%):-%N} to the path of the script (zsh).
+# :A で絶対パス化+リンク解決
+SOURCE_PATH=${(%):-%N:A}
 
 # Get the directory of the source file.
 # e.g., /path/to/repo/config/mac-mini-only/shell
-SOURCE_DIR=$(dirname "$SOURCE_PATH")
+SOURCE_DIR=${SOURCE_PATH:h}
 
 # The REPO_ROOT is three directories up from this script's original location.
 # e.g., from /path/to/repo/config/mac-mini-only/shell
-export REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
+export REPO_ROOT="${SOURCE_DIR:h:h:h}"
 
 # Source the common .zprofile from the repository.
 COMMON_ZPROFILE="$REPO_ROOT/config/common/shell/.zprofile"
@@ -25,7 +19,11 @@ if [ -f "$COMMON_ZPROFILE" ]; then
   source "$COMMON_ZPROFILE"
 else
   echo "Error: Common .zprofile not found at $COMMON_ZPROFILE" >&2
+  return 1
 fi
 
 # Add any machine-specific profile settings below this line.
 # Example: export MY_VAR="some_value"
+
+# Clean up temporary variables.
+unset SOURCE_PATH SOURCE_DIR COMMON_ZPROFILE

--- a/config/mac-mini-only/shell/.zprofile
+++ b/config/mac-mini-only/shell/.zprofile
@@ -1,67 +1,31 @@
-# Apple Silicon 用 Homebrew の初期化
-eval "$(/opt/homebrew/bin/brew shellenv)"
+# This file is for machine-specific settings.
+# It sources the common .zprofile file.
 
-# poppler のパス
-export PATH="/opt/homebrew/opt/poppler/bin:$PATH"
+# When sourced, Zsh sets ${(%):-%N} to the path of the script.
+# This works even for symlinks.
+SOURCE_PATH=${(%):-%N}
 
-# pipx/poetry 用のパス
-export PATH="$HOME/.local/bin:$PATH"
-
-# Android SDK 環境変数
-if [[ -z "$ANDROID_HOME" ]]; then
-    export ANDROID_HOME="$HOME/Library/Android/sdk"
-    export ANDROID_SDK_ROOT="$ANDROID_HOME"
+# If it's a symlink, resolve it to the actual file path in the repo.
+# $HOME/.zprofile -> /path/to/repo/config/mac-mini-only/shell/.zprofile
+if [[ -L "$SOURCE_PATH" ]]; then
+  SOURCE_PATH=$(readlink "$SOURCE_PATH")
 fi
 
-if [[ ":$PATH:" != *":$ANDROID_HOME/cmdline-tools/latest/bin:"* ]]; then
-    export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"
-fi
+# Get the directory of the source file.
+# e.g., /path/to/repo/config/mac-mini-only/shell
+SOURCE_DIR=$(dirname "$SOURCE_PATH")
 
-# rbenv の初期化
-if command -v rbenv 1>/dev/null 2>&1; then
-  eval "$(rbenv init -)"
-fi
+# The REPO_ROOT is three directories up from this script's original location.
+# e.g., from /path/to/repo/config/mac-mini-only/shell
+export REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
 
-# pyenv の初期化
-if command -v pyenv 1>/dev/null 2>&1; then
-  export PYENV_ROOT="$HOME/.pyenv"
-  export PATH="$PYENV_ROOT/bin:$PATH"
-  eval "$(pyenv init --path)"
-  eval "$(pyenv init -)"
-fi
-
-# ollama models のパス設定
-export OLLAMA_MODELS="$HOME/.ollama/models"
-
-# nvm の初期化
-export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
-  . "$(brew --prefix nvm)/nvm.sh"
-fi
-
-# JAVA_HOME の設定
-if command -v /usr/libexec/java_home >/dev/null 2>&1; then
-  JAVA_21="$(/usr/libexec/java_home -v "21" 2>/dev/null || true)"
-  if [ -n "$JAVA_21" ]; then
-    export JAVA_HOME="$JAVA_21"
-  else
-    echo "Warning: Java 21 not found. Skipping JAVA_HOME setup." >&2
-  fi
+# Source the common .zprofile from the repository.
+COMMON_ZPROFILE="$REPO_ROOT/config/common/shell/.zprofile"
+if [ -f "$COMMON_ZPROFILE" ]; then
+  source "$COMMON_ZPROFILE"
 else
-  echo "Warning: /usr/libexec/java_home not available. Skipping JAVA_HOME setup." >&2
+  echo "Error: Common .zprofile not found at $COMMON_ZPROFILE" >&2
 fi
 
-# Android SDK (追加PATHのみ)
-if [ -n "$ANDROID_HOME" ]; then
-  if [ -d "$ANDROID_HOME/emulator" ] && [[ ":$PATH:" != *":$ANDROID_HOME/emulator:"* ]]; then
-    export PATH="$PATH:$ANDROID_HOME/emulator"
-  fi
-  if [ -d "$ANDROID_HOME/platform-tools" ] && [[ ":$PATH:" != *":$ANDROID_HOME/platform-tools:"* ]]; then
-    export PATH="$PATH:$ANDROID_HOME/platform-tools"
-  fi
-fi
-
-# FVM 用 PATH 設定
-if [ -d "$HOME/fvm/default/bin" ] && [[ ":$PATH:" != *":$HOME/fvm/default/bin:"* ]]; then
-    export PATH="$HOME/fvm/default/bin:$PATH"
-fi
+# Add any machine-specific profile settings below this line.
+# Example: export MY_VAR="some_value"

--- a/config/mac-mini-only/shell/.zshrc
+++ b/config/mac-mini-only/shell/.zshrc
@@ -1,109 +1,31 @@
-# Python
-alias poet-n="poetry new"
-alias poet-ini="poetry init"
-alias poet-i="poetry install"
-alias poet-a="poetry add"
-alias poet-rm="poetry remove"
-alias poet-r="poetry run python"
-alias poet-u="poetry update"
-alias poet-ls="poetry list"
-alias poet-lock="poetry lock"
-alias poet-e="poetry export -f requirements.txt --output requirements.txt --without-hashes"
-alias poet-env="poetry env list"
-alias poet-env-d="poetry env remove"
+# This file is for machine-specific settings.
+# It sources the common .zshrc file.
 
-# pipx
-alias px="pipx"
-alias px-ls="pipx list"
-alias px-i="pipx install"
-alias px-ui="pipx uninstall"
-alias px-r="pipx run"
+# When sourced, Zsh sets ${(%):-%N} to the path of the script.
+# This works even for symlinks.
+SOURCE_PATH=${(%):-%N}
 
-# pip
-alias pl="pip list"
-alias pi="pip install"
-alias pu="python -m pip install --upgrade pip"
-alias pui="pip uninstall"
-alias pir="pip install -r requirements.txt"
-alias pif="pip freeze > requirements.txt"
+# If it's a symlink, resolve it to the actual file path in the repo.
+# $HOME/.zshrc -> /path/to/repo/config/mac-mini-only/shell/.zshrc
+if [[ -L "$SOURCE_PATH" ]]; then
+  SOURCE_PATH=$(readlink "$SOURCE_PATH")
+fi
 
-# Ollama
-alias ol="ollama"
-alias ol-ls="ollama list"
-alias ol-pl="ollama pull"
-alias ol-r="ollama run"
-alias ol-s="ollama serve"
-alias ol-sp="ollama stop"
-alias ol-c="ollama create"
-alias ol-d="ollama delete"
+# Get the directory of the source file.
+# e.g., /path/to/repo/config/mac-mini-only/shell
+SOURCE_DIR=$(dirname "$SOURCE_PATH")
 
-# Aider
-aid-set() {
-  export OLLAMA_API_BASE="$1"
-}
-aid-lch() {
-  aider --model "ollama/$1" --no-auto-commit --no-gitignore
-}
+# The REPO_ROOT is three directories up from this script's original location.
+# e.g., from /path/to/repo/config/mac-mini-only/shell
+REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
 
-# Ruby
-alias be="bundle exec"
-alias be-f="bundle exec fastlane"
-alias bi="bundle install"
+# Source the common .zshrc from the repository.
+COMMON_ZSHRC="$REPO_ROOT/config/common/shell/.zshrc"
+if [ -f "$COMMON_ZSHRC" ]; then
+  source "$COMMON_ZSHRC"
+else
+  echo "Error: Common .zshrc not found at $COMMON_ZSHRC" >&2
+fi
 
-# Node.js
-alias ni="npm install"
-alias nr="npm run"
-
-# Docker
-alias doc="docker"
-alias doc-b="docker build"
-alias doc-r="docker run"
-alias doc-i="docker images"
-alias doc-ps="docker ps"
-alias doc-st="docker stop"
-alias doc-rm="docker rm"
-
-# Mint
-alias mr="mint run"
-
-# Makefile
-alias mk="make"
-
-# AppleScript
-alias as="osascript"
-
-# Utility
-alias rel="source ~/.zshrc"
-alias gi="git"
-alias cl="clear"
-alias op="open"
-alias op-f="open ."
-alias op-s="open -b com.apple.systempreferences"
-alias op-st="open -a 'Stickies'"
-alias op-o="open -a 'Obsidian'"
-alias op-as="open -a 'Android Studio'"
-alias op-a="open -a 'Automator'"
-alias op-sc="open -a 'Script Editor'"
-alias op-t="open -na Terminal"
-alias op-c="open -a 'Google Chrome'"
-alias op-cg="open -a 'Google Chrome' 'https://github.com/akitorahayashi'"
-alias op-cj="open -a 'Google Chrome' 'https://jules.google.com/task'"
-
-md2pdf() {
-  if ! command -v pandoc >/dev/null 2>&1; then
-    echo "Error: pandoc is not installed." >&2
-    return 1
-  fi
-  if ! command -v lualatex >/dev/null 2>&1; then
-    echo "Error: lualatex (TeX Live) is not installed." >&2
-    return 1
-  fi
-  pandoc "$1" -o "$2" --pdf-engine=lualatex \
-    -V documentclass=ltjarticle \
-    -V mainfont="Hiragino Mincho ProN" \
-    -V sansfont="Hiragino Sans" \
-    -V monofont="Hiragino Kaku Gothic ProN" \
-    -V geometry:a4paper \
-    -V geometry:margin=2.5cm
-}
-
+# Add any machine-specific zshrc settings below this line.
+# Example: alias myalias="echo 'hello'"

--- a/config/mac-mini-only/shell/.zshrc
+++ b/config/mac-mini-only/shell/.zshrc
@@ -21,10 +21,14 @@ REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
 
 # Source the common .zshrc from the repository.
 COMMON_ZSHRC="$REPO_ROOT/config/common/shell/.zshrc"
-if [ -f "$COMMON_ZSHRC" ]; then
-  source "$COMMON_ZSHRC"
+if [[ -f "$COMMON_ZSHRC" ]]; then
+  # Avoid double-loading when re-sourcing .zshrc.
+  if [[ -z "${__ENV_COMMON_ZSHRC_SOURCED-}" ]]; then
+    typeset -g __ENV_COMMON_ZSHRC_SOURCED=1
+    source "$COMMON_ZSHRC"
+  fi
 else
-  echo "Error: Common .zshrc not found at $COMMON_ZSHRC" >&2
+  print -ru2 -- "Error: Common .zshrc not found at $COMMON_ZSHRC"
 fi
 
 # Add any machine-specific zshrc settings below this line.

--- a/config/mac-mini-only/shell/.zshrc
+++ b/config/mac-mini-only/shell/.zshrc
@@ -1,23 +1,17 @@
 # This file is for machine-specific settings.
 # It sources the common .zshrc file.
 
-# When sourced, Zsh sets ${(%):-%N} to the path of the script.
-# This works even for symlinks.
-SOURCE_PATH=${(%):-%N}
-
-# If it's a symlink, resolve it to the actual file path in the repo.
-# $HOME/.zshrc -> /path/to/repo/config/mac-mini-only/shell/.zshrc
-if [[ -L "$SOURCE_PATH" ]]; then
-  SOURCE_PATH=$(readlink "$SOURCE_PATH")
-fi
+# When sourced, Zsh sets ${(%):-%N} to the path of the script (zsh).
+# :A で絶対パス化+リンク解決
+SOURCE_PATH=${(%):-%N:A}
 
 # Get the directory of the source file.
 # e.g., /path/to/repo/config/mac-mini-only/shell
-SOURCE_DIR=$(dirname "$SOURCE_PATH")
+SOURCE_DIR=${SOURCE_PATH:h}
 
 # The REPO_ROOT is three directories up from this script's original location.
 # e.g., from /path/to/repo/config/mac-mini-only/shell
-REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
+REPO_ROOT="${SOURCE_DIR:h:h:h}"
 
 # Source the common .zshrc from the repository.
 COMMON_ZSHRC="$REPO_ROOT/config/common/shell/.zshrc"
@@ -29,7 +23,11 @@ if [[ -f "$COMMON_ZSHRC" ]]; then
   fi
 else
   print -ru2 -- "Error: Common .zshrc not found at $COMMON_ZSHRC"
+  return 1
 fi
 
 # Add any machine-specific zshrc settings below this line.
 # Example: alias myalias="echo 'hello'"
+
+# Clean up temporary variables.
+unset SOURCE_PATH SOURCE_DIR COMMON_ZSHRC

--- a/config/macbook-only/shell/.zprofile
+++ b/config/macbook-only/shell/.zprofile
@@ -1,23 +1,17 @@
 # This file is for machine-specific settings.
 # It sources the common .zprofile file.
 
-# When sourced, Zsh sets ${(%):-%N} to the path of the script.
-# This works even for symlinks.
-SOURCE_PATH=${(%):-%N}
-
-# If it's a symlink, resolve it to the actual file path in the repo.
-# $HOME/.zprofile -> /path/to/repo/config/macbook-only/shell/.zprofile
-if [[ -L "$SOURCE_PATH" ]]; then
-  SOURCE_PATH=$(readlink "$SOURCE_PATH")
-fi
+# When sourced, Zsh sets ${(%):-%N} to the path of the script (zsh).
+# :A で絶対パス化+リンク解決
+SOURCE_PATH=${(%):-%N:A}
 
 # Get the directory of the source file.
 # e.g., /path/to/repo/config/macbook-only/shell
-SOURCE_DIR=$(dirname "$SOURCE_PATH")
+SOURCE_DIR=${SOURCE_PATH:h}
 
 # The REPO_ROOT is three directories up from this script's original location.
 # e.g., from /path/to/repo/config/macbook-only/shell
-export REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
+export REPO_ROOT="${SOURCE_DIR:h:h:h}"
 
 # Source the common .zprofile from the repository.
 COMMON_ZPROFILE="$REPO_ROOT/config/common/shell/.zprofile"
@@ -25,7 +19,11 @@ if [ -f "$COMMON_ZPROFILE" ]; then
   source "$COMMON_ZPROFILE"
 else
   echo "Error: Common .zprofile not found at $COMMON_ZPROFILE" >&2
+  return 1
 fi
 
 # Add any machine-specific profile settings below this line.
 # Example: export MY_VAR="some_value"
+
+# Clean up temporary variables.
+unset SOURCE_PATH SOURCE_DIR COMMON_ZPROFILE

--- a/config/macbook-only/shell/.zprofile
+++ b/config/macbook-only/shell/.zprofile
@@ -1,67 +1,31 @@
-# Apple Silicon 用 Homebrew の初期化
-eval "$(/opt/homebrew/bin/brew shellenv)"
+# This file is for machine-specific settings.
+# It sources the common .zprofile file.
 
-# poppler のパス
-export PATH="/opt/homebrew/opt/poppler/bin:$PATH"
+# When sourced, Zsh sets ${(%):-%N} to the path of the script.
+# This works even for symlinks.
+SOURCE_PATH=${(%):-%N}
 
-# pipx/poetry 用のパス
-export PATH="$HOME/.local/bin:$PATH"
-
-# Android SDK 環境変数
-if [[ -z "$ANDROID_HOME" ]]; then
-    export ANDROID_HOME="$HOME/Library/Android/sdk"
-    export ANDROID_SDK_ROOT="$ANDROID_HOME"
+# If it's a symlink, resolve it to the actual file path in the repo.
+# $HOME/.zprofile -> /path/to/repo/config/macbook-only/shell/.zprofile
+if [[ -L "$SOURCE_PATH" ]]; then
+  SOURCE_PATH=$(readlink "$SOURCE_PATH")
 fi
 
-if [[ ":$PATH:" != *":$ANDROID_HOME/cmdline-tools/latest/bin:"* ]]; then
-    export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"
-fi
+# Get the directory of the source file.
+# e.g., /path/to/repo/config/macbook-only/shell
+SOURCE_DIR=$(dirname "$SOURCE_PATH")
 
-# rbenv の初期化
-if command -v rbenv 1>/dev/null 2>&1; then
-  eval "$(rbenv init -)"
-fi
+# The REPO_ROOT is three directories up from this script's original location.
+# e.g., from /path/to/repo/config/macbook-only/shell
+export REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
 
-# pyenv の初期化
-if command -v pyenv 1>/dev/null 2>&1; then
-  export PYENV_ROOT="$HOME/.pyenv"
-  export PATH="$PYENV_ROOT/bin:$PATH"
-  eval "$(pyenv init --path)"
-  eval "$(pyenv init -)"
-fi
-
-# ollama models のパス設定
-export OLLAMA_MODELS="$HOME/.ollama/models"
-
-# nvm の初期化
-export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-if [ -s "$(brew --prefix nvm)/nvm.sh" ]; then
-  . "$(brew --prefix nvm)/nvm.sh"
-fi
-
-# JAVA_HOME の設定
-if command -v /usr/libexec/java_home >/dev/null 2>&1; then
-  JAVA_21="$(/usr/libexec/java_home -v "21" 2>/dev/null || true)"
-  if [ -n "$JAVA_21" ]; then
-    export JAVA_HOME="$JAVA_21"
-  else
-    echo "Warning: Java 21 not found. Skipping JAVA_HOME setup." >&2
-  fi
+# Source the common .zprofile from the repository.
+COMMON_ZPROFILE="$REPO_ROOT/config/common/shell/.zprofile"
+if [ -f "$COMMON_ZPROFILE" ]; then
+  source "$COMMON_ZPROFILE"
 else
-  echo "Warning: /usr/libexec/java_home not available. Skipping JAVA_HOME setup." >&2
+  echo "Error: Common .zprofile not found at $COMMON_ZPROFILE" >&2
 fi
 
-# Android SDK (追加PATHのみ)
-if [ -n "$ANDROID_HOME" ]; then
-  if [ -d "$ANDROID_HOME/emulator" ] && [[ ":$PATH:" != *":$ANDROID_HOME/emulator:"* ]]; then
-    export PATH="$PATH:$ANDROID_HOME/emulator"
-  fi
-  if [ -d "$ANDROID_HOME/platform-tools" ] && [[ ":$PATH:" != *":$ANDROID_HOME/platform-tools:"* ]]; then
-    export PATH="$PATH:$ANDROID_HOME/platform-tools"
-  fi
-fi
-
-# FVM 用 PATH 設定
-if [ -d "$HOME/fvm/default/bin" ] && [[ ":$PATH:" != *":$HOME/fvm/default/bin:"* ]]; then
-    export PATH="$HOME/fvm/default/bin:$PATH"
-fi
+# Add any machine-specific profile settings below this line.
+# Example: export MY_VAR="some_value"

--- a/config/macbook-only/shell/.zshrc
+++ b/config/macbook-only/shell/.zshrc
@@ -1,108 +1,31 @@
-# Python
-alias poet-n="poetry new"
-alias poet-ini="poetry init"
-alias poet-i="poetry install"
-alias poet-a="poetry add"
-alias poet-rm="poetry remove"
-alias poet-r="poetry run python"
-alias poet-u="poetry update"
-alias poet-ls="poetry list"
-alias poet-lock="poetry lock"
-alias poet-e="poetry export -f requirements.txt --output requirements.txt --without-hashes"
-alias poet-env="poetry env list"
-alias poet-env-d="poetry env remove"
+# This file is for machine-specific settings.
+# It sources the common .zshrc file.
 
-# pipx
-alias px="pipx"
-alias px-ls="pipx list"
-alias px-i="pipx install"
-alias px-ui="pipx uninstall"
-alias px-r="pipx run"
+# When sourced, Zsh sets ${(%):-%N} to the path of the script.
+# This works even for symlinks.
+SOURCE_PATH=${(%):-%N}
 
-# pip
-alias pl="pip list"
-alias pi="pip install"
-alias pu="python -m pip install --upgrade pip"
-alias pui="pip uninstall"
-alias pir="pip install -r requirements.txt"
-alias pif="pip freeze > requirements.txt"
+# If it's a symlink, resolve it to the actual file path in the repo.
+# $HOME/.zshrc -> /path/to/repo/config/macbook-only/shell/.zshrc
+if [[ -L "$SOURCE_PATH" ]]; then
+  SOURCE_PATH=$(readlink "$SOURCE_PATH")
+fi
 
-# Ollama
-alias ol="ollama"
-alias ol-ls="ollama list"
-alias ol-pl="ollama pull"
-alias ol-r="ollama run"
-alias ol-s="ollama serve"
-alias ol-sp="ollama stop"
-alias ol-c="ollama create"
-alias ol-d="ollama delete"
+# Get the directory of the source file.
+# e.g., /path/to/repo/config/macbook-only/shell
+SOURCE_DIR=$(dirname "$SOURCE_PATH")
 
-# Aider
-aid-set() {
-  export OLLAMA_API_BASE="$1"
-}
-aid-lch() {
-  aider --model "ollama/$1" --no-auto-commit --no-gitignore
-}
+# The REPO_ROOT is three directories up from this script's original location.
+# e.g., from /path/to/repo/config/macbook-only/shell
+REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
 
-# Ruby
-alias be="bundle exec"
-alias be-f="bundle exec fastlane"
-alias bi="bundle install"
+# Source the common .zshrc from the repository.
+COMMON_ZSHRC="$REPO_ROOT/config/common/shell/.zshrc"
+if [ -f "$COMMON_ZSHRC" ]; then
+  source "$COMMON_ZSHRC"
+else
+  echo "Error: Common .zshrc not found at $COMMON_ZSHRC" >&2
+fi
 
-# Node.js
-alias ni="npm install"
-alias nr="npm run"
-
-# Docker
-alias doc="docker"
-alias doc-b="docker build"
-alias doc-r="docker run"
-alias doc-i="docker images"
-alias doc-ps="docker ps"
-alias doc-st="docker stop"
-alias doc-rm="docker rm"
-
-# Mint
-alias mr="mint run"
-
-# Makefile
-alias mk="make"
-
-# AppleScript
-alias as="osascript"
-
-# Utility
-alias rel="source ~/.zshrc"
-alias gi="git"
-alias cl="clear"
-alias op="open"
-alias op-f="open ."
-alias op-s="open -b com.apple.systempreferences"
-alias op-st="open -a 'Stickies'"
-alias op-o="open -a 'Obsidian'"
-alias op-as="open -a 'Android Studio'"
-alias op-a="open -a 'Automator'"
-alias op-sc="open -a 'Script Editor'"
-alias op-t="open -na Terminal"
-alias op-c="open -a 'Google Chrome'"
-alias op-cg="open -a 'Google Chrome' 'https://github.com/akitorahayashi'"
-alias op-cj="open -a 'Google Chrome' 'https://jules.google.com/task'"
-
-md2pdf() {
-  if ! command -v pandoc >/dev/null 2>&1; then
-    echo "Error: pandoc is not installed." >&2
-    return 1
-  fi
-  if ! command -v lualatex >/dev/null 2>&1; then
-    echo "Error: lualatex (TeX Live) is not installed." >&2
-    return 1
-  fi
-  pandoc "$1" -o "$2" --pdf-engine=lualatex \
-    -V documentclass=ltjarticle \
-    -V mainfont="Hiragino Mincho ProN" \
-    -V sansfont="Hiragino Sans" \
-    -V monofont="Hiragino Kaku Gothic ProN" \
-    -V geometry:a4paper \
-    -V geometry:margin=2.5cm
-}
+# Add any machine-specific zshrc settings below this line.
+# Example: alias myalias="echo 'hello'"

--- a/config/macbook-only/shell/.zshrc
+++ b/config/macbook-only/shell/.zshrc
@@ -1,23 +1,17 @@
 # This file is for machine-specific settings.
 # It sources the common .zshrc file.
 
-# When sourced, Zsh sets ${(%):-%N} to the path of the script.
-# This works even for symlinks.
-SOURCE_PATH=${(%):-%N}
-
-# If it's a symlink, resolve it to the actual file path in the repo.
-# $HOME/.zshrc -> /path/to/repo/config/macbook-only/shell/.zshrc
-if [[ -L "$SOURCE_PATH" ]]; then
-  SOURCE_PATH=$(readlink "$SOURCE_PATH")
-fi
+# When sourced, Zsh sets ${(%):-%N} to the path of the script (zsh).
+# :A で絶対パス化+リンク解決
+SOURCE_PATH=${(%):-%N:A}
 
 # Get the directory of the source file.
 # e.g., /path/to/repo/config/macbook-only/shell
-SOURCE_DIR=$(dirname "$SOURCE_PATH")
+SOURCE_DIR=${SOURCE_PATH:h}
 
 # The REPO_ROOT is three directories up from this script's original location.
 # e.g., from /path/to/repo/config/macbook-only/shell
-REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
+REPO_ROOT="${SOURCE_DIR:h:h:h}"
 
 # Source the common .zshrc from the repository.
 COMMON_ZSHRC="$REPO_ROOT/config/common/shell/.zshrc"
@@ -29,7 +23,11 @@ if [[ -f "$COMMON_ZSHRC" ]]; then
   fi
 else
   print -ru2 -- "Error: Common .zshrc not found at $COMMON_ZSHRC"
+  return 1
 fi
 
 # Add any machine-specific zshrc settings below this line.
 # Example: alias myalias="echo 'hello'"
+
+# Clean up temporary variables.
+unset SOURCE_PATH SOURCE_DIR COMMON_ZSHRC

--- a/config/macbook-only/shell/.zshrc
+++ b/config/macbook-only/shell/.zshrc
@@ -21,10 +21,14 @@ REPO_ROOT=$(cd "$SOURCE_DIR/../../.."; pwd)
 
 # Source the common .zshrc from the repository.
 COMMON_ZSHRC="$REPO_ROOT/config/common/shell/.zshrc"
-if [ -f "$COMMON_ZSHRC" ]; then
-  source "$COMMON_ZSHRC"
+if [[ -f "$COMMON_ZSHRC" ]]; then
+  # Avoid double-loading when re-sourcing .zshrc.
+  if [[ -z "${__ENV_COMMON_ZSHRC_SOURCED-}" ]]; then
+    typeset -g __ENV_COMMON_ZSHRC_SOURCED=1
+    source "$COMMON_ZSHRC"
+  fi
 else
-  echo "Error: Common .zshrc not found at $COMMON_ZSHRC" >&2
+  print -ru2 -- "Error: Common .zshrc not found at $COMMON_ZSHRC"
 fi
 
 # Add any machine-specific zshrc settings below this line.


### PR DESCRIPTION
`macbook-only` と `mac-mini-only` で重複していた `.zprofile` と `.zshrc` の設定を `config/common/shell` に抽出し、共通化しました。

これにより、設定のメンテナンス性が向上します。

各マシン固有の設定ファイルは、新しく作成された共通ファイルを `source` するように変更されています。また、シンボリックリンクで配置された場合でもリポジトリルートを動的に解決するロジックを追加し、堅牢性を高めています。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * macOS向けの共通シェル初期化を追加し、Homebrew/Android/Java/NVM/pyenv/rbenv/Ollama/FVM等を存在時に自動設定して利用しやすくしました。
  * シェル関数 md2pdf（依存チェック付き）、aid-set、aid-lch と多数の便利なエイリアスを追加。

* **リファクタ**
  * 個別マシンの初期化を共通設定の読み込みに統合。リポジトリルート検出と、共通設定が無い場合の明確なエラーメッセージを導入し重複を削減。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->