### PR TITLE
feat: rename --overlay option to --overwrite across commands and docu…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,13 @@ pipx-installable CLI for macOS dev environment setup using bundled Ansible playb
 
 | Command | Alias | Description |
 |---------|-------|-------------|
-| `menv create <profile>` | `cr` | Create core environment (macbook/mbk, mac-mini/mmn); use `-v` for verbose, `-o` for overlay |
-| `menv make <tag> [profile]` | `mk` | Run individual task (default: common); profile only needed for brew-formulae/brew-cask; use `-o` for overlay |
+| `menv create <profile>` | `cr` | Create core environment (macbook/mbk, mac-mini/mmn); use `-v` for verbose, `-o` for overwrite |
+| `menv make <tag> [profile]` | `mk` | Run individual task (default: common); profile only needed for brew-formulae/brew-cask; use `-o` for overwrite |
 | `menv list` | `ls` | List available tags |
 | `menv backup <target>` | `bk` | Backup system/VS Code |
 | `menv config set` | `cf set` | Set VCS identities interactively |
 | `menv config show` | `cf show` | Show current VCS identity configuration |
-| `menv config create [role]` | `cf cr [role]` | Deploy role configs to ~/.config/menv/; use `-o` for overlay |
+| `menv config create [role]` | `cf cr [role]` | Deploy role configs to ~/.config/menv/; use `-o` for overwrite |
 | `menv switch <profile>` | `sw` | Switch VCS identity (personal/p, work/w) |
 | `menv update` | `u` | Self-update via pipx |
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ menv ls
 menv make rust              # Run rust-platform + rust-tools
 menv make go                # Run go-platform + go-tools
 menv make python-tools      # Run python-tools
-menv make shell --overlay   # Force overwrite existing configs
+menv make shell --overwrite   # Force overwrite existing configs
 menv mk vscode              # Shorthand
 
 # LLM infrastructure (local models)
@@ -103,9 +103,9 @@ menv config set             # Configure VCS identities interactively
 menv config show            # Show current configuration
 menv config create          # Deploy all role configs to ~/.config/menv/
 menv config create rust     # Deploy only rust role config
-menv config create --overlay # Overwrite existing configs with package defaults
+menv config create --overwrite # Overwrite existing configs with package defaults
 menv cf set                 # Shorthand
-menv cf cr rust -o          # Shorthand with overlay
+menv cf cr rust -o          # Shorthand with overwrite
 ```
 
 **Switch VCS identity:**
@@ -133,9 +133,9 @@ menv introduce --help
 menv make --help
 ```
 
-**Create environment with overlay:**
+**Create environment with overwrite:**
 
 ```sh
-menv create macbook --overlay  # Force overwrite all configs during setup
-menv cr mbk -o                 # Shorthand with overlay
+menv create macbook --overwrite  # Force overwrite all configs during setup
+menv cr mbk -o                 # Shorthand with overwrite
 ```

--- a/src/menv/ansible/roles/rust/config/common/tools.yml
+++ b/src/menv/ansible/roles/rust/config/common/tools.yml
@@ -20,7 +20,7 @@ tools:
     tag: v2.0.0
   - name: mx
     git: git@github.com:akitorahayashi/mx.git
-    tag: v2.0.1
+    tag: v2.1.0
   - name: tls-rs
     git: git@github.com:akitorahayashi/tls-rs.git
     tag: v1.6.1

--- a/src/menv/commands/config.py
+++ b/src/menv/commands/config.py
@@ -106,9 +106,9 @@ def create_config(
         None,
         help="Role name to deploy config for. If omitted, deploys all roles.",
     ),
