### PR TITLE
Add comments to macOS system default settings YAML files. This change…

### DIFF
--- a/config/common/system-defaults/backup-definitions/desktop.yml
+++ b/config/common/system-defaults/backup-definitions/desktop.yml
@@ -1,12 +1,13 @@
 ---
+# Shows or hides icons for external hard drives on the desktop.
 - key: ShowExternalHardDrivesOnDesktop
   domain: com.apple.finder
   type: bool
   default: true
   comment: "Desktop"
 
+# Enables or disables the "Click wallpaper to reveal desktop" feature.
 - key: EnableStandardClickToShowDesktop
   domain: com.apple.WindowManager
   type: bool
   default: true
-

--- a/config/common/system-defaults/backup-definitions/dock.yml
+++ b/config/common/system-defaults/backup-definitions/dock.yml
@@ -1,60 +1,72 @@
 ---
+# Sets the size of the icons in the Dock (in pixels).
 - key: tilesize
   domain: com.apple.dock
   type: int
   default: 50
   comment: "Dock"
 
+# Enables or disables the auto-hiding feature of the Dock.
 - key: autohide
   domain: com.apple.dock
   type: bool
   default: true
 
+# Controls the speed of the Dock's auto-hide animation.
 - key: autohide-time-modifier
   domain: com.apple.dock
   type: float
   default: 0.5
 
+# Sets the delay before the Dock appears when auto-hide is enabled.
 - key: autohide-delay
   domain: com.apple.dock
   type: float
   default: 0
 
+# Shows or hides recent applications in the Dock.
 - key: show-recents
   domain: com.apple.dock
   type: bool
   default: false
 
+# Sets the animation effect used when minimizing windows.
 - key: mineffect
   domain: com.apple.dock
   type: string
   default: "genie"
 
+# When enabled, minimizes windows into their application icon in the Dock.
 - key: minimize-to-application
   domain: com.apple.dock
   type: bool
   default: false
 
+# When enabled, prevents icons from being added or removed from the Dock.
 - key: static-only
   domain: com.apple.dock
   type: bool
   default: false
 
+# Allows opening items in the Dock by scrolling over them.
 - key: scroll-to-open
   domain: com.apple.dock
   type: bool
   default: false
 
+# Enables or disables the animation for launching applications from the Dock.
 - key: launchanim
   domain: com.apple.dock
   type: bool
   default: false
 
+# Shows or hides hidden application icons in the Dock.
 - key: showhidden
   domain: com.apple.dock
   type: bool
   default: false
 
+# Disables the bouncing animation of app icons in the Dock.
 - key: no-bouncing
   domain: com.apple.dock
   type: bool

--- a/config/common/system-defaults/backup-definitions/finder.yml
+++ b/config/common/system-defaults/backup-definitions/finder.yml
@@ -1,75 +1,90 @@
 ---
+# Shows or hides the path bar in Finder windows.
 - key: ShowPathbar
   domain: com.apple.finder
   type: bool
   default: true
   comment: "Finder"
 
+# Shows or hides the status bar in Finder windows.
 - key: ShowStatusBar
   domain: com.apple.finder
   type: bool
   default: false
 
+# Shows or hides hidden files in Finder.
 - key: AppleShowAllFiles
   domain: com.apple.finder
   type: bool
   default: true
 
+# Shows or hides all file extensions in Finder.
 - key: AppleShowAllExtensions
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Shows the full POSIX path in the Finder window's title bar.
 - key: _FXShowPosixPathInTitle
   domain: com.apple.finder
   type: bool
   default: false
 
+# Sets the default view style for Finder windows. (e.g., "icnv" for icons, "clmv" for columns, "Nlsv" for list)
 - key: FXPreferredViewStyle
   domain: com.apple.finder
   type: string
   default: "icnv"
 
+# Sorts folders before files in Finder windows.
 - key: _FXSortFoldersFirst
   domain: com.apple.finder
   type: bool
   default: true
 
+# Sets the default search scope in Finder. ("SCev" for "Search This Mac", "SCcf" for "Search the Current Folder")
 - key: FXDefaultSearchScope
   domain: com.apple.finder
   type: string
   default: "SCev"
 
