### PR TITLE
refactor(config): Move gemini-cli to common node tools

### DIFF
--- a/config/common/node/global-packages.json
+++ b/config/common/node/global-packages.json
@@ -1,5 +1,6 @@
 {
     "globalPackages": {
-        "npm": "latest"
+        "npm": "latest",
+        "@google/gemini-cli": "latest"
     }
 }

--- a/config/macbook-only/node/global-packages.json
+++ b/config/macbook-only/node/global-packages.json
@@ -1,5 +1,3 @@
 {
-    "globalPackages": {
-        "@google/gemini-cli": "latest"
-    }
+    "globalPackages": {}
 }


### PR DESCRIPTION
Moves the `@google/gemini-cli` package from the `macbook-only` node configuration to the `common` node configuration.

This makes the `gemini-cli` tool available in all environments, not just on MacBooks. The installation is handled by the existing `make node-tools` target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新機能
  - 共通設定で Gemini CLI をグローバルインストール対象に追加（最新バージョン）。
- 雑務
  - MacBook 限定設定から Gemini CLI のグローバル管理を解除（空定義に変更）。
  - 共通設定を利用する環境で Gemini CLI が即時利用可能に。MacBook 限定設定では個別管理が必要。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->