### PR TITLE
fix: git.shからSSH関連の処理を削除

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
+# ==============================================================================
 # Makefile for macOS Environment Setup
+# ==============================================================================
 
-# Shell settings: exit on error, undefined variable, or pipe failure
+# ------------------------------------------------------------------------------
+# Shell and Environment Configuration
+# ------------------------------------------------------------------------------
 SHELL := /bin/bash
 .SHELLFLAGS := -euo pipefail -c
 
-# Define project root and script/config directories
 REPO_ROOT := $(CURDIR)
 export REPO_ROOT
 SCRIPT_DIR := $(REPO_ROOT)/scripts
@@ -12,133 +15,207 @@ CONFIG_DIR_COMMON := config/common
 CONFIG_DIR_MACBOOK := config/macbook-only
 CONFIG_DIR_MAC_MINI := config/mac-mini-only
 
-# Default target
+# ------------------------------------------------------------------------------
+# User-Facing Commands
+# ------------------------------------------------------------------------------
 .DEFAULT_GOAL := help
 
-# Help command to display available targets
 .PHONY: help
 help: ## Show this help message
 	@echo "Usage: make [target]"
 	@echo ""
 	@echo "Available targets:"
-	@awk 'BEGIN {FS=":.*## ";} /^[A-Za-z0-9_-]+:.*## / {printf "%-30s %s\n", $1, $2}' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS=":.*## ";} /^[a-zA-Z0-9_-]+:.*##/ && !/## @/ {printf "%-25s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-# Main setup targets
-.PHONY: all
-all: common ## Run all setup scripts with common configuration
-
-.PHONY: common
-common: ## Synchronize all common tools and configurations
-	@echo "🚀 Synchronizing common tools..."
-	@$(MAKE) brew CONFIG_DIR=$(CONFIG_DIR_COMMON)
-	@$(MAKE) git CONFIG_DIR=$(CONFIG_DIR_COMMON)
-	@$(MAKE) vscode CONFIG_DIR=$(CONFIG_DIR_COMMON)
-	@$(MAKE) ruby CONFIG_DIR=$(CONFIG_DIR_COMMON)
-	@$(MAKE) python CONFIG_DIR=$(CONFIG_DIR_COMMON)
-	@$(MAKE) java CONFIG_DIR=$(CONFIG_DIR_COMMON)
-	@$(MAKE) flutter CONFIG_DIR=$(CONFIG_DIR_COMMON)
-	@$(MAKE) node CONFIG_DIR=$(CONFIG_DIR_COMMON)
-	@$(MAKE) apply-defaults CONFIG_DIR=$(CONFIG_DIR_COMMON)
-	@echo "✅ All common setup completed successfully."
-
-.PHONY: macbook-only
-macbook-only: ## Run setup for MacBook only configurations
-	@echo "🚀 Setting up for MacBook only..."
-	@$(MAKE) brew CONFIG_DIR=$(CONFIG_DIR_MACBOOK)
-	@$(MAKE) link-shell CONFIG_DIR=$(CONFIG_DIR_MACBOOK)
-	@echo "✅ MacBook only setup completed successfully."
-
-.PHONY: mac-mini-only
-mac-mini-only: ## Run setup for Mac mini only configurations
-	@echo "🚀 Setting up for Mac mini only..."
-	@$(MAKE) brew CONFIG_DIR=$(CONFIG_DIR_MAC_MINI)
-	@$(MAKE) link-shell CONFIG_DIR=$(CONFIG_DIR_MAC_MINI)
-	@echo "✅ Mac mini only setup completed successfully."
-
+# --- Main Setup Targets ---
 .PHONY: macbook
-macbook: common macbook-only ## Setup for MacBook (common + specific)
+macbook: macbook-brew macbook-git macbook-vscode macbook-ruby macbook-python macbook-java macbook-flutter macbook-node macbook-shell macbook-defaults ## Setup for MacBook (common + specific)
 	@echo "✅ MacBook full setup completed successfully."
 
 .PHONY: mac-mini
