### PR TITLE
Refactor CLI tooling to Typer and add validation models

### DIFF
--- a/ansible/roles/shell/scripts/aider.py
+++ b/ansible/roles/shell/scripts/aider.py
@@ -1,79 +1,25 @@
 #!/usr/bin/env python3
-"""CLI wrapper for invoking aider with Ollama models.
-
-This script mirrors the behaviour of the historic shell functions that
-previously lived in ``aider.sh``.  It now provides subcommands for managing the
-``AIDER_OLLAMA_MODEL`` environment variable and exposes the main aider entry
-point directly.
-"""
+"""CLI wrapper for invoking aider with Ollama models."""
 
 from __future__ import annotations
 
-import argparse
 import os
 import shlex
 import shutil
 import subprocess
-import sys
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
+
+import typer
+from rich.console import Console
 
 MODEL_ENV = "AIDER_OLLAMA_MODEL"
 
-
-def _create_main_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        description="Invoke aider with curated defaults for the Environment setup project.",
-        add_help=True,
-    )
-    parser.add_argument(
-        "-d",
-        "--dir",
-        action="append",
-        dest="directories",
-        default=[],
-        help="Add a directory (recursively) to the aider context.",
-        metavar="DIR",
-    )
-    parser.add_argument(
-        "-e",
-        "--ext",
-        action="append",
-        dest="extensions",
-        default=[],
-        help="Add files by extension (recursively).",
-        metavar="EXT",
-    )
-    parser.add_argument(
-        "-f",
-        "--files",
-        action="append",
-        dest="files",
-        nargs="+",
-        default=[],
-        help="Add specific files to the aider context.",
-        metavar="FILE",
-    )
-    parser.add_argument(
-        "-y",
-        "--yes",
-        action="store_true",
-        dest="yolo",
-        help="Automatically accept aider suggestions (YOLO mode).",
-    )
-    parser.add_argument(
-        "-m",
-        "--message",
-        dest="message",
-        help="Send a one-off message to aider before exiting.",
-        metavar="TEXT",
-    )
-    parser.add_argument(
-        "targets",
-        nargs="*",
-        help="Additional files or directories to include.",
-    )
-    return parser
+app = typer.Typer(
+    add_completion=False,
+    help="Invoke aider with curated defaults for the Environment setup project.",
+)
+console = Console()
 
 
 def _iter_extension_matches(extensions: Iterable[str]) -> Iterable[str]:
@@ -90,18 +36,21 @@ def _iter_extension_matches(extensions: Iterable[str]) -> Iterable[str]:
                     yield str(path)
 
 
-def _flatten(nested: Iterable[Iterable[str]]) -> list[str]:
-    return [item for group in nested for item in group]
-
-
-def _run_aider(args: argparse.Namespace) -> int:
+def _build_aider_command(
+    *,
+    directories: Sequence[Path],
+    extensions: Sequence[str],
+    files: Sequence[Path],
+    yolo: bool,
+    message: str | None,
+    targets: Sequence[Path],
+) -> list[str]:
     model = os.getenv(MODEL_ENV)
     if not model:
-        print(
-            f"Error: {MODEL_ENV} environment variable is not set. Use `ai-st <model_name>` to set it.",
-            file=sys.stderr,
+        console.print(
+            f"[bold red]Error[/]: {MODEL_ENV} environment variable is not set. Use `ai set-model <model>` to set it."
         )
-        return 1
+        raise typer.Exit(1)
 
     provider_model = model if "/" in model else f"ollama/{model}"
 
@@ -113,55 +62,119 @@ def _run_aider(args: argparse.Namespace) -> int:
         "--no-gitignore",
     ]
 
-    if args.yolo:
+    if yolo:
         command.append("--yes")
 
-    if args.message:
-        command.extend(["--message", args.message])
+    if message:
+        command.extend(["--message", message])
 
-    targets: list[str] = []
-    targets.extend(args.directories or [])
-    targets.extend(_iter_extension_matches(args.extensions or []))
-    targets.extend(_flatten(args.files or []))
-    targets.extend(args.targets or [])
+    target_args: list[str] = []
+    target_args.extend(str(path) for path in directories)
+    target_args.extend(_iter_extension_matches(extensions))
+    target_args.extend(str(path) for path in files)
+    target_args.extend(str(path) for path in targets)
 
-    full_command = command + targets
+    return command + target_args
 
+
+def _run_aider(command: list[str]) -> int:
     try:
-        completed = subprocess.run(full_command, check=False)
+        completed = subprocess.run(command, check=False)
     except FileNotFoundError as exc:  # pragma: no cover - defensive guard
-        print(f"Error: failed to execute {full_command[0]!r}: {exc}", file=sys.stderr)
+        console.print(f"[bold red]Error[/]: failed to execute {command[0]!r}: {exc}")
         return 1
     return completed.returncode
 
 
-def _handle_set_model(args: argparse.Namespace) -> int:
-    model = args.model
-    if not model:
-        current = os.getenv(MODEL_ENV, "not set")
-        print("Usage: set-model <model_name>", file=sys.stderr)
-        print(f"Current {MODEL_ENV}: {current}", file=sys.stderr)
-        return 1
+@app.callback(invoke_without_command=True)
+def main(
+    ctx: typer.Context,
+    directories: tuple[Path, ...] = typer.Option(
+        (),
+        "--dir",
+        "-d",
+        help="Add a directory (recursively) to the aider context.",
+        metavar="DIR",
+    ),
+    extensions: tuple[str, ...] = typer.Option(
+        (),
+        "--ext",
+        "-e",
+        help="Add files by extension (recursively).",
+        metavar="EXT",
+    ),
+    files: tuple[Path, ...] = typer.Option(
+        (),
+        "--file",
+        "--files",
+        "-f",
+        help="Add specific files to the aider context. Repeat for multiple files.",
+        metavar="FILE",
+    ),
+    yolo: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Automatically accept aider suggestions (YOLO mode).",
+    ),
+    message: str | None = typer.Option(
+        None,
+        "--message",
+        "-m",
+        help="Send a one-off message to aider before exiting.",
+        metavar="TEXT",
+    ),
+    targets: tuple[Path, ...] = typer.Argument(
+        (),
+        metavar="TARGET",
+        help="Additional files or directories to include.",
+    ),
+) -> None:
+    """Default aider invocation."""
+
+    if ctx.invoked_subcommand is not None:
+        return
+
+    command = _build_aider_command(
+        directories=directories,
+        extensions=extensions,
+        files=files,
+        yolo=yolo,
+        message=message,
+        targets=targets,
+    )
+    raise typer.Exit(_run_aider(command))
+
+
+@app.command("set-model")
+def set_model(
+    model: str = typer.Argument(..., metavar="MODEL", help="Default Ollama model."),
+) -> None:
+    """Print shell commands to set the default Ollama model for aider."""
 
     quoted = shlex.quote(model)
