### PR TITLE
docs: report taxonomy inconsistencies and update notes

### DIFF
--- a/.jules/roles/observers/taxonomy/notes/project_structure.md
+++ b/.jules/roles/observers/taxonomy/notes/project_structure.md
@@ -1,0 +1,21 @@
+# Project Structure and Naming Conventions
+
+## Commands
+*   **Location:** `src/menv/commands/`
+*   **Convention:** One command per file (e.g., `create.py` for `menv create`).
+*   **Violations:**
+    *   `list` command is implemented in `make.py` as `list_tags`.
+
+## Services
+*   **Location:** `src/menv/services/`
+*   **Convention:** One class per file, matching the service name (e.g., `config_storage.py` -> `ConfigStorage`).
+*   **Status:** Consistent.
+
+## Protocols
+*   **Location:** `src/menv/protocols/`
+*   **Convention:** `XxxProtocol` suffix.
+*   **Status:** Consistent.
+
+## Models
+*   **Location:** `src/menv/models/`
+*   **Status:** Consistent.

--- a/.jules/roles/observers/taxonomy/notes/vocabulary.md
+++ b/.jules/roles/observers/taxonomy/notes/vocabulary.md
@@ -1,0 +1,29 @@
+# Vocabulary and Terminology
+
+## Conflicts
+
+### Config
+*   **Concept 1:** User Identity (Name, Email).
+    *   *Managed by:* `ConfigStorage`.
+    *   *CLI:* `menv config set`, `menv config show`.
+*   **Concept 2:** Role Configuration (Ansible Variables).
+    *   *Managed by:* `ConfigDeployer`.
+    *   *CLI:* `menv config create`.
+*   **Status:** **Ambiguous**. One term maps to two distinct concepts.
+
+### Create
+*   **Concept 1:** Provision Environment.
+    *   *CLI:* `menv create`.
+*   **Concept 2:** Deploy Configuration Files.
+    *   *CLI:* `menv config create`.
+    *   *Internal Term:* `deploy`.
+*   **Status:** **Ambiguous**. "Create" is overloaded.
+
+### Make vs Run
+*   **Concept:** Execute a task/tag.
+*   **CLI:** `make`.
+*   **Internal Term:** `run` (`AnsibleRunner.run_playbook`).
+*   **Status:** **Inconsistent**.
+
+## Phantom Terms
+*   `introduce`: Referenced in documentation but does not exist.

--- a/.jules/workstreams/generic/events/pending/ambiguous-config-terminology.yml
+++ b/.jules/workstreams/generic/events/pending/ambiguous-config-terminology.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "jan9q0"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Ambiguous Config Terminology"
+statement: |
+  The term "config" is overloaded in the CLI to refer to both user identity settings and Ansible role configuration files, violating the "One Concept, One Preferred Term" principle.
+
+evidence:
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "set_config"
+    note: "Uses 'config' to mean VCS identity (ConfigStorage)."
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "create_config"
+    note: "Uses 'config' to mean Role Configuration (ConfigDeployer)."
+
+tags:
+  - "vocabulary"
+  - "ux"

--- a/.jules/workstreams/generic/events/pending/ambiguous-create-terminology.yml
+++ b/.jules/workstreams/generic/events/pending/ambiguous-create-terminology.yml
@@ -1,0 +1,28 @@
+schema_version: 1
+id: "3c8uqb"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Ambiguous Create Terminology"
+statement: |
+  The verb "create" is used for both environment provisioning (`menv create`) and configuration deployment (`menv config create`), confusing the user action and violating "User-facing vocabulary aligned with code-level terminology". Code uses "deploy" for the config action.
+
+evidence:
+  - path: "src/menv/commands/create.py"
+    loc:
+      - "create"
+    note: "Command to provision environment."
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "create_config"
+    note: "Command to deploy config files."
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "ConfigDeployer.deploy_role"
+    note: "Code terminology is 'deploy'."
+
+tags:
+  - "vocabulary"
+  - "ux"

--- a/.jules/workstreams/generic/events/pending/command-structure-inconsistency.yml
+++ b/.jules/workstreams/generic/events/pending/command-structure-inconsistency.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+id: "5ny1wp"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Command Structure Inconsistency: list in make.py"
+statement: |
+  The `list` command is implemented as `list_tags` inside `src/menv/commands/make.py`
+  rather than in a dedicated file, violating the project's one-command-per-file convention.
+
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "list_tags"
+    note: "Function defined here."
+  - path: "src/menv/main.py"
+    loc:
+      - "app.command(name=\"list\"..."
+    note: "Command registered here pointing to menv.commands.make.list_tags."
+
+tags:
+  - "consistency"
+  - "architecture"

--- a/.jules/workstreams/generic/events/pending/list-tags-docstring-error.yml
+++ b/.jules/workstreams/generic/events/pending/list-tags-docstring-error.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "l4lcv3"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "List Tags Docstring Error"
+statement: |
+  The docstring for `list_tags` in `src/menv/commands/make.py` provides incorrect usage examples (`menv make list`), implying `list` is a subcommand of `make`. However, `list` is registered as a top-level command (`menv list`) in `main.py`.
+
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "list_tags"
+    note: "Docstring claims usage: 'menv make list'."
+  - path: "src/menv/main.py"
+    loc:
+      - "app.command(name=\"list\"..."
+    note: "Registered as top-level 'list' command."
+
+tags:
+  - "documentation"
+  - "consistency"

--- a/.jules/workstreams/generic/events/pending/make-vs-run-terminology.yml
+++ b/.jules/workstreams/generic/events/pending/make-vs-run-terminology.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "5n9fed"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Make vs Run Terminology"
+statement: |
+  The CLI uses `menv make` to run tasks, while the codebase consistently uses "Run" (`AnsibleRunner`, `run_playbook`). The use of "make" is likely a historical artifact and is inconsistent with the internal domain language.
+
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "make"
+    note: "CLI command is 'make'."
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "AnsibleRunner.run_playbook"
+    note: "Service method is 'run_playbook'."
+
+tags:
+  - "vocabulary"
+  - "ux"

--- a/.jules/workstreams/generic/events/pending/phantom-introduce-command.yml
+++ b/.jules/workstreams/generic/events/pending/phantom-introduce-command.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "rkfo1y"
+issue_id: ""
+created_at: "2026-01-31"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Phantom Introduce Command"
+statement: |
+  The `README.md` file references a `menv introduce` command, but no such command exists in the codebase (`main.py` or `commands/`). This is a "ghost name" that should be removed or implemented.
+
+evidence:
+  - path: "README.md"
+    loc:
+      - "menv introduce --help"
+    note: "Documentation mentions this command."
+  - path: "src/menv/main.py"
+    loc:
+      - "app"
+    note: "Command is not registered here."
+
+tags:
+  - "documentation"
+  - "consistency"


### PR DESCRIPTION
Analyzed the codebase for taxonomy and naming inconsistencies.

Findings:
- **Command Structure:** `list` command is implemented in `make.py`, violating "one command per file".
- **Ambiguity:** "config" refers to both identity and role vars. "create" refers to provisioning and deployment.
- **Inconsistency:** CLI uses "make", code uses "run".
- **Documentation:** Phantom `introduce` command in README. Incorrect docstring for `list_tags`.

Artifacts created:
- Event files in `.jules/workstreams/generic/events/pending/`.
- Note files in `.jules/roles/observers/taxonomy/notes/`.

---
*PR created automatically by Jules for task [16785908861893506296](https://jules.google.com/task/16785908861893506296) started by @akitorahayashi*