-mac-mini: common mac-mini-only ## Setup for Mac mini (common + specific)
+mac-mini: mac-mini-brew mac-mini-git mac-mini-vscode mac-mini-ruby mac-mini-python mac-mini-java mac-mini-flutter mac-mini-node mac-mini-shell mac-mini-defaults ## Setup for Mac mini (common + specific)
 	@echo "✅ Mac mini full setup completed successfully."
 
-# Individual setup targets
+# --- Individual Setup Targets for MacBook ---
+.PHONY: macbook-brew
+macbook-brew: ## [MacBook] Setup Homebrew and install packages
+	@echo "🚀 [MacBook] Running Homebrew setup..."
+	@$(MAKE) brew CONFIG_DIR=$(CONFIG_DIR_COMMON)
+	@$(MAKE) brew CONFIG_DIR=$(CONFIG_DIR_MACBOOK)
+
+.PHONY: macbook-git
+macbook-git: ## [MacBook] Configure Git settings
+	@echo "🚀 [MacBook] Running Git setup..."
+	@$(MAKE) git CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: macbook-vscode
+macbook-vscode: ## [MacBook] Setup VS Code settings and extensions
+	@echo "🚀 [MacBook] Running VS Code setup..."
+	@$(MAKE) vscode CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: macbook-ruby
+macbook-ruby: ## [MacBook] Setup Ruby environment with rbenv
+	@echo "🚀 [MacBook] Running Ruby setup..."
+	@$(MAKE) ruby CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: macbook-python
+macbook-python: ## [MacBook] Setup Python environment with pyenv
+	@echo "🚀 [MacBook] Running Python setup..."
+	@$(MAKE) python CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: macbook-java
+macbook-java: ## [MacBook] Setup Java environment
+	@echo "🚀 [MacBook] Running Java setup..."
+	@$(MAKE) java CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: macbook-flutter
+macbook-flutter: ## [MacBook] Setup Flutter environment
+	@echo "🚀 [MacBook] Running Flutter setup..."
+	@$(MAKE) flutter CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: macbook-node
+macbook-node: ## [MacBook] Setup Node.js environment with nvm
+	@echo "🚀 [MacBook] Running Node.js setup..."
+	@$(MAKE) node CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: macbook-shell
+macbook-shell: ## [MacBook] Link shell configuration files
+	@echo "🚀 [MacBook] Linking shell configuration..."
+	@$(MAKE) link-shell CONFIG_DIR=$(CONFIG_DIR_COMMON)
+	@$(MAKE) link-shell CONFIG_DIR=$(CONFIG_DIR_MACBOOK)
+
+.PHONY: macbook-defaults
+macbook-defaults: ## [MacBook] Apply macOS system defaults
+	@echo "🚀 [MacBook] Applying system defaults..."
+	@$(MAKE) apply-defaults CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+# --- Individual Setup Targets for Mac mini ---
+.PHONY: mac-mini-brew
+mac-mini-brew: ## [Mac mini] Setup Homebrew and install packages
+	@echo "🚀 [Mac mini] Running Homebrew setup..."
+	@$(MAKE) brew CONFIG_DIR=$(CONFIG_DIR_COMMON)
+	@$(MAKE) brew CONFIG_DIR=$(CONFIG_DIR_MAC_MINI)
+
+.PHONY: mac-mini-git
+mac-mini-git: ## [Mac mini] Configure Git settings
+	@echo "🚀 [Mac mini] Running Git setup..."
+	@$(MAKE) git CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: mac-mini-vscode
+mac-mini-vscode: ## [Mac mini] Setup VS Code settings and extensions
+	@echo "🚀 [Mac mini] Running VS Code setup..."
+	@$(MAKE) vscode CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: mac-mini-ruby
+mac-mini-ruby: ## [Mac mini] Setup Ruby environment with rbenv
+	@echo "🚀 [Mac mini] Running Ruby setup..."
+	@$(MAKE) ruby CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: mac-mini-python
+mac-mini-python: ## [Mac mini] Setup Python environment with pyenv
+	@echo "🚀 [Mac mini] Running Python setup..."
+	@$(MAKE) python CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: mac-mini-java
+mac-mini-java: ## [Mac mini] Setup Java environment
+	@echo "🚀 [Mac mini] Running Java setup..."
+	@$(MAKE) java CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: mac-mini-flutter
+mac-mini-flutter: ## [Mac mini] Setup Flutter environment
+	@echo "🚀 [Mac mini] Running Flutter setup..."
+	@$(MAKE) flutter CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: mac-mini-node
+mac-mini-node: ## [Mac mini] Setup Node.js environment with nvm
+	@echo "🚀 [Mac mini] Running Node.js setup..."
+	@$(MAKE) node CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+.PHONY: mac-mini-shell
+mac-mini-shell: ## [Mac mini] Link shell configuration files
+	@echo "🚀 [Mac mini] Linking shell configuration..."
+	@$(MAKE) link-shell CONFIG_DIR=$(CONFIG_DIR_COMMON)
+	@$(MAKE) link-shell CONFIG_DIR=$(CONFIG_DIR_MAC_MINI)
+
+.PHONY: mac-mini-defaults
+mac-mini-defaults: ## [Mac mini] Apply macOS system defaults
+	@echo "🚀 [Mac mini] Applying system defaults..."
+	@$(MAKE) apply-defaults CONFIG_DIR=$(CONFIG_DIR_COMMON)
+
+# --- Other User-Facing Commands ---
+.PHONY: backup-defaults
+backup-defaults: ## Backup current macOS system defaults
+	@echo "🚀 Backing up current macOS system defaults..."
+	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/system-defaults/backup-system-defaults.sh" "config/common"
+	@echo "✅ macOS system defaults backup completed."
+
+# ------------------------------------------------------------------------------
+# Internal (Hidden) Commands - Do not run directly
+# ------------------------------------------------------------------------------
 .PHONY: brew