-    print(f"export {MODEL_ENV}={quoted}")
-    print(f'echo "✅ Set {MODEL_ENV} to: {model}"')
-    return 0
+    console.print(f"export {MODEL_ENV}={quoted}")
+    console.print(f'echo "✅ Set {MODEL_ENV} to: {model}"')
 
 
-def _handle_unset_model() -> int:
+@app.command("unset-model")
+def unset_model() -> None:
+    """Print shell commands to unset the configured Ollama model."""
+
     if os.getenv(MODEL_ENV):
-        print(f"unset {MODEL_ENV}")
-        print(f'echo "✅ Unset {MODEL_ENV}"')
+        console.print(f"unset {MODEL_ENV}")
+        console.print(f'echo "✅ Unset {MODEL_ENV}"')
     else:
-        print(f'echo "{MODEL_ENV} is already not set"')
-    return 0
+        console.print(f'echo "{MODEL_ENV} is already not set"')
 
 
-def _handle_list_models() -> int:
+@app.command("list-models")
+def list_models() -> None:
+    """List available Ollama models."""
+
     if not shutil.which("ollama"):
-        print("Ollama is not installed", file=sys.stderr)
-        return 1
+        console.print("[bold red]Error[/]: Ollama is not installed.")
+        raise typer.Exit(1)
 
     try:
         result = subprocess.run(
@@ -171,10 +184,10 @@ def _handle_list_models() -> int:
             text=True,
         )
     except subprocess.CalledProcessError as exc:  # pragma: no cover - passthrough
-        print(exc.stderr or str(exc), file=sys.stderr)
-        return exc.returncode
+        console.print(exc.stderr or str(exc))
+        raise typer.Exit(exc.returncode or 1)
 
-    models = []
+    models: list[str] = []
     for idx, line in enumerate(result.stdout.splitlines()):
         if idx == 0 and line.lower().startswith("name"):
             continue
@@ -182,45 +195,20 @@ def _handle_list_models() -> int:
         if parts:
             models.append(parts[0])
 
-    print("Available Ollama models for aider:")
+    console.print("Available Ollama models for aider:")
     for name in models:
-        print(f"  {name}")
-    print()
-    print("Usage: ai-st <model> && ai [files...]")
-    print("Example: ai-st llama3.2 && ai main.py")
-    print()
+        console.print(f"  {name}")
+    console.print()
+    console.print("Usage: ai set-model <model> && ai [files...]")
+    console.print("Example: ai set-model llama3.2 && ai main.py")
+    console.print()
     current = os.getenv(MODEL_ENV, "not set")
-    print(f"Current {MODEL_ENV}: {current}")
-    return 0
+    console.print(f"Current {MODEL_ENV}: {current}")
 
 
-def main(argv: list[str] | None = None) -> int:
-    argv = list(argv or sys.argv[1:])
-    if argv and argv[0] in {"set-model", "unset-model", "list-models"}:
-        subparser = argparse.ArgumentParser(prog="aider.py")
-        subparsers = subparser.add_subparsers(dest="command", required=True)
-
-        parser_set = subparsers.add_parser(
-            "set-model", help="Set the default Ollama model for aider."
-        )
-        parser_set.add_argument("model", nargs="?")
-
-        subparsers.add_parser("unset-model", help="Unset the configured Ollama model.")
-        subparsers.add_parser("list-models", help="List available Ollama models.")
-
-        parsed = subparser.parse_args(argv)
-        if parsed.command == "set-model":
-            return _handle_set_model(parsed)
-        if parsed.command == "unset-model":
-            return _handle_unset_model()
-        if parsed.command == "list-models":
-            return _handle_list_models()
-        return 0  # pragma: no cover - defensive
-
-    parser = _create_main_parser()
-    parsed = parser.parse_args(argv)
-    return _run_aider(parsed)
+def run() -> None:  # pragma: no cover - CLI entry
+    app()
 
 
 if __name__ == "__main__":  # pragma: no cover - CLI entry
-    sys.exit(main())
+    run()

--- a/ansible/roles/shell/scripts/mcp.py
+++ b/ansible/roles/shell/scripts/mcp.py
@@ -1,256 +1,265 @@
 #!/usr/bin/env python3
 """MCP Configuration Management CLI."""
 
-import argparse
+from __future__ import annotations
+
 import json
 import shutil
 import subprocess
-import sys
 from pathlib import Path
