### PR TITLE
Migrate gh pr-ls and gm-mcp-ln helpers to Python

### DIFF
--- a/ansible/roles/gh/config/common/config.yml
+++ b/ansible/roles/gh/config/common/config.yml
@@ -19,35 +19,7 @@ aliases:
       echo "=== CHANGES ==="
       git diff "$base_branch...$target_branch"
     }; f "$@"
-  pr-ls: |
-    !f() {
-      gh pr list --limit 20 --json number,title,author,headRefName,state \
-        --jq '.[] | {number, title, author: .author.login, branch: .headRefName, state}' | while read -r pr; do
-        num=$(echo "$pr" | jq -r ".number")
-        branch=$(echo "$pr" | jq -r ".branch")
-        mergeable=$(gh pr view "$num" --json mergeable --jq ".mergeable")
-
-        # Check running actions
-        running=$(gh run list --branch "$branch" --status in_progress --limit 1 --json databaseId | jq "length")
-        has_running_actions=$([ "$running" -gt 0 ] && echo "true" || echo "false")
-
-        # Check CI status (latest workflow run)
-        ci_status="none"
-        latest_run=$(gh run list --branch "$branch" --limit 1 --json status,conclusion 2>/dev/null || echo "[]")
-        if [ "$latest_run" != "[]" ] && [ "$(echo "$latest_run" | jq length)" -gt 0 ]; then
-          run_status=$(echo "$latest_run" | jq -r '.[0].status')
-          run_conclusion=$(echo "$latest_run" | jq -r '.[0].conclusion')
-          if [ "$run_status" = "completed" ]; then
-            ci_status="$run_conclusion"
-          else
-            ci_status="$run_status"
-          fi
-        fi
-
-        echo "$pr" | jq --arg mergeable "$mergeable" --arg has_running "$has_running_actions" \
-          --arg ci_status "$ci_status" '. + {mergeable: $mergeable, actions_in_progress: $has_running, ci_status: $ci_status}'
-      done
-    }; f
+  pr-ls: '!gh-pr-ls.py "$@"'
   pr-ct: |
     !f() {
       local pr_id="$1"

--- a/ansible/roles/shell/config/common/.zsh/aiding/gemini.zsh
+++ b/ansible/roles/shell/config/common/.zsh/aiding/gemini.zsh
@@ -67,57 +67,5 @@ gm-ini() {
 
 # Link MCP configuration from root .mcp.json to .gemini/settings.json
 gm-mcp-ln() {
-    local project_root
-    project_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-    local mcp_json="${project_root}/.mcp.json"
-    local gemini_dir=".gemini"
-    local gemini_settings="${gemini_dir}/settings.json"
-
-    # Create .gemini directory if it doesn't exist
-    if [ ! -d "$gemini_dir" ]; then
-        mkdir -p "$gemini_dir"
-        echo "📁 Created .gemini directory"
-    fi
-
-    # Initialize settings.json if it doesn't exist
-    if [ ! -f "$gemini_settings" ]; then
-        echo '{"mcpServers": {}}' > "$gemini_settings"
-        echo "📄 Created .gemini/settings.json"
-    fi
-
-    # Check if .mcp.json exists in project root
-    if [ ! -f "$mcp_json" ]; then
-        echo "❌ No .mcp.json found in project root: $project_root"
-        return 1
-    fi
-
-    # Read .mcp.json content and extract servers
-    if ! command -v jq >/dev/null 2>&1; then
-        echo "❌ jq is required but not installed"
-        return 1
-    fi
-
-    # Extract mcpServers from .mcp.json and merge into .gemini/settings.json
-    local mcp_servers
-    mcp_servers=$(jq -r '.mcpServers // {}' "$mcp_json" 2>/dev/null)
-
-    if ! jq -r '.mcpServers // {}' "$mcp_json" >/dev/null 2>&1 || [ "$mcp_servers" = "null" ]; then
-        echo "❌ Failed to parse .mcp.json or no mcpServers found"
-        return 1
-    fi
-
-    # Update .gemini/settings.json with mcpServers from .mcp.json
-    local temp_file
-    temp_file=$(mktemp)
-    jq --argjson servers "$mcp_servers" '.mcpServers = $servers' "$gemini_settings" > "$temp_file"
-
-    if jq --argjson servers "$mcp_servers" '.mcpServers = $servers' "$gemini_settings" > "$temp_file"; then
-        mv "$temp_file" "$gemini_settings"
-        echo "✅ Synced mcpServers from $mcp_json to $gemini_settings"
-        echo "📊 Servers configured: $(echo "$mcp_servers" | jq -r 'keys | join(", ")')"
-    else
-        rm -f "$temp_file"
-        echo "❌ Failed to update .gemini/settings.json"
-        return 1
-    fi
+    command gm-mcp-ln.py "$@"
 }

--- a/ansible/roles/shell/scripts/gh-pr-ls.py
+++ b/ansible/roles/shell/scripts/gh-pr-ls.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""List pull requests with mergeability and CI status details."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from typing import Any, Dict, List, Optional
+
+Command = List[str]
+
+
+def _print_error(message: str) -> None:
+    """Print an error message to stderr."""
+    print(f"❌ {message}", file=sys.stderr)
+
+
+def _parse_json(output: str, description: str) -> Any:
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:  # pragma: no cover - exercised via error path tests
+        _print_error(f"Failed to parse JSON from '{description}': {exc}")
+        raise SystemExit(1) from exc
+
+
+def run_command(
+    command: Command,
+    *,
+    expect_json: bool = False,
+    default: Any = None,
+    exit_on_error: bool = True,
+    description: Optional[str] = None,
+) -> Any:
+    """Run a command and optionally parse its JSON output."""
+    desc = description or " ".join(command)
+    try:
+        completed = subprocess.run(  # noqa: S603,S607 - trusted command construction
+            command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        _print_error(f"Command not found while executing '{desc}'")
+        raise SystemExit(1) from exc
+    except subprocess.CalledProcessError as exc:
+        message = f"Command '{desc}' failed with exit code {exc.returncode}"
+        if exc.stderr:
+            message = f"{message}: {exc.stderr.strip()}"
+        if exit_on_error:
+            _print_error(message)
+            raise SystemExit(exc.returncode or 1) from exc
+        _print_error(message)
+        return default
+
+    output = completed.stdout.strip()
+    if expect_json:
+        if not output:
+            return default
+        return _parse_json(output, desc)
+    return output
+
+
+def _extract_author(pr: Dict[str, Any]) -> Optional[str]:
+    author = pr.get("author")
+    if isinstance(author, dict):
+        login = author.get("login")
+        if isinstance(login, str):
+            return login
+    if isinstance(author, str):
+        return author
+    return None
+
+
+def _mergeable_status(number: int) -> Optional[str]:
+    data = run_command(
+        ["gh", "pr", "view", str(number), "--json", "mergeable"],
+        expect_json=True,
+        default={},
+        description=f"gh pr view {number}",
+    )
+    if isinstance(data, dict):
+        mergeable = data.get("mergeable")
+        if isinstance(mergeable, str):
+            return mergeable
+    return None
+
+
+def _actions_in_progress(branch: str) -> str:
+    data = run_command(
+        [
+            "gh",
+            "run",
+            "list",
+            "--branch",
+            branch,
+            "--status",
+            "in_progress",
+            "--limit",
+            "1",
+            "--json",
+            "databaseId",
+        ],
+        expect_json=True,
+        default=[],
+        exit_on_error=False,
+        description=f"gh run list --branch {branch} --status in_progress",
+    )
+    if isinstance(data, list) and data:
+        return "true"
+    return "false"
+
+
+def _latest_ci_status(branch: str) -> str:
+    data = run_command(
+        [
+            "gh",
+            "run",
+            "list",
+            "--branch",
+            branch,
+            "--limit",
+            "1",
+            "--json",
+            "status,conclusion",
+        ],
+        expect_json=True,
+        default=[],
+        exit_on_error=False,
+        description=f"gh run list --branch {branch}",
+    )
+    if isinstance(data, list) and data:
+        run = data[0]
+        if isinstance(run, dict):
+            status = run.get("status")
+            conclusion = run.get("conclusion")
+            if status == "completed" and isinstance(conclusion, str):
+                return conclusion
+            if isinstance(status, str):
+                return status
+    return "none"
+
+
+def gather_pull_requests(limit: int = 20) -> List[Dict[str, Any]]:
+    prs_raw = run_command(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,author,headRefName,state",
+        ],
+        expect_json=True,
+        default=[],
+        description="gh pr list",
+    )
+
+    if not isinstance(prs_raw, list):
+        _print_error("Unexpected response from 'gh pr list'")
+        raise SystemExit(1)
+
+    results: List[Dict[str, Any]] = []
+    for pr in prs_raw:
+        if not isinstance(pr, dict):
+            continue
+        number = pr.get("number")
+        branch = pr.get("headRefName")
+        if not isinstance(number, int) or not isinstance(branch, str):
+            continue
+
+        entry: Dict[str, Any] = {
+            "number": number,
+            "title": pr.get("title"),
+            "author": _extract_author(pr),
+            "branch": branch,
+            "state": pr.get("state"),
+        }
+
+        mergeable = _mergeable_status(number)
+        if mergeable is not None:
+            entry["mergeable"] = mergeable
+        else:
+            entry["mergeable"] = "UNKNOWN"
+
+        entry["actions_in_progress"] = _actions_in_progress(branch)
+        entry["ci_status"] = _latest_ci_status(branch)
+        results.append(entry)
+
+    return results
+
+
+def main() -> int:
+    pull_requests = gather_pull_requests()
+    for pr in pull_requests:
+        print(json.dumps(pr, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ansible/roles/shell/scripts/gm-mcp-ln.py
+++ b/ansible/roles/shell/scripts/gm-mcp-ln.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Synchronize MCP server configuration into Gemini settings."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+
+def _print_error(message: str) -> None:
+    print(f"❌ {message}", file=sys.stderr)
+
+
+def _find_project_root(start: Path) -> Path:
+    for path in (start, *start.parents):
+        if (path / ".mcp.json").exists():
+            return path
+    raise FileNotFoundError("Unable to locate .mcp.json in current or parent directories")
+
+
+def _read_json(path: Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Missing file: {path}") from exc
+    except json.JSONDecodeError as exc:  # pragma: no cover - exercised via error path tests
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected object at {path}")
+    return data
+
+
+def _write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+
+
+def sync_mcp_servers(start_dir: Path) -> Dict[str, Any]:
+    project_root = _find_project_root(start_dir)
+    mcp_path = project_root / ".mcp.json"
+    gemini_settings = start_dir / ".gemini" / "settings.json"
+
+    mcp_content = _read_json(mcp_path)
+    servers = mcp_content.get("mcpServers")
+    if servers is None:
+        raise ValueError(f"No mcpServers key found in {mcp_path}")
+    if not isinstance(servers, dict):
+        raise ValueError("mcpServers must be an object")
+
+    try:
+        settings_content = _read_json(gemini_settings)
+    except FileNotFoundError:
+        settings_content = {"mcpServers": {}}
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+
+    settings_content["mcpServers"] = servers
+    _write_json(gemini_settings, settings_content)
+    return servers
+
+
+def main() -> int:
+    start_dir = Path.cwd()
+    try:
+        servers = sync_mcp_servers(start_dir)
+    except (FileNotFoundError, ValueError) as exc:
+        _print_error(str(exc))
+        return 1
+
+    if servers:
+        configured = ", ".join(sorted(servers.keys()))
+    else:
+        configured = "(none)"
+    print(f"✅ Synced MCP servers to {start_dir / '.gemini' / 'settings.json'}")
+    print(f"📊 Servers configured: {configured}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ansible/roles/shell/tasks/main.yml
+++ b/ansible/roles/shell/tasks/main.yml
@@ -54,3 +54,25 @@
     state: link
     force: true
   loop: "{{ shell_config_files.files }}"
+
+- name: "Ensure ~/.local/bin directory exists"
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.local/bin"
+    state: directory
+    mode: "0755"
+
+- name: "Find Python helper scripts"
+  ansible.builtin.find:
+    paths: "{{ role_path }}/scripts"
+    patterns: "*.py"
+    file_type: file
+  register: shell_helper_scripts
+
+- name: "Symlink Python helper scripts to ~/.local/bin"
+  ansible.builtin.file:
+    src: "{{ item.path }}"
+    dest: "{{ ansible_env.HOME }}/.local/bin/{{ item.path | basename }}"
+    state: link
+    force: true
+    mode: "0755"
+  loop: "{{ shell_helper_scripts.files }}"

--- a/tests/shell/test_gh_pr_ls.py
+++ b/tests/shell/test_gh_pr_ls.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Iterable
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "ansible" / "roles" / "shell" / "scripts" / "gh-pr-ls.py"
+
+
+@pytest.fixture(scope="module")
+def gh_pr_ls_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("gh_pr_ls", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_gather_pull_requests(monkeypatch: pytest.MonkeyPatch, gh_pr_ls_module: ModuleType) -> None:
+    responses: Iterable[object] = iter(
+        [
+            [
+                {
+                    "number": 1,
+                    "title": "Fix bug",
+                    "author": {"login": "alice"},
+                    "headRefName": "feature-1",
+                    "state": "OPEN",
+                },
+                {
+                    "number": 2,
+                    "title": "Add feature",
+                    "author": {"login": "bob"},
+                    "headRefName": "feature-2",
+                    "state": "OPEN",
+                },
+            ],
+            {"mergeable": "MERGEABLE"},
+            [{"databaseId": 1}],
+            [{"status": "completed", "conclusion": "success"}],
+            {"mergeable": "CONFLICTING"},
+            [],
+            [{"status": "in_progress"}],
+        ]
+    )
+
+    def fake_run_command(*_args, **_kwargs):
+        try:
+            return next(responses)
+        except StopIteration as exc:  # pragma: no cover - ensures test fails if extra call
+            raise AssertionError("run_command called more times than expected") from exc
+
+    monkeypatch.setattr(gh_pr_ls_module, "run_command", fake_run_command)
+
+    pull_requests = gh_pr_ls_module.gather_pull_requests(limit=5)
+    assert pull_requests == [
+        {
+            "number": 1,
+            "title": "Fix bug",
+            "author": "alice",
+            "branch": "feature-1",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "actions_in_progress": "true",
+            "ci_status": "success",
+        },
+        {
+            "number": 2,
+            "title": "Add feature",
+            "author": "bob",
+            "branch": "feature-2",
+            "state": "OPEN",
+            "mergeable": "CONFLICTING",
+            "actions_in_progress": "false",
+            "ci_status": "in_progress",
+        },
+    ]
+
+
+def test_main_prints_results(monkeypatch: pytest.MonkeyPatch, gh_pr_ls_module: ModuleType, capsys: pytest.CaptureFixture[str]) -> None:
+    sample = [
+        {
+            "number": 42,
+            "title": "Improve docs",
+            "author": "carol",
+            "branch": "docs/update",
+            "state": "OPEN",
+            "mergeable": "MERGEABLE",
+            "actions_in_progress": "false",
+            "ci_status": "success",
+        }
+    ]
+    monkeypatch.setattr(gh_pr_ls_module, "gather_pull_requests", lambda limit=20: sample)
+
+    exit_code = gh_pr_ls_module.main()
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out.strip().splitlines() == [
+        '{"number": 42, "title": "Improve docs", "author": "carol", "branch": "docs/update", "state": "OPEN", "mergeable": "MERGEABLE", "actions_in_progress": "false", "ci_status": "success"}'
+    ]
+
+
+def test_gather_pull_requests_invalid_response(monkeypatch: pytest.MonkeyPatch, gh_pr_ls_module: ModuleType) -> None:
+    monkeypatch.setattr(gh_pr_ls_module, "run_command", lambda *args, **kwargs: {})
+    with pytest.raises(SystemExit):
+        gh_pr_ls_module.gather_pull_requests()

--- a/tests/shell/test_gm_mcp_ln.py
+++ b/tests/shell/test_gm_mcp_ln.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "ansible" / "roles" / "shell" / "scripts" / "gm-mcp-ln.py"
+
+
+@pytest.fixture(scope="module")
+def gm_mcp_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("gm_mcp_ln", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sync_mcp_servers_updates_settings(tmp_path: Path, gm_mcp_module: ModuleType) -> None:
+    project_root = tmp_path
+    mcp_data = {"mcpServers": {"alpha": {"url": "http://alpha"}}}
+    (project_root / ".mcp.json").write_text(json.dumps(mcp_data), encoding="utf-8")
+
+    workdir = project_root / "workspace"
+    workdir.mkdir()
+    settings_path = workdir / ".gemini" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text(json.dumps({"existing": True}), encoding="utf-8")
+
+    servers = gm_mcp_module.sync_mcp_servers(workdir)
+    assert servers == mcp_data["mcpServers"]
+
+    updated = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert updated["mcpServers"] == mcp_data["mcpServers"]
+    assert updated["existing"] is True
+
+
+def test_sync_mcp_servers_creates_settings(tmp_path: Path, gm_mcp_module: ModuleType) -> None:
+    project_root = tmp_path
+    (project_root / ".mcp.json").write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    workdir = project_root / "nested" / "dir"
+    workdir.mkdir(parents=True)
+
+    servers = gm_mcp_module.sync_mcp_servers(workdir)
+    settings_path = workdir / ".gemini" / "settings.json"
+    assert settings_path.exists()
+    saved = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert saved["mcpServers"] == {}
+    assert servers == {}
+
+
+def test_sync_mcp_servers_missing_root(tmp_path: Path, gm_mcp_module: ModuleType) -> None:
+    workdir = tmp_path / "no-root"
+    workdir.mkdir()
+    with pytest.raises(FileNotFoundError):
+        gm_mcp_module.sync_mcp_servers(workdir)
+
+
+def test_sync_mcp_servers_invalid_settings(tmp_path: Path, gm_mcp_module: ModuleType) -> None:
+    project_root = tmp_path
+    (project_root / ".mcp.json").write_text(json.dumps({"mcpServers": {}}), encoding="utf-8")
+
+    workdir = project_root / "workspace"
+    workdir.mkdir()
+    settings_path = workdir / ".gemini" / "settings.json"
+    settings_path.parent.mkdir(parents=True)
+    settings_path.write_text("not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        gm_mcp_module.sync_mcp_servers(workdir)


### PR DESCRIPTION
## Summary
- add Python replacements for the `gh pr-ls` alias and `gm-mcp-ln` helper with improved error handling
- update gh config, zsh functions, and the shell role to expose the new scripts via ~/.local/bin
- add pytest coverage for the new helpers to verify normal and error scenarios

## Testing
- uv run pytest tests/shell

------
https://chatgpt.com/codex/tasks/task_e_68df15559b9c8320bd521ebdd2280171

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a PR listing command that outputs enriched JSON (author, mergeability, actions in progress, CI status).
  - Added a command to sync MCP server settings from project config into Gemini.
- Refactor
  - Reworked existing shell alias/function to delegate to the new tools without changing usage.
- Chores
  - Automatically creates a local bin and links helper scripts for easy command access.
- Tests
  - Added test coverage for the PR listing and MCP sync commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->