### PR TITLE
Observer: Report Python anti-patterns and structural findings

### DIFF
--- a/.jules/roles/observers/pythonista/notes/structure.md
+++ b/.jules/roles/observers/pythonista/notes/structure.md
@@ -1,0 +1,18 @@
+# Project Structure Analysis
+
+## Service Layer (`src/menv/services/`)
+- Adheres to Protocol/Implementation pattern (`Protocol` suffix in `src/menv/protocols/`).
+- Anti-patterns identified:
+  - `AnsiblePaths`: Unsafe resource cleanup (`__del__` with `except Exception: pass`).
+  - `VersionChecker`: Swallowed exceptions hiding failures.
+  - `ConfigStorage`: Fragile manual TOML serialization.
+  - `AnsibleRunner`: I/O mixing (direct `sys.stdout` and `subprocess`).
+
+## Commands (`src/menv/commands/`)
+- Uses `Typer` for CLI.
+- Dependency injection via `AppContext`.
+- Architecture violation: `list` command logic resides in `make.py`.
+- Boundary issue: `TypedDict` (`MenvConfig`) used without runtime validation at IO boundary.
+
+## Models (`src/menv/models/`)
+- `TypedDict` usage provides type hints but no runtime safety for external data (config files).

--- a/.jules/workstreams/generic/events/pending/architectural-violation-commands.yml
+++ b/.jules/workstreams/generic/events/pending/architectural-violation-commands.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+id: "ev0005"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "pythonista"
+confidence: "medium"
+title: "Architectural violation in commands structure"
+statement: |
+  The `list` command logic (`list_tags`) is implemented within `src/menv/commands/make.py` instead of having its own dedicated module, violating the project's one-command-per-file architectural pattern.
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "64-83"
+    note: "list_tags function implementation inside make.py"
+  - path: "src/menv/main.py"
+    loc:
+      - "74"
+    note: "list command import from make module"
+tags:
+  - "python"
+  - "architecture"
+  - "consistency"

--- a/.jules/workstreams/generic/events/pending/io-mixing-ansible-runner.yml
+++ b/.jules/workstreams/generic/events/pending/io-mixing-ansible-runner.yml
@@ -1,0 +1,18 @@
+schema_version: 1
+id: "ev0004"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "pythonista"
+confidence: "high"
+title: "I/O mixing in AnsibleRunner"
+statement: |
+  The AnsibleRunner service mixes business logic with low-level I/O operations by directly invoking `subprocess` and writing to `sys.stdout`. This coupling makes the service difficult to test and violates the separation of concerns.
+evidence:
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "83-95"
+    note: "run_playbook method uses subprocess and writes directly to sys.stdout"
+tags:
+  - "python"
+  - "anti-pattern"
+  - "testability"

--- a/.jules/workstreams/generic/events/pending/manual-toml-serialization.yml
+++ b/.jules/workstreams/generic/events/pending/manual-toml-serialization.yml
@@ -1,0 +1,18 @@
+schema_version: 1
+id: "ev0003"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "pythonista"
+confidence: "high"
+title: "Manual TOML serialization in ConfigStorage"
+statement: |
+  The ConfigStorage service implements manual TOML serialization by string concatenation instead of using a reliable library (e.g., tomlkit). This is fragile, error-prone, and reinvents the wheel.
+evidence:
+  - path: "src/menv/services/config_storage.py"
+    loc:
+      - "57-79"
+    note: "save method manually constructs TOML string with basic escaping"
+tags:
+  - "python"
+  - "anti-pattern"
+  - "maintainability"

--- a/.jules/workstreams/generic/events/pending/swallowed-exceptions-version-checker.yml
+++ b/.jules/workstreams/generic/events/pending/swallowed-exceptions-version-checker.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+id: "ev0002"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "pythonista"
+confidence: "high"
+title: "Swallowed exceptions in VersionChecker"
+statement: |
+  The VersionChecker service swallows exceptions (HTTPError, KeyError, ValueError, Exception) in `get_latest_version` and `needs_update` without logging or surfacing the cause, making debugging network or parsing issues impossible.
+evidence:
+  - path: "src/menv/services/version_checker.py"
+    loc:
+      - "38-39"
+    note: "get_latest_version swallows multiple exceptions and returns None"
+  - path: "src/menv/services/version_checker.py"
+    loc:
+      - "45-46"
+    note: "needs_update swallows broad Exception and returns False"
+tags:
+  - "python"
+  - "anti-pattern"
+  - "observability"

--- a/.jules/workstreams/generic/events/pending/unsafe-cleanup-ansible-paths.yml
+++ b/.jules/workstreams/generic/events/pending/unsafe-cleanup-ansible-paths.yml
@@ -1,0 +1,18 @@
+schema_version: 1
+id: "ev0001"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "pythonista"
+confidence: "high"
+title: "Unsafe resource cleanup in AnsiblePaths"
+statement: |
+  The AnsiblePaths service uses `__del__` for resource cleanup with a swallowed exception. This relies on the garbage collector which is not guaranteed to run, and the naked except block hides potential errors during cleanup.
+evidence:
+  - path: "src/menv/services/ansible_paths.py"
+    loc:
+      - "41-47"
+    note: "__del__ implementation with `except Exception: pass`"
+tags:
+  - "python"
+  - "anti-pattern"
+  - "reliability"


### PR DESCRIPTION
Performed static analysis of the `menv` codebase as the `pythonista` observer.
Identified and documented 5 key anti-patterns/issues:
1.  Unsafe resource cleanup in `AnsiblePaths` (swallowing exceptions in `__del__`).
2.  Swallowed exceptions in `VersionChecker` (hiding failures).
3.  Fragile manual TOML serialization in `ConfigStorage`.
4.  I/O mixing in `AnsibleRunner` (logic coupled with `subprocess` and `sys.stdout`).
5.  Architectural violation: `list` command implementation inside `make.py`.

Generated corresponding event files in `.jules/workstreams/generic/events/pending/` and updated the observer's declarative memory.

---
*PR created automatically by Jules for task [6986328257184901084](https://jules.google.com/task/6986328257184901084) started by @akitorahayashi*