+from typing import Any
+
+import typer
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from rich.console import Console
+from rich.table import Table
+
+CONFIG_FILENAME = ".mcp.json"
+LOCAL_CONFIG_PATH = Path(CONFIG_FILENAME)
+GLOBAL_CONFIG_PATH = Path.home() / CONFIG_FILENAME
 
 
-def validate_server_name(name: str, command: str) -> None:
-    """Validate that server name is provided."""
-    if not name:
-        print("Error: MCP server name is required")
-        print(f"Usage: {command} <mcp-server-name>")
-        sys.exit(1)
+class McpServer(BaseModel):
+    """Representation of a single MCP server entry."""
+
+    model_config = ConfigDict(extra="allow")
+
+    command: str | None = None
+    args: list[str] = Field(default_factory=list)
+    description: str | None = None
+
+    def display_command(self) -> str:
+        """Return a human-friendly command string."""
+
+        if not self.command:
+            return "<missing command>"
+        if self.args:
+            return f"{self.command} {' '.join(self.args)}"
+        return self.command
 
 
-def validate_local_config(suggest_init: bool = False) -> None:
-    """Validate that .mcp.json exists in current directory."""
-    if not Path(".mcp.json").exists():
-        print("Error: .mcp.json file not found in current directory")
+class McpConfig(BaseModel):
+    """Root MCP configuration."""
+
+    model_config = ConfigDict(extra="allow")
+
+    mcpServers: dict[str, McpServer] = Field(default_factory=dict)
+
+
+app = typer.Typer(help="Manage MCP configuration files.")
+console = Console()
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except FileNotFoundError:
+        raise
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def _load_config(path: Path) -> McpConfig:
+    try:
+        payload = _read_json(path)
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(f"Configuration not found: {path}") from exc
+    try:
+        return McpConfig.model_validate(payload)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid MCP configuration in {path}: {exc}") from exc
+
+
+def _write_config(path: Path, config: McpConfig) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(config.model_dump(mode="json"), handle, indent=2)
+        handle.write("\n")
+
+
+def _require_global_config() -> Path:
+    if not GLOBAL_CONFIG_PATH.exists():
+        console.print("[bold red]Error[/]: ~/.mcp.json file not found.")
+        raise typer.Exit(1)
+    return GLOBAL_CONFIG_PATH
+
+
+def _require_local_config(suggest_init: bool = False) -> Path:
+    if not LOCAL_CONFIG_PATH.exists():
+        console.print("[bold red]Error[/]: .mcp.json file not found in current directory.")
         if suggest_init:
-            print("Run 'mcp-ini' first to create .mcp.json")
-        sys.exit(1)
+            console.print("Run [bold]mcp ini[/] first to create one.")
+        raise typer.Exit(1)
+    return LOCAL_CONFIG_PATH
 
 
-def validate_global_config() -> None:
-    """Validate that ~/.mcp.json exists."""
-    global_config = Path.home() / ".mcp.json"
-    if not global_config.exists():
-        print("Error: ~/.mcp.json file not found")
-        sys.exit(1)
+def _available_servers_table(config: McpConfig) -> Table:
+    table = Table(title="Available MCP servers")
+    table.add_column("Name", style="cyan", no_wrap=True)
+    table.add_column("Command", style="magenta")
+    table.add_column("Description", style="green")
+
+    for name, server in sorted(config.mcpServers.items()):
+        table.add_row(name, server.display_command(), server.description or "—")
+    return table
 
 
-def server_exists_global(name: str) -> bool:
-    """Check if server exists in global config."""
-    global_config = Path.home() / ".mcp.json"
-    with open(global_config) as f:
-        data = json.load(f)
-    return name in data.get("mcpServers", {})
+def _load_global_config() -> McpConfig:
+    path = _require_global_config()
+    try:
+        return _load_config(path)
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[bold red]Error[/]: {exc}")
+        raise typer.Exit(1)
 
 
-def server_exists_local(name: str) -> bool:
-    """Check if server exists in local config."""
-    with open(".mcp.json") as f:
-        data = json.load(f)
-    return name in data.get("mcpServers", {})
+def _load_local_config(*, suggest_init: bool = False) -> McpConfig:
+    path = _require_local_config(suggest_init=suggest_init)
+    try:
+        return _load_config(path)
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[bold red]Error[/]: {exc}")
+        raise typer.Exit(1)
 
 
-def show_available_servers(config_file: Path) -> None:
-    """Show available servers in config."""
-    with open(config_file) as f:
-        data = json.load(f)
-    servers = list(data.get("mcpServers", {}).keys())
-    if servers:
-        print("Available servers:")
-        for server in servers:
-            print(f"  {server}")
-    else:
-        print("No servers available")
+@app.command("ini")
+def init_local_config() -> None:
+    """Create a new local .mcp.json file."""
+
+    if LOCAL_CONFIG_PATH.exists():
+        console.print("[bold red]Error[/]: .mcp.json already exists in the current directory.")
+        raise typer.Exit(1)
+
+    _write_config(LOCAL_CONFIG_PATH, McpConfig())
+    console.print("[bold green]✅[/] Created .mcp.json with an empty mcpServers map.")
 
 
-def cmd_ini() -> None:
-    """Initialize .mcp.json in current directory."""
-    if Path(".mcp.json").exists():
-        print(".mcp.json file already exists in current directory")
-        sys.exit(1)
+@app.command("ini-f")
+def init_from_global() -> None:
+    """Copy ~/.mcp.json to the current directory."""
 
-    with open(".mcp.json", "w") as f:
-        json.dump({"mcpServers": {}}, f, indent=2)
-    print("✅ Created .mcp.json with mcpServers key in current directory")
+    _require_global_config()
+    if LOCAL_CONFIG_PATH.exists():
+        console.print("[bold red]Error[/]: .mcp.json already exists in the current directory.")
+        raise typer.Exit(1)
 
-
-def cmd_ini_f() -> None:
-    """Initialize .mcp.json from global config."""
-    validate_global_config()
-    if Path(".mcp.json").exists():
-        print(".mcp.json file already exists in current directory")
-        sys.exit(1)
-
-    global_config = Path.home() / ".mcp.json"
-    shutil.copy(global_config, ".mcp.json")
-    print("✅ Created .mcp.json in current directory from ~/.mcp.json")
+    shutil.copy(GLOBAL_CONFIG_PATH, LOCAL_CONFIG_PATH)
+    console.print("[bold green]✅[/] Created local .mcp.json from ~/.mcp.json.")
 
 
-def cmd_ls() -> None:
+@app.command("ls")
+def list_servers() -> None:
     """List available MCP servers."""
-    validate_global_config()
-    global_config = Path.home() / ".mcp.json"
 
-    with open(global_config) as f:
-        data = json.load(f)
+    config = _load_global_config()
+    if not config.mcpServers:
+        console.print("[bold red]Error[/]: No MCP servers found in ~/.mcp.json.")
+        raise typer.Exit(1)
 