+# Enables or disables the warning when changing a file's extension.
 - key: FXEnableExtensionChangeWarning
   domain: com.apple.finder
   type: bool
   default: false
 
+# Enables or disables the warning before emptying the Trash.
 - key: WarnOnEmptyTrash
   domain: com.apple.finder
   type: bool
   default: true
 
+# Automatically removes items from the Trash after 30 days.
 - key: FXRemoveOldTrashItems
   domain: com.apple.finder
   type: bool
   default: true
 
+# Prevents the creation of .DS_Store files on network volumes.
 - key: DSDontWriteNetworkStores
   domain: com.apple.desktopservices
   type: bool
   default: true
 
+# Shows or hides the "Quit Finder" menu item.
 - key: QuitMenuItem
   domain: com.apple.finder
   type: bool
   default: false
 
+# Disables all animations in Finder.
 - key: DisableAllAnimations
   domain: com.apple.finder
   type: bool
   default: false
 
+# Enables or disables spring-loaded folders.
 - key: com.apple.springing.enabled
   domain: NSGlobalDomain
   type: bool

--- a/config/common/system-defaults/backup-definitions/hot_corners.yml
+++ b/config/common/system-defaults/backup-definitions/hot_corners.yml
@@ -1,20 +1,25 @@
 ---
+# Configures the action for the top-left hot corner.
+# 0: No Action, 2: Mission Control, 3: Application Windows, 4: Desktop, 5: Start Screen Saver, 6: Disable Screen Saver, 7: Dashboard, 10: Put Display to Sleep, 11: Launchpad, 12: Notification Center, 13: Lock Screen
 - key: wvous-tl-corner
   domain: com.apple.dock
   type: int
   default: 11
   comment: "Hot Corners"
 
+# Configures the action for the top-right hot corner.
 - key: wvous-tr-corner
   domain: com.apple.dock
   type: int
   default: 5
 
+# Configures the action for the bottom-left hot corner.
 - key: wvous-bl-corner
   domain: com.apple.dock
   type: int
   default: 10
 
+# Configures the action for the bottom-right hot corner.
 - key: wvous-br-corner
   domain: com.apple.dock
   type: int

--- a/config/common/system-defaults/backup-definitions/keyboard.yml
+++ b/config/common/system-defaults/backup-definitions/keyboard.yml
@@ -1,30 +1,36 @@
 ---
+# Sets the key repeat rate. A smaller value means a faster repeat rate.
 - key: KeyRepeat
   domain: NSGlobalDomain
   type: int
   default: 6
   comment: "Keyboard"
 
+# Sets the delay until key repeat begins. A smaller value means a shorter delay.
 - key: InitialKeyRepeat
   domain: NSGlobalDomain
   type: int
   default: 25
 
+# Enables or disables the press-and-hold feature for accented characters.
 - key: ApplePressAndHoldEnabled
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Controls keyboard navigation access for UI controls. (1: Text boxes and lists only, 3: All controls)
 - key: AppleKeyboardUIMode
   domain: NSGlobalDomain
   type: int
   default: 1
 
+# Toggles the behavior of the function keys. (true: Standard function keys, false: Special features)
 - key: com.apple.keyboard.fnState
   domain: NSGlobalDomain
   type: bool
   default: false
 
+# Enables or disables "natural" scrolling.
 - key: com.apple.swipescrolldirection
   domain: NSGlobalDomain
   type: bool

--- a/config/common/system-defaults/backup-definitions/mission_control.yml
+++ b/config/common/system-defaults/backup-definitions/mission_control.yml
@@ -1,25 +1,30 @@
 ---
+# Controls the animation duration for Mission Control.
 - key: expose-animation-duration
   domain: com.apple.dock
   type: float
   default: 0.2
   comment: "Mission Control"
 
+# Automatically rearranges Spaces based on most recent use.
 - key: mru-spaces
   domain: com.apple.dock
   type: bool
   default: true
 
+# Groups windows by application in Mission Control.
 - key: expose-group-by-app
   domain: com.apple.dock
   type: bool
   default: true
 