-    overlay: bool = typer.Option(
+    overwrite: bool = typer.Option(
         False,
-        "--overlay",
+        "--overwrite",
         "-o",
         help="Overwrite existing config with package defaults.",
     ),
@@ -121,14 +121,14 @@ def create_config(
     Examples:
         menv config create              # Deploy all role configs
         menv config create rust         # Deploy only rust config
-        menv config create --overlay    # Overwrite existing with defaults
-        menv cf cr rust -o              # Shorthand with overlay
+        menv config create --overwrite    # Overwrite existing with defaults
+        menv cf cr rust -o              # Shorthand with overwrite
     """
     app_ctx: AppContext = ctx.obj
 
     if role:
         # Deploy single role
-        result = app_ctx.config_deployer.deploy_role(role, overlay=overlay)
+        result = app_ctx.config_deployer.deploy_role(role, overwrite=overwrite)
         if result.success:
             console.print(f"[green]✓[/] {result.role}: {result.message}")
         else:
@@ -136,7 +136,7 @@ def create_config(
             raise typer.Exit(code=1)
     else:
         # Deploy all roles
-        results = app_ctx.config_deployer.deploy_all(overlay=overlay)
+        results = app_ctx.config_deployer.deploy_all(overwrite=overwrite)
         success_count = 0
         fail_count = 0
 

--- a/src/menv/commands/create.py
+++ b/src/menv/commands/create.py
@@ -128,9 +128,9 @@ def create(
         "-v",
         help="Enable verbose output.",
     ),
-    overlay: bool = typer.Option(
+    overwrite: bool = typer.Option(
         False,
-        "--overlay",
+        "--overwrite",
         "-o",
         help="Overwrite existing configuration files.",
     ),
@@ -193,13 +193,13 @@ def create(
     if roles_to_deploy:
         console.print("[bold]Deploying configurations...[/]")
         results = app_ctx.config_deployer.deploy_multiple_roles(
-            sorted(list(roles_to_deploy)), overlay=overlay
+            sorted(list(roles_to_deploy)), overwrite=overwrite
         )
 
         for result in results:
             if result.success:
                 # Only print a message for newly deployed configs
-                if overlay or "already exists" not in result.message:
+                if overwrite or "already exists" not in result.message:
                     console.print(f"  [dim]Deployed config for {result.role}[/]")
             else:
                 # Failure - which will be the last item in results

--- a/src/menv/commands/make.py
+++ b/src/menv/commands/make.py
@@ -43,18 +43,18 @@ def _get_roles_for_tags(app_ctx: AppContext, tags: list[str]) -> set[str]:
 
 
 def _deploy_configs_for_roles(
-    app_ctx: AppContext, roles: set[str], overlay: bool = False
+    app_ctx: AppContext, roles: set[str], overwrite: bool = False
 ) -> bool:
     """Deploy configs for roles if not already deployed.
 
     Returns True if all deployments succeeded, False otherwise.
     """
     for role in roles:
-        if overlay or not app_ctx.config_deployer.is_deployed(role):
-            result = app_ctx.config_deployer.deploy_role(role, overlay=overlay)
+        if overwrite or not app_ctx.config_deployer.is_deployed(role):
+            result = app_ctx.config_deployer.deploy_role(role, overwrite=overwrite)
             if result.success:
                 # Only print a message for newly deployed or overwritten configs
-                if overlay or "already exists" not in result.message:
+                if overwrite or "already exists" not in result.message:
                     console.print(f"[dim]Deployed config for {role}[/]")
             else:
                 console.print(f"[red]Error:[/] Failed to deploy config for {role}")
@@ -105,9 +105,9 @@ def make(
         "-v",
         help="Enable verbose output.",
     ),
-    overlay: bool = typer.Option(
+    overwrite: bool = typer.Option(
         False,
-        "--overlay",
+        "--overwrite",
         "-o",
         help="Overwrite existing configuration files.",
     ),
@@ -151,7 +151,7 @@ def make(
 
     # Auto-deploy configs for roles that will be executed
     roles_to_deploy = _get_roles_for_tags(app_ctx, tags_to_run)
-    if not _deploy_configs_for_roles(app_ctx, roles_to_deploy, overlay=overlay):
+    if not _deploy_configs_for_roles(app_ctx, roles_to_deploy, overwrite=overwrite):
         raise typer.Exit(code=1)
 
     console.print(f"[bold green]Running:[/] {tag}")

--- a/src/menv/protocols/config_deployer.py
+++ b/src/menv/protocols/config_deployer.py
@@ -29,23 +29,23 @@ class ConfigDeployerProtocol(Protocol):
         """
         ...
 
-    def deploy_role(self, role: str, overlay: bool = False) -> DeployResult:
+    def deploy_role(self, role: str, overwrite: bool = False) -> DeployResult:
         """Deploy config for a single role to ~/.config/menv/roles/{role}/.
 
         Args:
             role: The role name to deploy.
-            overlay: If True, overwrite existing config.
+            overwrite: If True, overwrite existing config.
 
         Returns:
             DeployResult with success status and message.
         """
         ...
 
-    def deploy_all(self, overlay: bool = False) -> list[DeployResult]:
+    def deploy_all(self, overwrite: bool = False) -> list[DeployResult]:
         """Deploy configs for all roles.
 
         Args:
-            overlay: If True, overwrite existing configs.
+            overwrite: If True, overwrite existing configs.
 
         Returns:
             List of DeployResult for each role.
@@ -94,13 +94,13 @@ class ConfigDeployerProtocol(Protocol):
         ...
 
     def deploy_multiple_roles(
-        self, roles: list[str], overlay: bool = False
+        self, roles: list[str], overwrite: bool = False
     ) -> list[DeployResult]:
         """Deploy configs for multiple roles, stopping on first failure.
 
         Args:
             roles: List of role names to deploy.
-            overlay: If True, overwrite existing configs.
+            overwrite: If True, overwrite existing configs.
 
         Returns:
             List of DeployResult for each role attempted.

--- a/src/menv/services/config_deployer.py
+++ b/src/menv/services/config_deployer.py
@@ -40,12 +40,12 @@ class ConfigDeployer:
                     found_roles.append(role_path.name)
         return sorted(found_roles)
 
-    def deploy_role(self, role: str, overlay: bool = False) -> DeployResult:
+    def deploy_role(self, role: str, overwrite: bool = False) -> DeployResult:
         """Deploy config for a single role to ~/.config/menv/roles/{role}/.
 
         Args:
             role: The role name to deploy.
-            overlay: If True, overwrite existing config.
+            overwrite: If True, overwrite existing config.
 
         Returns:
             DeployResult with success status and message.
@@ -68,19 +68,19 @@ class ConfigDeployer:
         local_config = self.get_local_config_path(role)
 
         # Check if already deployed
-        if local_config.exists() and not overlay:
+        if local_config.exists() and not overwrite:
             return DeployResult(
                 role=role,
                 success=True,
-                message="Config already exists (use --overlay to overwrite).",
+                message="Config already exists (use --overwrite to overwrite).",
                 path=local_config,
             )
 
         # Create parent directories
         local_config.parent.mkdir(parents=True, exist_ok=True)
 
-        # Remove existing if overlay
-        if local_config.exists() and overlay:
+        # Remove existing if overwrite
+        if local_config.exists() and overwrite:
             shutil.rmtree(local_config)
 
         # Copy config directory
@@ -93,18 +93,18 @@ class ConfigDeployer:
             path=local_config,
         )
 
-    def deploy_all(self, overlay: bool = False) -> list[DeployResult]:
+    def deploy_all(self, overwrite: bool = False) -> list[DeployResult]:
         """Deploy configs for all roles.
 
         Args:
-            overlay: If True, overwrite existing configs.
+            overwrite: If True, overwrite existing configs.
 
         Returns:
             List of DeployResult for each role.
         """
         results = []
         for role in self.roles_with_config:
-            result = self.deploy_role(role, overlay=overlay)
+            result = self.deploy_role(role, overwrite=overwrite)
             results.append(result)
         return results
 
@@ -150,13 +150,13 @@ class ConfigDeployer:
         return list(self.roles_with_config)
 
     def deploy_multiple_roles(
-        self, roles: list[str], overlay: bool = False
+        self, roles: list[str], overwrite: bool = False
     ) -> list[DeployResult]:
         """Deploy configs for multiple roles, stopping on first failure.
 
         Args:
             roles: List of role names to deploy.
-            overlay: If True, overwrite existing configs.
+            overwrite: If True, overwrite existing configs.
 
         Returns:
             List of DeployResult for each role attempted.
@@ -164,7 +164,7 @@ class ConfigDeployer:
         """
         results = []
         for role in roles:
-            result = self.deploy_role(role, overlay=overlay)
+            result = self.deploy_role(role, overwrite=overwrite)
             results.append(result)
             if not result.success:
                 break

--- a/tests/mocks/config_deployer.py
+++ b/tests/mocks/config_deployer.py
@@ -45,12 +45,12 @@ class MockConfigDeployer(ConfigDeployerProtocol):
         """Return list of roles with config directories."""
         return self._roles_with_config
 
-    def deploy_role(self, role: str, overlay: bool = False) -> DeployResult:
+    def deploy_role(self, role: str, overwrite: bool = False) -> DeployResult:
         """Mock deploy config for a single role.
 
         Args:
             role: The role name to deploy.
-            overlay: If True, overwrite existing config.
+            overwrite: If True, overwrite existing config.
 
         Returns:
             DeployResult with success status and message.
@@ -64,11 +64,11 @@ class MockConfigDeployer(ConfigDeployerProtocol):
 
         local_path = self.get_local_config_path(role)
 
-        if role in self._deployed_roles and not overlay:
+        if role in self._deployed_roles and not overwrite:
             return DeployResult(
                 role=role,
                 success=True,
-                message="Config already exists (use --overlay to overwrite).",
+                message="Config already exists (use --overwrite to overwrite).",
                 path=local_path,
             )
 
@@ -80,18 +80,18 @@ class MockConfigDeployer(ConfigDeployerProtocol):
             path=local_path,
         )
 
-    def deploy_all(self, overlay: bool = False) -> list[DeployResult]:
+    def deploy_all(self, overwrite: bool = False) -> list[DeployResult]:
         """Mock deploy configs for all roles.
 
         Args:
-            overlay: If True, overwrite existing configs.
+            overwrite: If True, overwrite existing configs.
 
         Returns:
             List of DeployResult for each role.
         """
         results = []
         for role in self.roles_with_config:
-            result = self.deploy_role(role, overlay=overlay)
+            result = self.deploy_role(role, overwrite=overwrite)
             results.append(result)
         return results
 
@@ -137,13 +137,13 @@ class MockConfigDeployer(ConfigDeployerProtocol):
         return list(self.roles_with_config)
 
     def deploy_multiple_roles(
-        self, roles: list[str], overlay: bool = False
+        self, roles: list[str], overwrite: bool = False
     ) -> list[DeployResult]:
         """Deploy configs for multiple roles, stopping on first failure.
 
         Args:
             roles: List of role names to deploy.
-            overlay: If True, overwrite existing configs.
+            overwrite: If True, overwrite existing configs.
 
         Returns:
             List of DeployResult for each role attempted.
@@ -151,7 +151,7 @@ class MockConfigDeployer(ConfigDeployerProtocol):
         """
         results = []
         for role in roles:
-            result = self.deploy_role(role, overlay=overlay)
+            result = self.deploy_role(role, overwrite=overwrite)
             results.append(result)
             if not result.success:
                 break

--- a/tests/unit/commands/test_config.py
+++ b/tests/unit/commands/test_config.py
@@ -53,14 +53,14 @@ class TestConfigCommand:
         result = cli_runner.invoke(app, ["config", "create", "--help"])
 
         assert result.exit_code == 0
-        assert "--overlay" in result.output or "-o" in result.output
+        assert "--overwrite" in result.output or "-o" in result.output
 
     def test_cf_cr_alias_works(self, cli_runner: CliRunner) -> None:
         """Test that 'cf cr' alias for config create works."""
         result = cli_runner.invoke(app, ["cf", "cr", "--help"])
 
         assert result.exit_code == 0
-        assert "--overlay" in result.output or "-o" in result.output
+        assert "--overwrite" in result.output or "-o" in result.output
 
     def test_config_create_invalid_role_shows_error(
         self, cli_runner: CliRunner

--- a/tests/unit/commands/test_create.py
+++ b/tests/unit/commands/test_create.py
@@ -59,16 +59,16 @@ class TestCreateCommand:
         assert result.exit_code == 0
         assert "--verbose" in result.output or "-v" in result.output
 
-    def test_create_shows_overlay_option(self, cli_runner: CliRunner) -> None:
-        """Test that create --help shows --overlay/-o option."""
+    def test_create_shows_overwrite_option(self, cli_runner: CliRunner) -> None:
+        """Test that create --help shows --overwrite/-o option."""
         result = cli_runner.invoke(app, ["create", "--help"])
 
         assert result.exit_code == 0
-        assert "--overlay" in result.output or "-o" in result.output
+        assert "--overwrite" in result.output or "-o" in result.output
 
-    def test_create_overlay_option_accepted(self, cli_runner: CliRunner) -> None:
-        """Test that --overlay option is accepted without error."""
-        result = cli_runner.invoke(app, ["create", "macbook", "--overlay", "--help"])
+    def test_create_overwrite_option_accepted(self, cli_runner: CliRunner) -> None:
+        """Test that --overwrite option is accepted without error."""
+        result = cli_runner.invoke(app, ["create", "macbook", "--overwrite", "--help"])
 
         # --help should show command help without running
         assert result.exit_code == 0

--- a/tests/unit/commands/test_make.py
+++ b/tests/unit/commands/test_make.py
@@ -51,16 +51,16 @@ class TestMakeCommand:
         # Should show error about missing argument
         assert result.exit_code != 0 or "TAG" in result.output
 
-    def test_make_shows_overlay_option(self, cli_runner: CliRunner) -> None:
-        """Test that make --help shows --overlay/-o option."""
+    def test_make_shows_overwrite_option(self, cli_runner: CliRunner) -> None:
+        """Test that make --help shows --overwrite/-o option."""
         result = cli_runner.invoke(app, ["make", "--help"])
 
         assert result.exit_code == 0
-        assert "--overlay" in result.output or "-o" in result.output
+        assert "--overwrite" in result.output or "-o" in result.output
 
-    def test_make_overlay_option_accepted(self, cli_runner: CliRunner) -> None:
-        """Test that --overlay option is accepted without error."""
-        result = cli_runner.invoke(app, ["make", "shell", "--overlay", "--help"])
+    def test_make_overwrite_option_accepted(self, cli_runner: CliRunner) -> None:
+        """Test that --overwrite option is accepted without error."""
+        result = cli_runner.invoke(app, ["make", "shell", "--overwrite", "--help"])
 
         # --help should show command help without running
         assert result.exit_code == 0

--- a/tests/unit/services/test_config_deployer.py
+++ b/tests/unit/services/test_config_deployer.py
@@ -125,7 +125,7 @@ class TestConfigDeployer:
         )
         assert rust_version_path.read_text() == "1.75.0"
 
-    def test_deploy_role_skips_if_exists_without_overlay(
+    def test_deploy_role_skips_if_exists_without_overwrite(
         self, deployer: ConfigDeployer, temp_home: Path
     ) -> None:
         """Test that deploy_role skips deployment if config exists."""
@@ -144,18 +144,18 @@ class TestConfigDeployer:
         )
         local_file.write_text("1.80.0")
 
-        # Second deployment without overlay
-        result = deployer.deploy_role("rust", overlay=False)
+        # Second deployment without overwrite
+        result = deployer.deploy_role("rust", overwrite=False)
 
         assert result.success is True
         assert "already exists" in result.message
         # File should not be overwritten
         assert local_file.read_text() == "1.80.0"
 
-    def test_deploy_role_overwrites_with_overlay(
+    def test_deploy_role_overwrites_with_overwrite(
         self, deployer: ConfigDeployer, temp_home: Path
     ) -> None:
-        """Test that deploy_role overwrites config with overlay flag."""
+        """Test that deploy_role overwrites config with overwrite flag."""
         # First deployment
         deployer.deploy_role("rust")
 
@@ -171,8 +171,8 @@ class TestConfigDeployer:
         )
         local_file.write_text("1.80.0")
 
-        # Second deployment with overlay
-        result = deployer.deploy_role("rust", overlay=True)
+        # Second deployment with overwrite
+        result = deployer.deploy_role("rust", overwrite=True)
 
         assert result.success is True
         assert "Deployed" in result.message
@@ -284,10 +284,10 @@ class TestDeployMultipleRoles:
 
         assert results == []
 
-    def test_deploy_multiple_roles_with_overlay(
+    def test_deploy_multiple_roles_with_overwrite(
         self, deployer: ConfigDeployer, temp_home: Path
     ) -> None:
-        """Test that deploy_multiple_roles respects overlay flag."""
+        """Test that deploy_multiple_roles respects overwrite flag."""
         # First deployment
         deployer.deploy_multiple_roles(["rust"])
 
@@ -303,8 +303,8 @@ class TestDeployMultipleRoles:
         )
         local_file.write_text("modified")
 
-        # Second deployment with overlay
-        results = deployer.deploy_multiple_roles(["rust"], overlay=True)
+        # Second deployment with overwrite
+        results = deployer.deploy_multiple_roles(["rust"], overwrite=True)
 
         assert len(results) == 1
         assert results[0].success is True


### PR DESCRIPTION
…mentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed CLI flag from `--overlay` to `--overwrite` for the create, make, and config create commands (short flag `-o` remains unchanged)

* **Chores**
  * Updated mx tool to v2.1.0

* **Tests**
  * Updated tests to align with terminology changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->