-brew: ## Setup Homebrew and install packages from Brewfile
-	@echo "🚀 Running Homebrew setup with config: $(CONFIG_DIR)"
+brew: ## @hidden
+	@echo "  -> Running Homebrew setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/homebrew.sh" "$(CONFIG_DIR)"
 
 .PHONY: git
-git: ## Configure Git settings
-	@echo "🚀 Running Git setup with config: $(CONFIG_DIR)"
+git: ## @hidden
+	@echo "  -> Running Git setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/git.sh" "$(CONFIG_DIR)"
 
 .PHONY: vscode
-vscode: ## Setup VS Code settings and extensions
-	@echo "🚀 Running VS Code setup with config: $(CONFIG_DIR)"
+vscode: ## @hidden
+	@echo "  -> Running VS Code setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/vscode.sh" "$(CONFIG_DIR)"
 
 .PHONY: ruby
-ruby: ## Setup Ruby environment with rbenv
-	@echo "🚀 Running Ruby setup with config: $(CONFIG_DIR)"
+ruby: ## @hidden
+	@echo "  -> Running Ruby setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/ruby.sh" "$(CONFIG_DIR)"
 
 .PHONY: python
-python: ## Setup Python environment with pyenv
-	@$(MAKE) python-platform CONFIG_DIR=$(CONFIG_DIR)
-	@$(MAKE) python-tools CONFIG_DIR=$(CONFIG_DIR)
-	@echo "✅ Python setup completed successfully."
+python: python-platform python-tools ## @hidden
+	@echo "  -> Python setup completed for config: $(CONFIG_DIR)"
 
 .PHONY: python-platform
-python-platform: ## Setup Python platform (pyenv, python, pipx)
-	@echo "🚀 Running Python platform setup with config: $(CONFIG_DIR)"
+python-platform: ## @hidden
+	@echo "  -> Running Python platform setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/python/platform.sh" "$(CONFIG_DIR)"
 
 .PHONY: python-tools
-python-tools: ## Install global Python tools
-	@echo "🚀 Running Python tools setup with config: $(CONFIG_DIR)"
+python-tools: ## @hidden
+	@echo "  -> Running Python tools setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/python/tools.sh" "$(CONFIG_DIR)"
 
 .PHONY: java