-    servers = data.get("mcpServers", {})
-    if not servers:
-        print("No MCP servers found in ~/.mcp.json")
-        sys.exit(1)
-
-    print("Available MCP servers:")
-    print("=====================")
-
-    for name, config in servers.items():
-        command = config.get("command")
-        if command:
-            args = config.get("args", [])
-            full_command = f"{command} {' '.join(args)}" if args else command
-            description = config.get("description", "No description available")
-
-            print(f"[{name}]")
-            print(f"{full_command}")
-            print(f"- {description}")
-            print()
-        else:
-            print(f"[{name}]: No command found")
-            print()
+    console.print(_available_servers_table(config))
 
 
-def cmd_a(names: list[str]) -> None:
-    """Add servers to local config."""
-    validate_local_config(suggest_init=True)
-    validate_global_config()
+def _normalise_name(name: str) -> str:
+    value = name.strip()
+    if not value:
+        raise typer.BadParameter("MCP server name must not be empty.")
+    return value
 
-    for name in names:
-        validate_server_name(name, "mcp-a")
 
-        if not server_exists_global(name):
-            print(f"Error: MCP server '{name}' not found in ~/.mcp.json")
-            show_available_servers(Path.home() / ".mcp.json")
+@app.command("a")
+def add_servers(
+    names: list[str] = typer.Argument(..., metavar="SERVER", help="Server names to add."),
+) -> None:
+    """Add servers from ~/.mcp.json into the local configuration."""
+
+    local_config = _load_local_config(suggest_init=True)
+    global_config = _load_global_config()
+
+    added_any = False
+    for raw_name in names:
+        name = _normalise_name(raw_name)
+
+        if name not in global_config.mcpServers:
+            console.print(
+                f"[bold red]Error[/]: MCP server '{name}' not found in ~/.mcp.json."
+            )
+            console.print(_available_servers_table(global_config))
             continue
 
-        if server_exists_local(name):
-            print(f"Error: MCP server '{name}' already exists in local .mcp.json")
+        if name in local_config.mcpServers:
+            console.print(
+                f"[bold yellow]Warning[/]: MCP server '{name}' already exists locally. Skipping."
+            )
             continue
 
-        # Get server config from global
-        global_config = Path.home() / ".mcp.json"
-        with open(global_config) as f:
-            global_data = json.load(f)
+        local_config.mcpServers[name] = global_config.mcpServers[name].model_copy(deep=True)
+        console.print(f"[bold green]✅[/] Added MCP server '{name}' to local .mcp.json.")
+        added_any = True
 
-        server_config = global_data["mcpServers"][name]
-
-        # Add to local
-        with open(".mcp.json") as f:
-            local_data = json.load(f)
-
-        local_data["mcpServers"][name] = server_config
-
-        with open(".mcp.json", "w") as f:
-            json.dump(local_data, f, indent=2)
-
-        print(f"✅ Added MCP server '{name}' to local .mcp.json")
+    if added_any:
+        _write_config(LOCAL_CONFIG_PATH, local_config)
 
 
-def cmd_rm(name: str) -> None:
-    """Remove server from local config."""
-    validate_server_name(name, "mcp-rm")
-    validate_local_config()
+@app.command("rm")
+def remove_server(
+    name: str = typer.Argument(..., metavar="SERVER", help="Server name to remove."),
+) -> None:
+    """Remove a server from the local configuration."""
 
-    if not server_exists_local(name):
-        print(f"Error: MCP server '{name}' not found in local .mcp.json")
-        print("Available servers in local config:")
-        show_available_servers(Path(".mcp.json"))
-        sys.exit(1)
+    local_config = _load_local_config()
+    key = _normalise_name(name)
 
-    with open(".mcp.json") as f:
-        data = json.load(f)
+    if key not in local_config.mcpServers:
+        console.print(
+            f"[bold red]Error[/]: MCP server '{key}' not found in local .mcp.json."
+        )
+        console.print(_available_servers_table(local_config))
+        raise typer.Exit(1)
 
-    del data["mcpServers"][name]
-
-    with open(".mcp.json", "w") as f:
-        json.dump(data, f, indent=2)
-
-    print(f"✅ Removed MCP server '{name}' from local .mcp.json")
+    del local_config.mcpServers[key]
+    _write_config(LOCAL_CONFIG_PATH, local_config)
+    console.print(f"[bold green]✅[/] Removed MCP server '{key}' from local .mcp.json.")
 
 
-def cmd_cmd(name: str) -> None:
-    """Show command for server and copy to clipboard."""
-    validate_server_name(name, "mcp-cmd")
-    validate_global_config()
+@app.command("cmd")
+def show_command(
+    name: str = typer.Argument(..., metavar="SERVER", help="Server name to inspect."),
+) -> None:
+    """Show and copy the launch command for a server."""
 
-    if not server_exists_global(name):
-        print(f"Error: MCP server '{name}' not found in ~/.mcp.json")
-        show_available_servers(Path.home() / ".mcp.json")
-        sys.exit(1)
+    global_config = _load_global_config()
+    key = _normalise_name(name)
 
-    global_config = Path.home() / ".mcp.json"
-    with open(global_config) as f:
-        data = json.load(f)
+    server = global_config.mcpServers.get(key)
+    if not server:
+        console.print(
+            f"[bold red]Error[/]: MCP server '{key}' not found in ~/.mcp.json."
+        )
+        console.print(_available_servers_table(global_config))
+        raise typer.Exit(1)
 
-    config = data["mcpServers"][name]
-    command = config.get("command")
+    command = server.command
     if not command:
-        print(f"Error: No command found for MCP server '{name}'")
-        sys.exit(1)
+        console.print(
+            f"[bold red]Error[/]: MCP server '{key}' does not define a command."
+        )
+        raise typer.Exit(1)
 
-    args = config.get("args", [])
-    full_command = f"{command} {' '.join(args)}" if args else command
+    formatted = server.display_command()
+    console.print(f"Command for '{key}': [bold]{formatted}[/]")
 
