### PR TITLE
Align LLM management tooling with mbk/mmn naming

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -22,6 +22,13 @@ A comprehensive automation project for setting up consistent macOS development e
    - Pipx and uv package managers
    - Ansible dependencies via `uv sync --frozen`
 
+## LLM Runtime Management
+Local LLM runtimes (Ollama, MLX) are managed via `just` commands.
+- `just llm-up mbk|mmn`: Start services for the specified profile.
+- `just llm-down mbk|mmn`: Stop services.
+- `just llm-ps mbk|mmn`: Check service status.
+- `just llm-logs mbk|mmn`: Show log file locations.
+
 ## Design Rules
 
 ### Configuration Path Resolution

--- a/README.md
+++ b/README.md
@@ -214,6 +214,11 @@ This project uses Ansible to automate the setup of a complete development enviro
     -   Downloads and executes the official installer from https://cli.coderabbit.ai/install.sh.
     -   Installs binary to `~/.local/bin/coderabbit` with alias `cr`.
 
+20. **LLM Runtimes (`llm` role)**
+    -   Manages local LLM runtimes like Ollama and MLX through a dedicated Python script.
+    -   Provides `just` recipes for starting, stopping, and checking the status of LLM services for different profiles (`mbk`, `mmn`).
+    -   Commands: `just llm-up <profile>`, `just llm-down <profile>`, `just llm-ps <profile>`, `just llm-logs <profile>` (`<profile>` is `mbk` or `mmn`).
+
 ## Automation Policies
 
 This section outlines key policies that govern how automation is implemented in this project.

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -15,5 +15,6 @@
     - { role: editor, tags: ["editor", "vscode", "cursor"] }
     - { role: coderabbit, tags: ["coderabbit"] }
     - { role: mcp, tags: ["mcp"] }
+    - { role: llm, tags: ["llm"] }
     - { role: system, tags: ["system"] }
     - { role: docker, tags: ["docker"] }

--- a/ansible/roles/llm/tasks/main.yml
+++ b/ansible/roles/llm/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: "Ensure ~/.scripts/python directory exists"
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.scripts/python"
+    state: directory
+    mode: "0755"
+
+- name: "Symlink LLM manager script"
+  ansible.builtin.file:
+    src: "{{ repo_root_path }}/ansible/scripts/shell/llm_manager.py"
+    dest: "{{ ansible_env.HOME }}/.scripts/python/llm_manager.py"
+    state: link
+    force: true
+    mode: "0755"
+
+- name: "Ensure .tmp directory exists for PID files"
+  ansible.builtin.file:
+    path: "{{ repo_root_path }}/.tmp"
+    state: directory
+    mode: "0700"