-java: ## Setup Java environment
-	@echo "🚀 Running Java setup with config: $(CONFIG_DIR)"
+java: ## @hidden
+	@echo "  -> Running Java setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/java.sh" "$(CONFIG_DIR)"
 
 .PHONY: flutter
-flutter: ## Setup Flutter environment
-	@echo "🚀 Running Flutter setup with config: $(CONFIG_DIR)"
+flutter: ## @hidden
+	@echo "  -> Running Flutter setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/flutter.sh" "$(CONFIG_DIR)"
 
 .PHONY: node
-node: ## Setup Node.js environment with nvm
-	@$(MAKE) node-platform CONFIG_DIR=$(CONFIG_DIR)
-	@$(MAKE) node-packages CONFIG_DIR=$(CONFIG_DIR)
-	@echo "✅ Node.js setup completed successfully."
+node: node-platform node-packages ## @hidden
+	@echo "  -> Node.js setup completed for config: $(CONFIG_DIR)"
 
 .PHONY: node-platform
-node-platform: ## Setup Node.js platform (nvm, node)
-	@echo "🚀 Running Node.js platform setup with config: $(CONFIG_DIR)"
+node-platform: ## @hidden
+	@echo "  -> Running Node.js platform setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/node/platform.sh" "$(CONFIG_DIR)"
 
 .PHONY: node-packages
-node-packages: ## Install global Node.js packages
-	@echo "🚀 Running Node.js packages setup with config: $(CONFIG_DIR)"
+node-packages: ## @hidden
+	@echo "  -> Running Node.js packages setup with config: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/node/packages.sh" "$(CONFIG_DIR)"
 
 .PHONY: link-shell
-link-shell: ## Create symbolic links for shell configuration files
-	@echo "🚀 Creating symbolic links for shell configuration files with config: $(CONFIG_DIR)"
+link-shell: ## @hidden
+	@echo "  -> Linking shell configuration files from: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/link-shell.sh" "$(CONFIG_DIR)"
 
-
 .PHONY: apply-defaults
-apply-defaults: ## Apply macOS system defaults
-	@echo "🚀 Applying macOS system defaults with config: $(CONFIG_DIR)"
+apply-defaults: ## @hidden
+	@echo "  -> Applying macOS system defaults from: $(CONFIG_DIR)"
 	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/system-defaults/apply-system-defaults.sh" "$(CONFIG_DIR)"
-
-.PHONY: backup-defaults
-backup-defaults: ## Backup current macOS system defaults
-	@echo "🚀 Backing up current macOS system defaults with config: $(CONFIG_DIR)"
-	@$(SHELL) -euo pipefail "$(SCRIPT_DIR)/system-defaults/backup-system-defaults.sh" "$(CONFIG_DIR)"
-	@echo "✅ macOS system defaults backup completed."

--- a/README.md
+++ b/README.md
@@ -103,42 +103,7 @@
     xcode-select --install
     ```
 
-2.  **SSH鍵の生成とGitHubへの登録**
-
-    SSH鍵がまだない場合は生成します。
-
-    ```sh
-    # メールアドレスを自分のものに置き換えてください
-    ssh-keygen -t ed25519 -C "your_email@example.com"
-
-    # macOS で SSH エージェントとキーチェーンへ登録（再起動後も保持）
-    eval "$(ssh-agent -s)"
-    /usr/bin/ssh-add --apple-use-keychain ~/.ssh/id_ed25519
-    # 必要に応じて ~/.ssh/config を作成
-    cat <<'EOF' >> ~/.ssh/config
-    Host github.com
-        AddKeysToAgent yes
-        UseKeychain yes
-        IdentityFile ~/.ssh/id_ed25519
-    EOF
-    ```
-
-    生成された公開鍵 (`~/.ssh/id_ed25519.pub`) をコピーし、[GitHubのSSHキー設定ページ](https://github.com/settings/keys)に追加します。
-
-    ```sh
-    # 公開鍵をクリップボードにコピー
-    pbcopy < ~/.ssh/id_ed25519.pub
-    ```
-
-    以下のコマンドでGitHubへの接続をテストします。
-
-    ```sh
-    ssh -T git@github.com
-    ```
-
-    "successfully authenticated" というメッセージが表示されれば成功です。
-
-3.  **Gitの個人設定 (`.env`ファイル作成)**
+2.  **Gitの個人設定 (`.env`ファイル作成)**
 
     リポジトリのルートにある`.env.example`をコピーして`.env`ファイルを作成します。
     その後、`.env`ファイル内の`GIT_USERNAME`と`GIT_EMAIL`をご自身のものに編集してください。
@@ -149,7 +114,7 @@
     ```
     この`.env`ファイルは、次のステップで実行される `make macbook` または `make git` によって自動的に読み込まれ、Gitのグローバル設定に反映されます。
 
