### PR TITLE
Prototype service provisioning scaffold

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -23,5 +23,4 @@
     - { role: mcp, tags: ["mcp"] }
     - { role: system, tags: ["system"] }
     - { role: docker, tags: ["docker"] }
-    - { role: macbook-services, tags: ["macbook-services"] }
-    - { role: mac-mini-services, tags: ["mac-mini-services"] }
+    - { role: services, tags: ["services"] }

--- a/ansible/roles/services/mac_mini/defaults/main.yml
+++ b/ansible/roles/services/mac_mini/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+services_mac_mini_stub_api_port: 8080

--- a/ansible/roles/services/mac_mini/tasks/main.yml
+++ b/ansible/roles/services/mac_mini/tasks/main.yml
@@ -2,11 +2,12 @@
 - name: "Deploy all services for mac-mini"
   community.docker.docker_compose_v2:
     project_src: "{{ repo_root_path }}/ansible/services/mac-mini/compose/"
+    files: ["stub-api.yml"]
     state: present
-    restarted: true
+    recreate: auto
 
 - name: "Wait for stub-api service to become available"
   ansible.builtin.wait_for:
     host: 127.0.0.1
-    port: 8080
+    port: "{{ services_mac_mini_stub_api_port | default(8080) }}"
     timeout: 60

--- a/ansible/roles/services/macbook/defaults/main.yml
+++ b/ansible/roles/services/macbook/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+services_macbook_ollama_service_port: 11434

--- a/ansible/roles/services/macbook/tasks/main.yml
+++ b/ansible/roles/services/macbook/tasks/main.yml
@@ -2,11 +2,12 @@
 - name: "Deploy all services for macbook"
   community.docker.docker_compose_v2:
     project_src: "{{ repo_root_path }}/ansible/services/macbook/compose/"
+    files: ["ollama.yml"]
     state: present
-    restarted: true
+    recreate: auto
 
 - name: "Wait for ollama-service to become available"
   ansible.builtin.wait_for:
     host: 127.0.0.1
-    port: 11434
+    port: "{{ services_macbook_ollama_service_port | default(11434) }}"
     timeout: 60

--- a/ansible/roles/services/tasks/main.yml
+++ b/ansible/roles/services/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Include MacBook services role
+  ansible.builtin.include_role:
+    name: macbook
+  when: profile == 'macbook'
+
+- name: Include Mac Mini services role
+  ansible.builtin.include_role:
+    name: mac_mini
+  when: profile == 'mac-mini'

--- a/ansible/roles/shell/config/common/.zsh/dev/dev.sh
+++ b/ansible/roles/shell/config/common/.zsh/dev/dev.sh
@@ -21,6 +21,8 @@ dev_alias_as() {
 	alias "${prefix}-s=${cmd_prefix} setup"
 	alias "${prefix}-f=${cmd_prefix} format"
 	alias "${prefix}-l=${cmd_prefix} lint"
+	alias "${prefix}-b=${cmd_prefix} build"
+	alias "${prefix}-rb=${cmd_prefix} rebuild"
 	alias "${prefix}-r=${cmd_prefix} run"
 	alias "${prefix}-t=${cmd_prefix} test"
 	alias "${prefix}-cln=${cmd_prefix} clean"

--- a/ansible/roles/shell/config/common/.zsh/python/uv.sh
+++ b/ansible/roles/shell/config/common/.zsh/python/uv.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 alias u="uv"
 alias u-ini="uv init"
 u-v() {

--- a/ansible/roles/vscode/config/common/settings.json
+++ b/ansible/roles/vscode/config/common/settings.json
@@ -13,5 +13,15 @@
   "git.enableSmartCommit": true,
   "git.autofetch": true,
   "workbench.settings.applyToAllProfiles": [],
-  "editor.tabSize": 2
+  "editor.tabSize": 2,
+  "terminal.integrated.allowedLinkSchemes": [
+    "file",
+    "http",
+    "https",
+    "mailto",
+    "vscode",
+    "vscode-insiders",
+    "docker-desktop"
+  ],
+  "chat.editing.confirmEditRequestRetry": false
 }

--- a/ansible/services/mac-mini/compose/stub-api.yml
+++ b/ansible/services/mac-mini/compose/stub-api.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+---
 services:
   stub-api:
     image: traefik/whoami

--- a/ansible/services/macbook/compose/ollama.yml
+++ b/ansible/services/macbook/compose/ollama.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+---
 services:
   ollama:
     image: ollama/ollama
@@ -6,7 +6,7 @@ services:
     ports:
       - "11434:11434"
     volumes:
-      - "~/.ollama/models:/root/.ollama/models"
+      - "${HOME}/.ollama/models:/root/.ollama/models"
     restart: always
     environment:
       - OLLAMA_KEEP_ALIVE=-1

--- a/justfile
+++ b/justfile
@@ -197,7 +197,7 @@ mbk-brew-cask:
 # Deploy MacBook services
 mbk-services:
   @echo "🚀 Deploying all MacBook services..."
-  @just _run_ansible "macbook-services" "macbook" "macbook-services"
+  @just _run_ansible "services" "macbook" "services"
 
 # ------------------------------------------------------------------------------
 # Mac Mini-Specific Recipes
@@ -210,7 +210,7 @@ mmn-brew-cask:
 # Deploy Mac Mini services
 mmn-services:
   @echo "🚀 Deploying all Mac Mini services..."
-  @just _run_ansible "mac-mini-services" "mac-mini" "mac-mini-services"
+  @just _run_ansible "services" "mac-mini" "services"
 
 # ------------------------------------------------------------------------------
 # VCS Profile Switching

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "environment"
 version = "0.1.0"
 description = "Ansible playbook for my entire MacOS environment."
-authors = [{ name = "akitorahayashi", email = "atora.has75@gmail.com" }]
+authors = [{ name = "akitorahayashi" }]
 requires-python = ">=3.12,<4.0"
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- add a declarative services tree with stub Compose files for MacBook and Mac mini plus a placeholder for Mac Studio
- introduce macbook-services and mac-mini-services Ansible roles that deploy the new Compose projects and verify service availability
- wire the new service roles into the main playbook and expose them via dedicated Just recipes

## Testing
- not run (just is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e68f4b9c448320875a86f60d8c64a8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - One-command deployment of MacBook and Mac Mini services via new tasks.
  - Mac Mini: adds a stub API service (default port 8080) with readiness checks.
  - MacBook: adds an Ollama service (default port 11434) with readiness checks.
  - Profile-aware services deployment integrated into automation.
  - Shell: new build/rebuild aliases and a Python virtual env helper that auto-installs required versions.
  - VS Code: expanded allowed link schemes and streamlined chat edit retry behavior.

- Chores
  - Project metadata updated (author email removed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->