-    print(f"Command for '{name}': {full_command}")
-
-    # Copy to clipboard
-    add_format = f"{name} {full_command}"
+    add_format = f"{key} {formatted}"
     try:
         subprocess.run(["pbcopy"], input=add_format.encode(), check=True)
-        print(f"📋 Copied to clipboard: {add_format}")
+        console.print(f"[bold green]📋[/] Copied to clipboard: {add_format}")
     except subprocess.CalledProcessError:
-        print("Failed to copy to clipboard")
+        console.print("[bold red]Error[/]: Failed to copy command to clipboard.")
 
 
-def main():
-    parser = argparse.ArgumentParser(description="MCP Configuration Management")
-    subparsers = parser.add_subparsers(dest="command", help="Available commands")
-
-    # ini
-    subparsers.add_parser("ini", help="Initialize .mcp.json in current directory")
-
-    # ini-f
-    subparsers.add_parser("ini-f", help="Initialize .mcp.json from global config")
-
-    # ls
-    subparsers.add_parser("ls", help="List available MCP servers")
-
-    # a
-    parser_a = subparsers.add_parser("a", help="Add server to local config")
-    parser_a.add_argument("names", nargs="+", help="Server names")
-
-    # rm
-    parser_rm = subparsers.add_parser("rm", help="Remove server from local config")
-    parser_rm.add_argument("name", help="Server name")
-
-    # cmd
-    parser_cmd = subparsers.add_parser("cmd", help="Show command for server")
-    parser_cmd.add_argument("name", help="Server name")
-
-    args = parser.parse_args()
-
-    if args.command == "ini":
-        cmd_ini()
-    elif args.command == "ini-f":
-        cmd_ini_f()
-    elif args.command == "ls":
-        cmd_ls()
-    elif args.command == "a":
-        cmd_a(args.names)
-    elif args.command == "rm":
-        cmd_rm(args.name)
-    elif args.command == "cmd":
-        cmd_cmd(args.name)
-    else:
-        parser.print_help()
+def main() -> None:  # pragma: no cover - CLI entry
+    app()
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover - CLI entry
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 description = "Ansible playbook for my entire MacOS environment."
 authors = [{ name = "akitorahayashi" }]
 requires-python = ">=3.12,<4.0"
+dependencies = [
+    "typer>=0.12.0,<0.20.0",
+    "rich>=14.0,<15.0",
+    "pydantic>=2.0,<3.0",
+]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,15 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12, <4.0"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
 
 [[package]]
 name = "black"
@@ -67,9 +76,35 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "menv"
 version = "0.1.0"
 source = { virtual = "." }