-4.  **各種ツールとパッケージのインストール**
+3.  **各種ツールとパッケージのインストール**
 
     お使いのMacに合わせて、以下のいずれかのコマンドを実行してください。
 
@@ -164,7 +129,7 @@
     ```
     このコマンドは、Homebrew、Git、Ruby、Python、Node.jsなど、開発に必要なツールを一括でインストールし、macOSとシェルの設定も適用します。
 
-5.  **GitHub CLIの認証**
+4.  **GitHub CLIの認証**
 
     `make macbook` または `make mac-mini` でGitHub CLI (`gh`) がインストールされた後、以下のコマンドで認証を行ってください。
 
@@ -176,6 +141,6 @@
     gh auth login --hostname your-enterprise-hostname.com
     ```
 
-6.  **macOSの再起動**
+5.  **macOSの再起動**
 
     すべての設定を完全に適用するために、macOSを再起動してください。

--- a/scripts/git.sh
+++ b/scripts/git.sh
@@ -96,35 +96,6 @@ echo "[SUCCESS] Git の core.excludesfile に global gitignore を設定しま�
 
 echo "[SUCCESS] gitignore_global の設定完了"
 
-# SSH エージェントとキーの確認
-echo ""
-echo "==== Start: SSH エージェントとキーの確認中... ===="
-
-# SSH キーが存在するかチェック
-if [[ -f "$HOME/.ssh/id_ed25519" ]]; then
-    echo "[SUCCESS] SSH キー (id_ed25519) が存在します"
-
-    # SSH エージェントが既に動いているかチェック
-    if ! ssh-add -l >/dev/null 2>&1; then
-        echo "[INFO] SSH エージェントを起動中..."
-        eval "$(ssh-agent -s)"
-    else
-        echo "[INFO] SSH エージェントは既に動作中です"
-    fi
-
-    # SSH キーをエージェントに追加
-    echo "[INFO] SSH キーを SSH エージェントに追加中..."
-    if ssh-add "$HOME/.ssh/id_ed25519"; then
-        echo "[SUCCESS] SSH キーが正常に追加されました"
-    else
-        echo "[WARN] SSH キーの追加に失敗しました。手動でパスフレーズを入力する必要があります"
-    fi
-else
-    echo "[WARN] SSH キー (id_ed25519) が見つかりません"
-    echo "[INFO] 手動でSSHキーを生成してください："
-    echo "[INFO] ssh-keygen -t ed25519 -C \"your_email@example.com\""
-fi
-
 echo "[SUCCESS] Git環境のセットアップが完了しました"
 
 # Git設定の検証
@@ -142,12 +113,6 @@ echo "[SUCCESS] gitコマンドが使用可能です: $(git --version)"
 # 設定ファイルの存在確認
 echo "[SUCCESS] $HOME/.config/git/config が存在します。"
 
-# SSHキーの検証
-if [ -f "$HOME/.ssh/id_ed25519" ]; then
-    echo "[SUCCESS] SSH鍵ファイル(id_ed25519)が存在します"
-else
-    echo "[WARN] SSH鍵ファイル(id_ed25519)が見つかりません"
-fi
 
 # gitignore_global の検証
 ignore_file="$HOME/.gitignore_global"


### PR DESCRIPTION
`scripts/git.sh` から、SSHエージェントの確認とSSHキーの検証に関連する処理を削除しました。

これらの処理は現在のセットアップフローでは不要であり、スクリプトを簡素化するために削除されました。