### PR TITLE
shellのREPO_ROOTの読み込みを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 # Editor-specific files
 .vscode/
+.cursor/
 .aider*
 *.swp
 *.swo
@@ -13,9 +14,6 @@
 
 # Log files
 *.log
-
-# Cursor
-.cursor/
 
 # Environment variables
 .env

--- a/config/mac-mini-only/shell/.zprofile
+++ b/config/mac-mini-only/shell/.zprofile
@@ -1,17 +1,21 @@
 # This file is for machine-specific settings.
 # It sources the common .zprofile file.
 
-# When sourced, Zsh sets ${(%):-%N} to the path of the script (zsh).
-# :A で絶対パス化+リンク解決
-SOURCE_PATH=${(%):-%N:A}
+# If REPO_ROOT is not set, determine it from the script's location.
+if [ -z "$REPO_ROOT" ]; then
+  # When sourced, Zsh sets ${(%):-%x} to the path of the sourced script.
+  # :A resolves the absolute path, including any symlinks.
+  SOURCE_PATH=${(%):-%x:A}
 
-# Get the directory of the source file.
-# e.g., /path/to/repo/config/mac-mini-only/shell
-SOURCE_DIR=${SOURCE_PATH:h}
+  # Get the directory of the source file.
+  # e.g., /path/to/repo/config/mac-mini-only/shell
+  SOURCE_DIR=${SOURCE_PATH:h}
 
-# The REPO_ROOT is three directories up from this script's original location.
-# e.g., from /path/to/repo/config/mac-mini-only/shell
-export REPO_ROOT="${SOURCE_DIR:h:h:h}"
+  # The REPO_ROOT is three directories up from this script's original location.
+  # e.g., from /path/to/repo/config/mac-mini-only/shell
+  export REPO_ROOT="${SOURCE_DIR:h:h:h}"
+fi
+
 
 # Source the common .zprofile from the repository.
 COMMON_ZPROFILE="$REPO_ROOT/config/common/shell/.zprofile"

--- a/config/mac-mini-only/shell/.zshrc
+++ b/config/mac-mini-only/shell/.zshrc
@@ -1,17 +1,20 @@
 # This file is for machine-specific settings.
 # It sources the common .zshrc file.
 
-# When sourced, Zsh sets ${(%):-%N} to the path of the script (zsh).
-# :A で絶対パス化+リンク解決
-SOURCE_PATH=${(%):-%N:A}
+# If REPO_ROOT is not set, determine it from the script's location.
+if [ -z "$REPO_ROOT" ]; then
+    # When sourced, Zsh sets ${(%):-%x} to the path of the sourced script.
+    # :A resolves the absolute path, including any symlinks.
+    SOURCE_PATH=${(%):-%x:A}
 
-# Get the directory of the source file.
-# e.g., /path/to/repo/config/mac-mini-only/shell
-SOURCE_DIR=${SOURCE_PATH:h}
+    # Get the directory of the source file.
+    # e.g., /path/to/repo/config/mac-mini-only/shell
+    SOURCE_DIR=${SOURCE_PATH:h}
 
-# The REPO_ROOT is three directories up from this script's original location.
-# e.g., from /path/to/repo/config/mac-mini-only/shell
-REPO_ROOT="${SOURCE_DIR:h:h:h}"
+    # The REPO_ROOT is three directories up from this script's original location.
+    # e.g., from /path/to/repo/config/mac-mini-only/shell
+    export REPO_ROOT="${SOURCE_DIR:h:h:h}"
+fi
 
 # Source the common .zshrc from the repository.
 COMMON_ZSHRC="$REPO_ROOT/config/common/shell/.zshrc"

--- a/config/macbook-only/shell/.zprofile
+++ b/config/macbook-only/shell/.zprofile
@@ -1,17 +1,21 @@
 # This file is for machine-specific settings.
 # It sources the common .zprofile file.
 
-# When sourced, Zsh sets ${(%):-%N} to the path of the script (zsh).
-# :A で絶対パス化+リンク解決
-SOURCE_PATH=${(%):-%N:A}
+# If REPO_ROOT is not set, determine it from the script's location.
+if [ -z "$REPO_ROOT" ]; then
+  # When sourced, Zsh sets ${(%):-%x} to the path of the sourced script.
+  # :A resolves the absolute path, including any symlinks.
+  SOURCE_PATH=${(%):-%x:A}
 
-# Get the directory of the source file.
-# e.g., /path/to/repo/config/macbook-only/shell
-SOURCE_DIR=${SOURCE_PATH:h}
+  # Get the directory of the source file.
+  # e.g., /path/to/repo/config/macbook-only/shell
+  SOURCE_DIR=${SOURCE_PATH:h}
 
-# The REPO_ROOT is three directories up from this script's original location.
-# e.g., from /path/to/repo/config/macbook-only/shell
-export REPO_ROOT="${SOURCE_DIR:h:h:h}"
+  # The REPO_ROOT is three directories up from this script's original location.
+  # e.g., from /path/to/repo/config/macbook-only/shell
+  export REPO_ROOT="${SOURCE_DIR:h:h:h}"
+fi
+
 
 # Source the common .zprofile from the repository.
 COMMON_ZPROFILE="$REPO_ROOT/config/common/shell/.zprofile"

--- a/config/macbook-only/shell/.zshrc
+++ b/config/macbook-only/shell/.zshrc
@@ -1,17 +1,20 @@
 # This file is for machine-specific settings.
 # It sources the common .zshrc file.
 
-# When sourced, Zsh sets ${(%):-%N} to the path of the script (zsh).
-# :A で絶対パス化+リンク解決
-SOURCE_PATH=${(%):-%N:A}
+# If REPO_ROOT is not set, determine it from the script's location.
+if [ -z "$REPO_ROOT" ]; then
+    # When sourced, Zsh sets ${(%):-%x} to the path of the sourced script.
+    # :A resolves the absolute path, including any symlinks.
+    SOURCE_PATH=${(%):-%x:A}
 
-# Get the directory of the source file.
-# e.g., /path/to/repo/config/macbook-only/shell
-SOURCE_DIR=${SOURCE_PATH:h}
+    # Get the directory of the source file.
+    # e.g., /path/to/repo/config/macbook-only/shell
+    SOURCE_DIR=${SOURCE_PATH:h}
 
-# The REPO_ROOT is three directories up from this script's original location.
-# e.g., from /path/to/repo/config/macbook-only/shell
-REPO_ROOT="${SOURCE_DIR:h:h:h}"
+    # The REPO_ROOT is three directories up from this script's original location.
+    # e.g., from /path/to/repo/config/macbook-only/shell
+    export REPO_ROOT="${SOURCE_DIR:h:h:h}"
+fi
 
 # Source the common .zshrc from the repository.
 COMMON_ZSHRC="$REPO_ROOT/config/common/shell/.zshrc"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - mac向けシェル初期化を見直し、リポジトリルート関連の環境設定を未設定時のみ計算・エクスポート。共通設定の読み込みに一度きりのガードと存在チェックを追加し、欠如時は明確なエラーを表示。外部で設定済みの値は尊重し、一時変数のクリーンアップも維持して安定性とトラブルシュート性を向上。
- Chores
  - .cursor の無視設定をエディタ関連ブロックへ統合し、重複を解消。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->