+dependencies = [
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "typer" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -81,6 +116,11 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.0,<3.0" },
+    { name = "rich", specifier = ">=14.0,<15.0" },
+    { name = "typer", specifier = ">=0.12.0,<0.20.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -134,6 +174,84 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/da/b8a7ee04378a53f6fefefc0c5e05570a3ebfdfa0523a878bcd3b475683ee/pydantic-2.12.0.tar.gz", hash = "sha256:c1a077e6270dbfb37bfd8b498b3981e2bb18f68103720e51fa6c306a5a9af563", size = 814760, upload-time = "2025-10-07T15:58:03.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/9d/d5c855424e2e5b6b626fbc6ec514d8e655a600377ce283008b115abb7445/pydantic-2.12.0-py3-none-any.whl", hash = "sha256:f6a1da352d42790537e95e83a8bdfb91c7efbae63ffd0b86fa823899e807116f", size = 459730, upload-time = "2025-10-07T15:58:01.576Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/14/12b4a0d2b0b10d8e1d9a24ad94e7bbb43335eaf29c0c4e57860e8a30734a/pydantic_core-2.41.1.tar.gz", hash = "sha256:1ad375859a6d8c356b7704ec0f547a58e82ee80bb41baa811ad710e124bc8f2f", size = 454870, upload-time = "2025-10-07T10:50:45.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/bc/5f520319ee1c9e25010412fac4154a72e0a40d0a19eb00281b1f200c0947/pydantic_core-2.41.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:db2f82c0ccbce8f021ad304ce35cbe02aa2f95f215cac388eed542b03b4d5eb4", size = 2099300, upload-time = "2025-10-06T21:10:30.463Z" },
+    { url = "https://files.pythonhosted.org/packages/31/14/010cd64c5c3814fb6064786837ec12604be0dd46df3327cf8474e38abbbd/pydantic_core-2.41.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:47694a31c710ced9205d5f1e7e8af3ca57cbb8a503d98cb9e33e27c97a501601", size = 1910179, upload-time = "2025-10-06T21:10:31.782Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/2e/23fc2a8a93efad52df302fdade0a60f471ecc0c7aac889801ac24b4c07d6/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e9decce94daf47baf9e9d392f5f2557e783085f7c5e522011545d9d6858e00", size = 1957225, upload-time = "2025-10-06T21:10:33.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b6/6db08b2725b2432b9390844852e11d320281e5cea8a859c52c68001975fa/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ab0adafdf2b89c8b84f847780a119437a0931eca469f7b44d356f2b426dd9741", size = 2053315, upload-time = "2025-10-06T21:10:34.87Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d9/4de44600f2d4514b44f3f3aeeda2e14931214b6b5bf52479339e801ce748/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5da98cc81873f39fd56882e1569c4677940fbc12bce6213fad1ead784192d7c8", size = 2224298, upload-time = "2025-10-06T21:10:36.233Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/ae/dbe51187a7f35fc21b283c5250571a94e36373eb557c1cba9f29a9806dcf/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:209910e88afb01fd0fd403947b809ba8dba0e08a095e1f703294fda0a8fdca51", size = 2351797, upload-time = "2025-10-06T21:10:37.601Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a7/975585147457c2e9fb951c7c8dab56deeb6aa313f3aa72c2fc0df3f74a49/pydantic_core-2.41.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365109d1165d78d98e33c5bfd815a9b5d7d070f578caefaabcc5771825b4ecb5", size = 2074921, upload-time = "2025-10-06T21:10:38.927Z" },
+    { url = "https://files.pythonhosted.org/packages/62/37/ea94d1d0c01dec1b7d236c7cec9103baab0021f42500975de3d42522104b/pydantic_core-2.41.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:706abf21e60a2857acdb09502bc853ee5bce732955e7b723b10311114f033115", size = 2187767, upload-time = "2025-10-06T21:10:40.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/fe/694cf9fdd3a777a618c3afd210dba7b414cb8a72b1bd29b199c2e5765fee/pydantic_core-2.41.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:bf0bd5417acf7f6a7ec3b53f2109f587be176cb35f9cf016da87e6017437a72d", size = 2136062, upload-time = "2025-10-06T21:10:42.09Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/174aeabd89916fbd2988cc37b81a59e1186e952afd2a7ed92018c22f31ca/pydantic_core-2.41.1-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2e71b1c6ceb9c78424ae9f63a07292fb769fb890a4e7efca5554c47f33a60ea5", size = 2317819, upload-time = "2025-10-06T21:10:43.974Z" },
+    { url = "https://files.pythonhosted.org/packages/65/e8/e9aecafaebf53fc456314f72886068725d6fba66f11b013532dc21259343/pydantic_core-2.41.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:80745b9770b4a38c25015b517451c817799bfb9d6499b0d13d8227ec941cb513", size = 2312267, upload-time = "2025-10-06T21:10:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2f/1c2e71d2a052f9bb2f2df5a6a05464a0eb800f9e8d9dd800202fe31219e1/pydantic_core-2.41.1-cp312-cp312-win32.whl", hash = "sha256:83b64d70520e7890453f1aa21d66fda44e7b35f1cfea95adf7b4289a51e2b479", size = 1990927, upload-time = "2025-10-06T21:10:46.738Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/78/562998301ff2588b9c6dcc5cb21f52fa919d6e1decc75a35055feb973594/pydantic_core-2.41.1-cp312-cp312-win_amd64.whl", hash = "sha256:377defd66ee2003748ee93c52bcef2d14fde48fe28a0b156f88c3dbf9bc49a50", size = 2034703, upload-time = "2025-10-06T21:10:48.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/53/d95699ce5a5cdb44bb470bd818b848b9beadf51459fd4ea06667e8ede862/pydantic_core-2.41.1-cp312-cp312-win_arm64.whl", hash = "sha256:c95caff279d49c1d6cdfe2996e6c2ad712571d3b9caaa209a404426c326c4bde", size = 1972719, upload-time = "2025-10-06T21:10:50.256Z" },
+    { url = "https://files.pythonhosted.org/packages/27/8a/6d54198536a90a37807d31a156642aae7a8e1263ed9fe6fc6245defe9332/pydantic_core-2.41.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:70e790fce5f05204ef4403159857bfcd587779da78627b0babb3654f75361ebf", size = 2105825, upload-time = "2025-10-06T21:10:51.719Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/4784fd7b22ac9c8439db25bf98ffed6853d01e7e560a346e8af821776ccc/pydantic_core-2.41.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9cebf1ca35f10930612d60bd0f78adfacee824c30a880e3534ba02c207cceceb", size = 1910126, upload-time = "2025-10-06T21:10:53.145Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/92/31eb0748059ba5bd0aa708fb4bab9fcb211461ddcf9e90702a6542f22d0d/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:170406a37a5bc82c22c3274616bf6f17cc7df9c4a0a0a50449e559cb755db669", size = 1961472, upload-time = "2025-10-06T21:10:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/91/946527792275b5c4c7dde4cfa3e81241bf6900e9fee74fb1ba43e0c0f1ab/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12d4257fc9187a0ccd41b8b327d6a4e57281ab75e11dda66a9148ef2e1fb712f", size = 2063230, upload-time = "2025-10-06T21:10:57.179Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5d/a35c5d7b414e5c0749f1d9f0d159ee2ef4bab313f499692896b918014ee3/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a75a33b4db105dd1c8d57839e17ee12db8d5ad18209e792fa325dbb4baeb00f4", size = 2229469, upload-time = "2025-10-06T21:10:59.409Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4d/8713737c689afa57ecfefe38db78259d4484c97aa494979e6a9d19662584/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:08a589f850803a74e0fcb16a72081cafb0d72a3cdda500106942b07e76b7bf62", size = 2347986, upload-time = "2025-10-06T21:11:00.847Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ec/929f9a3a5ed5cda767081494bacd32f783e707a690ce6eeb5e0730ec4986/pydantic_core-2.41.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a97939d6ea44763c456bd8a617ceada2c9b96bb5b8ab3dfa0d0827df7619014", size = 2072216, upload-time = "2025-10-06T21:11:02.43Z" },
+    { url = "https://files.pythonhosted.org/packages/26/55/a33f459d4f9cc8786d9db42795dbecc84fa724b290d7d71ddc3d7155d46a/pydantic_core-2.41.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d2ae423c65c556f09569524b80ffd11babff61f33055ef9773d7c9fabc11ed8d", size = 2193047, upload-time = "2025-10-06T21:11:03.787Z" },
+    { url = "https://files.pythonhosted.org/packages/77/af/d5c6959f8b089f2185760a2779079e3c2c411bfc70ea6111f58367851629/pydantic_core-2.41.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:4dc703015fbf8764d6a8001c327a87f1823b7328d40b47ce6000c65918ad2b4f", size = 2140613, upload-time = "2025-10-06T21:11:05.607Z" },
+    { url = "https://files.pythonhosted.org/packages/58/e5/2c19bd2a14bffe7fabcf00efbfbd3ac430aaec5271b504a938ff019ac7be/pydantic_core-2.41.1-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:968e4ffdfd35698a5fe659e5e44c508b53664870a8e61c8f9d24d3d145d30257", size = 2327641, upload-time = "2025-10-06T21:11:07.143Z" },
+    { url = "https://files.pythonhosted.org/packages/93/ef/e0870ccda798c54e6b100aff3c4d49df5458fd64217e860cb9c3b0a403f4/pydantic_core-2.41.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:fff2b76c8e172d34771cd4d4f0ade08072385310f214f823b5a6ad4006890d32", size = 2318229, upload-time = "2025-10-06T21:11:08.73Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/4b/c3b991d95f5deb24d0bd52e47bcf716098fa1afe0ce2d4bd3125b38566ba/pydantic_core-2.41.1-cp313-cp313-win32.whl", hash = "sha256:a38a5263185407ceb599f2f035faf4589d57e73c7146d64f10577f6449e8171d", size = 1997911, upload-time = "2025-10-06T21:11:10.329Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/5c316fd62e01f8d6be1b7ee6b54273214e871772997dc2c95e204997a055/pydantic_core-2.41.1-cp313-cp313-win_amd64.whl", hash = "sha256:b42ae7fd6760782c975897e1fdc810f483b021b32245b0105d40f6e7a3803e4b", size = 2034301, upload-time = "2025-10-06T21:11:12.113Z" },
+    { url = "https://files.pythonhosted.org/packages/29/41/902640cfd6a6523194123e2c3373c60f19006447f2fb06f76de4e8466c5b/pydantic_core-2.41.1-cp313-cp313-win_arm64.whl", hash = "sha256:ad4111acc63b7384e205c27a2f15e23ac0ee21a9d77ad6f2e9cb516ec90965fb", size = 1977238, upload-time = "2025-10-06T21:11:14.1Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/28b040e88c1b89d851278478842f0bdf39c7a05da9e850333c6c8cbe7dfa/pydantic_core-2.41.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:440d0df7415b50084a4ba9d870480c16c5f67c0d1d4d5119e3f70925533a0edc", size = 1875626, upload-time = "2025-10-06T21:11:15.69Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/58/b41dd3087505220bb58bc81be8c3e8cbc037f5710cd3c838f44f90bdd704/pydantic_core-2.41.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:71eaa38d342099405dae6484216dcf1e8e4b0bebd9b44a4e08c9b43db6a2ab67", size = 2045708, upload-time = "2025-10-06T21:11:17.258Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b8/760f23754e40bf6c65b94a69b22c394c24058a0ef7e2aa471d2e39219c1a/pydantic_core-2.41.1-cp313-cp313t-win_amd64.whl", hash = "sha256:555ecf7e50f1161d3f693bc49f23c82cf6cdeafc71fa37a06120772a09a38795", size = 1997171, upload-time = "2025-10-06T21:11:18.822Z" },
+    { url = "https://files.pythonhosted.org/packages/41/12/cec246429ddfa2778d2d6301eca5362194dc8749ecb19e621f2f65b5090f/pydantic_core-2.41.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:05226894a26f6f27e1deb735d7308f74ef5fa3a6de3e0135bb66cdcaee88f64b", size = 2107836, upload-time = "2025-10-06T21:11:20.432Z" },
+    { url = "https://files.pythonhosted.org/packages/20/39/baba47f8d8b87081302498e610aefc37142ce6a1cc98b2ab6b931a162562/pydantic_core-2.41.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:85ff7911c6c3e2fd8d3779c50925f6406d770ea58ea6dde9c230d35b52b16b4a", size = 1904449, upload-time = "2025-10-06T21:11:22.185Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/9a3d87cae2c75a5178334b10358d631bd094b916a00a5993382222dbfd92/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47f1f642a205687d59b52dc1a9a607f45e588f5a2e9eeae05edd80c7a8c47674", size = 1961750, upload-time = "2025-10-06T21:11:24.348Z" },
+    { url = "https://files.pythonhosted.org/packages/27/42/a96c9d793a04cf2a9773bff98003bb154087b94f5530a2ce6063ecfec583/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:df11c24e138876ace5ec6043e5cae925e34cf38af1a1b3d63589e8f7b5f5cdc4", size = 2063305, upload-time = "2025-10-06T21:11:26.556Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/8d/028c4b7d157a005b1f52c086e2d4b0067886b213c86220c1153398dbdf8f/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7f0bf7f5c8f7bf345c527e8a0d72d6b26eda99c1227b0c34e7e59e181260de31", size = 2228959, upload-time = "2025-10-06T21:11:28.426Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f7/ee64cda8fcc9ca3f4716e6357144f9ee71166775df582a1b6b738bf6da57/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82b887a711d341c2c47352375d73b029418f55b20bd7815446d175a70effa706", size = 2345421, upload-time = "2025-10-06T21:11:30.226Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c0/e8ec05f0f5ee7a3656973ad9cd3bc73204af99f6512c1a4562f6fb4b3f7d/pydantic_core-2.41.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5f1d5d6bbba484bdf220c72d8ecd0be460f4bd4c5e534a541bb2cd57589fb8b", size = 2065288, upload-time = "2025-10-06T21:11:32.019Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/25/d77a73ff24e2e4fcea64472f5e39b0402d836da9b08b5361a734d0153023/pydantic_core-2.41.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2bf1917385ebe0f968dc5c6ab1375886d56992b93ddfe6bf52bff575d03662be", size = 2189759, upload-time = "2025-10-06T21:11:33.753Z" },
+    { url = "https://files.pythonhosted.org/packages/66/45/4a4ebaaae12a740552278d06fe71418c0f2869537a369a89c0e6723b341d/pydantic_core-2.41.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:4f94f3ab188f44b9a73f7295663f3ecb8f2e2dd03a69c8f2ead50d37785ecb04", size = 2140747, upload-time = "2025-10-06T21:11:35.781Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6d/b727ce1022f143194a36593243ff244ed5a1eb3c9122296bf7e716aa37ba/pydantic_core-2.41.1-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:3925446673641d37c30bd84a9d597e49f72eacee8b43322c8999fa17d5ae5bc4", size = 2327416, upload-time = "2025-10-06T21:11:37.75Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/8c/02df9d8506c427787059f87c6c7253435c6895e12472a652d9616ee0fc95/pydantic_core-2.41.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:49bd51cc27adb980c7b97357ae036ce9b3c4d0bb406e84fbe16fb2d368b602a8", size = 2318138, upload-time = "2025-10-06T21:11:39.463Z" },
+    { url = "https://files.pythonhosted.org/packages/98/67/0cf429a7d6802536941f430e6e3243f6d4b68f41eeea4b242372f1901794/pydantic_core-2.41.1-cp314-cp314-win32.whl", hash = "sha256:a31ca0cd0e4d12ea0df0077df2d487fc3eb9d7f96bbb13c3c5b88dcc21d05159", size = 1998429, upload-time = "2025-10-06T21:11:41.989Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/742fef93de5d085022d2302a6317a2b34dbfe15258e9396a535c8a100ae7/pydantic_core-2.41.1-cp314-cp314-win_amd64.whl", hash = "sha256:1b5c4374a152e10a22175d7790e644fbd8ff58418890e07e2073ff9d4414efae", size = 2028870, upload-time = "2025-10-06T21:11:43.66Z" },
+    { url = "https://files.pythonhosted.org/packages/31/38/cdd8ccb8555ef7720bd7715899bd6cfbe3c29198332710e1b61b8f5dd8b8/pydantic_core-2.41.1-cp314-cp314-win_arm64.whl", hash = "sha256:4fee76d757639b493eb600fba668f1e17475af34c17dd61db7a47e824d464ca9", size = 1974275, upload-time = "2025-10-06T21:11:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/7e/8ac10ccb047dc0221aa2530ec3c7c05ab4656d4d4bd984ee85da7f3d5525/pydantic_core-2.41.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f9b9c968cfe5cd576fdd7361f47f27adeb120517e637d1b189eea1c3ece573f4", size = 1875124, upload-time = "2025-10-06T21:11:47.591Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e4/7d9791efeb9c7d97e7268f8d20e0da24d03438a7fa7163ab58f1073ba968/pydantic_core-2.41.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1ebc7ab67b856384aba09ed74e3e977dded40e693de18a4f197c67d0d4e6d8e", size = 2043075, upload-time = "2025-10-06T21:11:49.542Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c3/3f6e6b2342ac11ac8cd5cb56e24c7b14afa27c010e82a765ffa5f771884a/pydantic_core-2.41.1-cp314-cp314t-win_amd64.whl", hash = "sha256:8ae0dc57b62a762985bc7fbf636be3412394acc0ddb4ade07fe104230f1b9762", size = 1995341, upload-time = "2025-10-06T21:11:51.497Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/3e/a51c5f5d37b9288ba30683d6e96f10fa8f1defad1623ff09f1020973b577/pydantic_core-2.41.1-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b04fa9ed049461a7398138c604b00550bc89e3e1151d84b81ad6dc93e39c4c06", size = 2115344, upload-time = "2025-10-07T10:50:02.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bd/389504c9e0600ef4502cd5238396b527afe6ef8981a6a15cd1814fc7b434/pydantic_core-2.41.1-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b3b7d9cfbfdc43c80a16638c6dc2768e3956e73031fca64e8e1a3ae744d1faeb", size = 1927994, upload-time = "2025-10-07T10:50:04.379Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9c/5111c6b128861cb792a4c082677e90dac4f2e090bb2e2fe06aa5b2d39027/pydantic_core-2.41.1-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eec83fc6abef04c7f9bec616e2d76ee9a6a4ae2a359b10c21d0f680e24a247ca", size = 1959394, upload-time = "2025-10-07T10:50:06.335Z" },
+    { url = "https://files.pythonhosted.org/packages/14/3f/cfec8b9a0c48ce5d64409ec5e1903cb0b7363da38f14b41de2fcb3712700/pydantic_core-2.41.1-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6771a2d9f83c4038dfad5970a3eef215940682b2175e32bcc817bdc639019b28", size = 2147365, upload-time = "2025-10-07T10:50:07.978Z" },
 ]
 
 [[package]]
