### PR TITLE
Switch LLM tools installation from pnpm to npm

### DIFF
--- a/ansible/roles/nodejs/tasks/llm.yml
+++ b/ansible/roles/nodejs/tasks/llm.yml
@@ -1,10 +1,14 @@
 ---
-- name: "Install @anthropic-ai/claude-code via npm"
-  ansible.builtin.shell:
-    cmd: "source $(brew --prefix nvm)/nvm.sh && nvm use default && npm install -g @anthropic-ai/claude-code@latest"
-  changed_when: false
-  environment:
-    NVM_DIR: "{{ ansible_env.HOME }}/.nvm"
+- name: "Install LLM CLI tools via npm"
+  community.general.npm:
+    name: "{{ item }}"
+    version: "latest"
+    global: yes
+    executable: "{{ ansible_env.HOME }}/.nvm/versions/node/v{{ nodejs_version }}/bin/npm"
+  loop:
+    - "@anthropic-ai/claude-code"
+    - "@google/gemini-cli"
+    - "@openai/codex"
 
 - name: "Ensure Claude configuration directory exists"
   ansible.builtin.file:
@@ -31,13 +35,6 @@
     path: "{{ ansible_env.HOME }}/.claude/commands"
     state: directory
     mode: "0755"
-
-- name: "Install @google/gemini-cli via npm"
-  ansible.builtin.shell:
-    cmd: "source $(brew --prefix nvm)/nvm.sh && nvm use default && npm install -g @google/gemini-cli@latest"
-  changed_when: false
-  environment:
-    NVM_DIR: "{{ ansible_env.HOME }}/.nvm"
 
 - name: "Ensure Gemini configuration directory exists"
   ansible.builtin.file:
@@ -75,13 +72,6 @@
     path: "{{ ansible_env.HOME }}/.gemini/commands"
     state: directory
     mode: "0755"
-
-- name: "Install @openai/codex via npm"
-  ansible.builtin.shell:
-    cmd: "source $(brew --prefix nvm)/nvm.sh && nvm use default && npm install -g @openai/codex@latest"
-  changed_when: false
-  environment:
-    NVM_DIR: "{{ ansible_env.HOME }}/.nvm"
 
 - name: "Ensure Codex configuration directories exist"
   ansible.builtin.file:


### PR DESCRIPTION
This change modifies `ansible/roles/nodejs/tasks/llm.yml` to install Claude, Gemini, and Codex CLI tools using `npm` instead of `pnpm`. It also removes the `pnpm`-specific environment variables (`PNPM_HOME` and its addition to `PATH`) from these tasks, as `npm` is available directly through `nvm`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated installation of development tools (Claude, Gemini, Codex) into a single, unified install flow.
  * Removed legacy installation setup and related environment adjustments.
  * Added a runtime check that warns if the Gemini CLI isn’t available and adjusted tool configuration steps accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->