+# Automatically switches to a Space with open windows for an application.
 - key: workspaces-auto-swoosh
   domain: com.apple.dock
   type: bool
   default: false
 
+# When disabled, fullscreen windows will not create a new space and will instead share a space with other windows.
 - key: spans-displays
   domain: com.apple.spaces
   type: bool

--- a/config/common/system-defaults/backup-definitions/mouse.yml
+++ b/config/common/system-defaults/backup-definitions/mouse.yml
@@ -1,10 +1,12 @@
 ---
+# Sets the mouse tracking speed. A higher value means faster tracking.
 - key: com.apple.mouse.scaling
   domain: .GlobalPreferences
   type: float
   default: 1
   comment: "Mouse"
 
+# Makes the window under the cursor active in Terminal.
 - key: FocusFollowsMouse
   domain: com.apple.Terminal
   type: bool

--- a/config/common/system-defaults/backup-definitions/screenshots.yml
+++ b/config/common/system-defaults/backup-definitions/screenshots.yml
@@ -1,25 +1,30 @@
 ---
+# Sets the default location for saving screenshots.
 - key: location
   domain: com.apple.screencapture
   type: string
   default: "$HOME/Desktop"
   comment: "Screenshots"
 
+# Disables the shadow effect for window screenshots.
 - key: disable-shadow
   domain: com.apple.screencapture
   type: bool
   default: false
 
+# Includes the date in the screenshot filename.
 - key: include-date
   domain: com.apple.screencapture
   type: bool
   default: false
 
+# Shows a thumbnail of the screenshot after taking it.
 - key: show-thumbnail
   domain: com.apple.screencapture
   type: bool
   default: true
 
+# Sets the default file format for screenshots (e.g., png, jpg, gif, tiff, bmp).
 - key: type
   domain: com.apple.screencapture
   type: string

--- a/config/common/system-defaults/backup-definitions/sound.yml
+++ b/config/common/system-defaults/backup-definitions/sound.yml
@@ -1,20 +1,24 @@
 ---
+# Enables or disables user interface sound effects.
 - key: com.apple.sound.uiaudio.enabled
   domain: com.apple.systemsound
   type: int
   default: 0
   comment: "Sound"
 
+# Enables or disables feedback when volume is changed.
 - key: com.apple.sound.beep.feedback
   domain: NSGlobalDomain
   type: int
   default: 0
 
+# Sets the path to the alert sound file.
 - key: com.apple.sound.beep.sound
   domain: NSGlobalDomain
   type: string
   default: "/System/Library/Sounds/Boop.aiff"
 
+# Sets the minimum bitpool for Bluetooth audio, affecting quality and stability.
 - key: "Apple Bitpool Min (editable)"
   domain: com.apple.BluetoothAudioAgent
   type: int

--- a/config/common/system-defaults/backup-definitions/system_settings.yml
+++ b/config/common/system-defaults/backup-definitions/system_settings.yml
@@ -1,55 +1,66 @@
 ---
+# Sets the highlight color for selected text and UI elements.
 - key: AppleHighlightColor
   domain: NSGlobalDomain
   type: string
   default: "0.709800 0.835300 1.000000"
   comment: "System settings"
 
+# Controls when scroll bars are shown. ("Automatic", "WhenScrolling", "Always")
 - key: AppleShowScrollBars
   domain: NSGlobalDomain
   type: string
   default: "Automatic"
 
+# Expands the save panel by default.
 - key: NSNavPanelExpandedStateForSaveMode
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Expands the save panel by default.
 - key: NSNavPanelExpandedStateForSaveMode2
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Expands the print dialog by default.
 - key: PMPrintingExpandedStateForPrint
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Expands the print dialog by default.
 - key: PMPrintingExpandedStateForPrint2
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Saves new documents to iCloud by default.
 - key: NSDocumentSaveNewDocumentsToCloud
   domain: NSGlobalDomain
   type: bool
   default: false
 
+# Keeps windows open when quitting an application.
 - key: NSQuitAlwaysKeepsWindows
   domain: com.apple.systempreferences
   type: bool
   default: false
 