@@ -230,6 +348,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -253,4 +384,49 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/00/e7f1501e81e8ec290e79527827af1d88f541d8d26151751b46108978dade/ruff-0.13.2-py3-none-win32.whl", hash = "sha256:7c2a0b7c1e87795fec3404a485096bcd790216c7c146a922d121d8b9c8f1aaac", size = 12245990, upload-time = "2025-09-25T14:54:03.647Z" },
     { url = "https://files.pythonhosted.org/packages/ee/bd/d9f33a73de84fafd0146c6fba4f497c4565fe8fa8b46874b8e438869abc2/ruff-0.13.2-py3-none-win_amd64.whl", hash = "sha256:17d95fb32218357c89355f6f6f9a804133e404fc1f65694372e02a557edf8585", size = 13324004, upload-time = "2025-09-25T14:54:06.05Z" },
     { url = "https://files.pythonhosted.org/packages/c3/12/28fa2f597a605884deb0f65c1b1ae05111051b2a7030f5d8a4ff7f4599ba/ruff-0.13.2-py3-none-win_arm64.whl", hash = "sha256:da711b14c530412c827219312b7d7fbb4877fb31150083add7e8c5336549cea7", size = 12484437, upload-time = "2025-09-25T14:54:08.022Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "typer"
+version = "0.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/58/a79003b91ac2c6890fc5d90145c662fd5771c6f11447f116b63300436bc9/typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722", size = 98953, upload-time = "2024-08-24T21:17:57.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/2b/886d13e742e514f704c33c4caa7df0f3b89e5a25ef8db02aa9ca3d9535d5/typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b", size = 47288, upload-time = "2024-08-24T21:17:55.451Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]


### PR DESCRIPTION
## Summary
- add Typer, Rich, and Pydantic as project dependencies for the Python CLI tooling
- refactor the SSH, MCP, aider, and submodule management scripts to use Typer with rich console output
- validate MCP and GitHub pull request JSON using Pydantic models and modernize related utilities

## Testing
- uv run ruff check

------
https://chatgpt.com/codex/tasks/task_e_68ec1209ad108320bb7c6f560b31a373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified, Typer-powered CLIs with Rich output for Aider, MCP manager, SSH manager, and Git submodule deletion.
  - Aider: set/unset model, list models, and run with flexible targets.
  - MCP: initialize local/global config, list/add/remove servers, and show server commands with table views.
  - SSH manager: generate keys, list hosts, and remove hosts with clear feedback.
- Refactor
  - Stronger input validation, safer path handling, and centralized error reporting across tools.
  - More consistent pull request listing with clearer fields and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->