--- a/ansible/scripts/shell/llm_manager.py
+++ b/ansible/scripts/shell/llm_manager.py
@@ -1,0 +1,262 @@
+"""Utility for managing local LLM processes used in environment development."""
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+PID_DIR = Path(__file__).parent.parent.parent / ".tmp"
+
+
+@dataclass(frozen=True)
+class Service:
+    """Definition of a managed process."""
+
+    name: str
+    command: List[str]
+    log_filename: str
+    pid_filename: str
+
+    def log_path(self) -> Path:
+        return PID_DIR / self.log_filename
+
+    def pid_path(self) -> Path:
+        return PID_DIR / self.pid_filename
+
+
+def create_ollama_service(target_name: str) -> Service:
+    port = "11435" if target_name == "mmn" else "11434"
+    return Service(
+        name="ollama",
+        command=["ollama", "serve", "--host", f"0.0.0.0:{port}"],
+        log_filename=f"ollama-{target_name}.log",
+        pid_filename=f"ollama-{target_name}.pid",
+    )
+
+
+def create_mlx_service(target_name: str, port: int) -> Service:
+    return Service(
+        name="mlx",
+        command=[
+            "mlx_lm.server",
+            "--model",
+            "mlx-community/Llama-3.2-3B-Instruct-4bit",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            str(port),
+        ],
+        log_filename=f"mlx-{target_name}.log",
+        pid_filename=f"mlx-{target_name}.pid",
+    )
+
+
+TARGETS = {
+    "mmn": (
+        create_ollama_service("mmn"),
+        create_mlx_service("mmn", 8081),
+    ),
+    "mbk": (
+        create_ollama_service("mbk"),
+        create_mlx_service("mbk", 8080),
+    ),
+}
+
+
+def ensure_pid_dir() -> None:
+    PID_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+
+def is_process_running(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    else:
+        return True
+
+
+def read_pid(path: Path) -> int | None:
+    if not path.exists():
+        return None
+    try:
+        value = path.read_text().strip()
+        return int(value)
+    except (OSError, ValueError):
+        return None
+
+
+def write_pid(path: Path, pid: int) -> None:
+    path.write_text(f"{pid}\n")
+
+
+def remove_pid(path: Path) -> None:
+    path.unlink(missing_ok=True)
+
+
+def start_service(service: Service) -> None:
+    ensure_pid_dir()
+    pid_path = service.pid_path()
+    pid = read_pid(pid_path)
+    if pid and is_process_running(pid):
+        print(f"• {service.name} already running (pid {pid})")
+        return
+
+    log_file = service.log_path()
+    with log_file.open("ab", buffering=0) as log_handle:
+        try:
+            process = subprocess.Popen(
+                service.command,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Unable to start {service.name}: command '{service.command[0]}' not found"
+            ) from exc
+        else:
+            write_pid(pid_path, process.pid)
+            print(f"• Started {service.name} (pid {process.pid})")
+
+
+def stop_service(service: Service, *, force: bool = False) -> None:
+    pid_path = service.pid_path()
+    pid = read_pid(pid_path)
+    if pid:
+        if not is_process_running(pid):
+            remove_pid(pid_path)
+            print(f"• {service.name} pid {pid} not running; cleaned up pid file")
+            return
+
+        sig = signal.SIGKILL if force else signal.SIGTERM
+        try:
+            os.kill(pid, sig)
+        except OSError as exc:  # pragma: no cover - defensive
+            print(f"• Failed to stop {service.name} (pid {pid}): {exc}")
+        else:
+            remove_pid(pid_path)
+            print(f"• Stopped {service.name} (pid {pid})")
+    else:
+        try:
+            subprocess.run(
+                ["pkill", "-f", service.command[0]],
+                check=True,
+                capture_output=True,
+            )
+            print(f"• Stopped {service.name} (killed by process name)")
+        except subprocess.CalledProcessError:
+            print(f"• {service.name} is not running (no pid file or process found)")
+
+
+def status_service(service: Service) -> None:
+    pid = read_pid(service.pid_path())
+    if pid and is_process_running(pid):
+        print(f"• {service.name}: running (pid {pid})")
+    else:
+        print(f"• {service.name}: not running")
+
+
+def list_targets() -> str:
+    entries = [f"  - {name}" for name in sorted(TARGETS)]
+    return "\n".join(entries)
+
+
+def get_services(target: str) -> Iterable[Service]:
+    try:
+        return TARGETS[target]
+    except KeyError as exc:
+        raise SystemExit(
+            textwrap.dedent(
+                f"Unknown target '{target}'. Available targets:\n{list_targets()}"
+            )
+        ) from exc
+
+
+def cmd_up(target: str) -> None:
+    print(f"🚀 Starting {target} LLM runtimes...")
+    for service in get_services(target):
+        start_service(service)
+
+
+def cmd_down(target: str, *, force: bool) -> None:
+    print(f"🛑 Stopping {target} LLM runtimes...")
+    for service in get_services(target):
+        stop_service(service, force=force)
+
+
+def cmd_ps(target: str) -> None:
+    print(f"ℹ️  Status for {target} LLM runtimes:")
+    for service in get_services(target):
+        status_service(service)
+
+
+def cmd_logs(target: str) -> None:
+    print("Log files:")
+    for service in get_services(target):
+        print(f"• {service.name}: {service.log_path()}")
+    print("Use 'tail -f <log>' to follow output.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Manage local LLM runtimes for development.",
+    )
+    parser.add_argument(
+        "target",
+        choices=sorted(TARGETS.keys()),
+        help="Target environment to manage",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("up", help="Start the configured services")
+
+    down_parser = subparsers.add_parser("down", help="Stop the configured services")
+    down_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force-stop services using SIGKILL",
+    )
+
+    subparsers.add_parser("ps", help="Show running status of services")
+
+    subparsers.add_parser("logs", help="Display log file locations")
+
+    return parser
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    command_map = {
+        "up": lambda a: cmd_up(a.target),
+        "down": lambda a: cmd_down(a.target, force=getattr(a, 'force', False)),
+        "ps": lambda a: cmd_ps(a.target),
+        "logs": lambda a: cmd_logs(a.target),
+    }
+
+    try:
+        command_func = command_map.get(args.command)
+        if command_func:
+            command_func(args)
+        else:  # pragma: no cover - argparse enforces choices
+            parser.error(f"Unknown command {args.command}")
+            return 2
+    except RuntimeError as exc:
+        print(exc, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/justfile
+++ b/justfile
@@ -207,6 +207,30 @@ mmn-brew-cask:
   @just _run_ansible "brew" "mac-mini" "brew-cask"
 
 # ==============================================================================
+# LLM Runtimes
+# ==============================================================================
+
+# Start all LLM runtimes for a given profile (mbk or mmn)
+llm-up profile:
+  @echo "🚀 Starting {{profile}} LLM runtimes..."
+  @uv run python ansible/scripts/shell/llm_manager.py {{profile}} up
+
+# Stop all LLM runtimes for a given profile
+llm-down profile:
+  @echo "🛑 Stopping {{profile}} LLM runtimes..."
+  @uv run python ansible/scripts/shell/llm_manager.py {{profile}} down
+
+# Show status of LLM services for a given profile
+llm-ps profile:
+  @echo "ℹ️  Status of {{profile}} LLM services:"
+  @uv run python ansible/scripts/shell/llm_manager.py {{profile}} ps
+
+# Show logs of LLM services for a given profile
+llm-logs profile:
+  @echo "📜 Logs for {{profile}} LLM services:"
+  @uv run python ansible/scripts/shell/llm_manager.py {{profile}} logs
+
+# ==============================================================================
 # VCS Profile Switching
 # ==============================================================================
 sw-p:

--- a/tests/scripts/test_llm_manager.py
+++ b/tests/scripts/test_llm_manager.py
@@ -1,0 +1,117 @@
+"""Tests for the LLM manager script."""
+import importlib.util
+import signal
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "ansible" / "scripts" / "shell" / "llm_manager.py"
+SPEC = importlib.util.spec_from_file_location("menv_llm_manager", MODULE_PATH)
+assert SPEC and SPEC.loader
+llm_manager = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = llm_manager
+SPEC.loader.exec_module(llm_manager)
+
+
+@pytest.fixture
+def mock_paths(tmp_path, monkeypatch):
+    """Mock PID_DIR and service paths."""
+    pid_dir = tmp_path / ".tmp"
+    pid_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(llm_manager, "PID_DIR", pid_dir)
+    return pid_dir
+
+
+class TestLlmManager:
+    """Test suite for the LLM manager script."""
+
+    def test_cmd_up(self, mock_paths, capsys):
+        """Verify 'up' command starts processes."""
+        with patch.object(llm_manager.subprocess, "Popen") as mock_popen:
+            mock_process = MagicMock(pid=123)
+            mock_popen.return_value = mock_process
+            llm_manager.cmd_up("mbk")
+            captured = capsys.readouterr()
+            assert "Starting mbk LLM runtimes..." in captured.out
+            assert mock_popen.call_count == 2  # ollama and mlx
+            assert "Started ollama" in captured.out
+            assert "Started mlx" in captured.out
+
+    def test_cmd_down(self, mock_paths, capsys):
+        """Verify 'down' command stops processes."""
+        pid_dir = mock_paths
+        (pid_dir / "ollama-mbk.pid").write_text("12345")
+        (pid_dir / "mlx-mbk.pid").write_text("54321")
+
+        with patch.object(llm_manager.os, "kill") as mock_kill, patch.object(
+            llm_manager, "is_process_running", return_value=True
+        ):
+            llm_manager.cmd_down("mbk", force=False)
+            captured = capsys.readouterr()
+            assert "Stopping mbk LLM runtimes..." in captured.out
+            mock_kill.assert_any_call(12345, signal.SIGTERM)
+            mock_kill.assert_any_call(54321, signal.SIGTERM)
+            assert "Stopped ollama (pid 12345)" in captured.out
+            assert "Stopped mlx (pid 54321)" in captured.out
+
+    def test_cmd_ps(self, mock_paths, capsys):
+        """Verify 'ps' command shows correct status."""
+        pid_dir = mock_paths
+        (pid_dir / "ollama-mbk.pid").write_text("123")
+
+        with patch.object(
+            llm_manager,
+            "is_process_running",
+            side_effect=lambda pid: pid == 123,
+        ):
+            llm_manager.cmd_ps("mbk")
+            captured = capsys.readouterr()
+            assert "ollama: running (pid 123)" in captured.out
+            assert "mlx: not running" in captured.out
+
+    def test_main_entrypoint(self):
+        """Test the main function with CLI arguments."""
+        with patch.object(llm_manager, "cmd_up") as mock_up:
+            llm_manager.main(["mbk", "up"])
+            mock_up.assert_called_once_with("mbk")
+
+        with patch.object(llm_manager, "cmd_down") as mock_down:
+            llm_manager.main(["mmn", "down", "--force"])
+            mock_down.assert_called_once_with("mmn", force=True)
+
+    def test_build_parser_lists_targets(self):
+        """Ensure parser enforces targets and commands."""
+        parser = llm_manager.build_parser()
+        # Valid combinations should parse without raising.
+        parser.parse_args(["mmn", "up"])
+        parser.parse_args(["mbk", "logs"])
+
+        # Invalid target raises SystemExit from argparse.
+        with pytest.raises(SystemExit):
+            parser.parse_args(["invalid", "up"])
+
+        # Invalid command raises SystemExit from argparse.
+        with pytest.raises(SystemExit):
+            parser.parse_args(["mbk", "invalid-command"])
+
+
+class TestIsProcessRunning:
+    """Tests for the process detection helper."""
+
+    def test_is_process_running_true(self):
+        """Returns True when os.kill succeeds."""
+        with patch.object(llm_manager.os, "kill", return_value=None) as mock_kill:
+            assert llm_manager.is_process_running(123) is True
+            mock_kill.assert_called_once_with(123, 0)
+
+    def test_is_process_running_false(self):
+        """Returns False when process does not exist."""
+        with patch.object(llm_manager.os, "kill", side_effect=ProcessLookupError):
+            assert llm_manager.is_process_running(321) is False
+
+    def test_is_process_running_permission_error(self):
+        """Returns True when os.kill raises PermissionError."""
+        with patch.object(llm_manager.os, "kill", side_effect=PermissionError):
+            assert llm_manager.is_process_running(999) is True


### PR DESCRIPTION
## Summary
- update the LLM manager targets to use the mbk and mmn profile names consistently
- refresh contributor docs and justfile comments to reference the new profile naming

## Testing
- uv run pytest tests/scripts/test_llm_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68f2614a440483209f5e492d2a6b0117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new CLI commands for managing local LLM runtimes: `llm-up`, `llm-down`, `llm-ps`, and `llm-logs`
  * Support for multiple runtime profiles (mbk and mmn)
  * Ability to start, stop, check status, and view logs of LLM services

* **Documentation**
  * Added LLM runtime management documentation with usage examples

* **Tests**
  * Added comprehensive test coverage for LLM runtime management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->