+# Disables automatic termination of applications.
 - key: NSDisableAutomaticTermination
   domain: NSGlobalDomain
   type: bool
   default: false
 
+# Disables the "Are you sure you want to open this?" dialog for downloaded applications.
 - key: LSQuarantine
   domain: com.apple.LaunchServices
   type: bool
   default: false
 
+# Controls the crash reporter dialog. ("none", "basic", "developer")
 - key: DialogType
   domain: com.apple.CrashReporter
   type: string

--- a/config/common/system-defaults/backup-definitions/trackpad.yml
+++ b/config/common/system-defaults/backup-definitions/trackpad.yml
@@ -1,40 +1,48 @@
 ---
+# Sets the trackpad tracking speed. A higher value means faster tracking.
 - key: com.apple.trackpad.scaling
   domain: NSGlobalDomain
   type: float
   default: 1.5
   comment: "Trackpad"
 
+# Enables or disables tap to click. (0: disabled, 1: enabled)
 - key: Clicking
   domain: com.apple.AppleMultitouchTrackpad
   type: int
   default: 1
 
+# Enables or disables dragging. (0: disabled, 1: enabled)
 - key: Dragging
   domain: com.apple.AppleMultitouchTrackpad
   type: int
   default: 0
 
+# Enables or disables three-finger drag.
 - key: TrackpadThreeFingerDrag
   domain: com.apple.AppleMultitouchTrackpad
   type: bool
   default: false
 
+# Sets the force required for a click. (0: Light, 1: Medium, 2: Firm)
 - key: FirstClickThreshold
   domain: com.apple.AppleMultitouchTrackpad
   type: int
   default: 1
 
+# Suppresses force click and haptic feedback.
 - key: ForceSuppressed
   domain: com.apple.AppleMultitouchTrackpad
   type: bool
   default: true
 
+# Sets the action for a three-finger tap. (0: Off, 2: Look up & data detectors)
 - key: TrackpadThreeFingerTapGesture
   domain: com.apple.AppleMultitouchTrackpad
   type: int
   default: 0
 
+# Enables or disables secondary click (right-click).
 - key: TrackpadRightClick
   domain: com.apple.AppleMultitouchTrackpad
   type: bool

--- a/config/common/system-defaults/backup-definitions/ui_ux.yml
+++ b/config/common/system-defaults/backup-definitions/ui_ux.yml
@@ -1,50 +1,60 @@
 ---
+# Hides the menu bar.
 - key: _HIHideMenuBar
   domain: NSGlobalDomain
   type: bool
   default: false
   comment: "UI/UX"
 
+# Sets the size of the sidebar icons. (1: Small, 2: Medium, 3: Large)
 - key: NSTableViewDefaultSizeMode
   domain: NSGlobalDomain
   type: int
   default: 2
 
+# Sets the speed of window resizing. A smaller value means faster resizing.
 - key: NSWindowResizeTime
   domain: NSGlobalDomain
   type: float
   default: 0.01
 
+# Enables or disables automatic capitalization.
 - key: NSAutomaticCapitalizationEnabled
   domain: NSGlobalDomain
   type: bool
   default: false
 
+# Enables or disables smart dash substitution.
 - key: NSAutomaticDashSubstitutionEnabled
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Enables or disables smart period substitution.
 - key: NSAutomaticPeriodSubstitutionEnabled
   domain: NSGlobalDomain
   type: bool
   default: false
 
+# Enables or disables smart quote substitution.
 - key: NSAutomaticQuoteSubstitutionEnabled
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Enables or disables automatic spelling correction.
 - key: NSAutomaticSpellingCorrectionEnabled
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Enables the WebKit developer extras in Safari for inspecting web views.
 - key: WebKitDeveloperExtras
   domain: NSGlobalDomain
   type: bool
   default: true
 
+# Enables or disables swipe navigation (e.g., two-finger swipe to go back/forward).
 - key: AppleEnableSwipeNavigateWithScrolls
   domain: NSGlobalDomain
   type: bool


### PR DESCRIPTION
… adds descriptive English comments to all YAML files under `config/common/system-defaults/backup-definitions/`. The comments explain the effect of each setting key, improving the readability and maintainability of the configuration files.