### PR TITLE
obs: report list cmd and llm profile inconsistencies

### DIFF
--- a/.jules/roles/observers/consistency/notes/project_structure.md
+++ b/.jules/roles/observers/consistency/notes/project_structure.md
@@ -1,0 +1,18 @@
+# Project Structure Observations
+
+## CLI Command Structure
+- **Pattern**: `src/menv/commands/<command>.py`.
+- **Constraint**: `AGENTS.md` requires "1 command per file".
+- **Status**: Mostly followed (backup, config, create, make, switch, update).
+- **Exceptions**: The `list` command is implemented within `src/menv/commands/make.py`.
+
+## Ansible Role Configuration
+- **Pattern**: `src/menv/ansible/roles/<role>/config/{common,profiles}/`.
+- **Constraint**: Documentation claims only `brew` role uses `profiles`.
+- **Status**: Contradicted by implementation.
+- **Exceptions**: `llm` role utilizes `config/profiles/mac-mini/models.yml`.
+
+## Role Implementation
+- **Roles**: brew, editor, gh, go, llm, nodejs, python, ruby, rust, shell, ssh, system, vcs.
+- **Node.js**: Includes `coder` task.
+- **Rust**: Uses `tools.yml` to define GitHub release downloads.

--- a/.jules/workstreams/generic/events/pending/arch-violation-list-command.yml
+++ b/.jules/workstreams/generic/events/pending/arch-violation-list-command.yml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+# Metadata
+id: "c9x8z1"
+issue_id: ""
+created_at: "2024-05-22"
+author_role: "consistency"
+confidence: "high"
+
+# Content
+title: "Architecture Violation: list command file placement"
+statement: |
+  The `list` command (alias `ls`) is implemented as `list_tags` within `src/menv/commands/make.py` and registered in `src/menv/main.py`. This violates the explicit architectural rule in `AGENTS.md` which states "CLI commands (1 command per file)".
+
+# Evidence supporting the observation
+evidence:
+  - path: "AGENTS.md"
+    loc:
+      - "Architecture Principles"
+    note: "Explicitly states: 'CLI commands (1 command per file)'"
+
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "def list_tags"
+    note: "Implementation of the list command residing in make.py"
+
+  - path: "src/menv/main.py"
+    loc:
+      - "app.command(name='list'"
+    note: "Registration of the list command using the function from make.py"
+
+tags:
+  - "architecture"
+  - "cli"

--- a/.jules/workstreams/generic/events/pending/doc-drift-profile-usage.yml
+++ b/.jules/workstreams/generic/events/pending/doc-drift-profile-usage.yml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+# Metadata
+id: "m4n9p2"
+issue_id: ""
+created_at: "2024-05-22"
+author_role: "consistency"
+confidence: "high"
+
+# Content
+title: "Documentation Drift: Profile Usage in llm role"
+statement: |
+  The documentation (`README.md` and `AGENTS.md`) explicitly states that only the `brew` role utilizes profile-specific configurations. However, the `llm` role implementation includes a `profiles/` directory with `models.yml`, indicating undisclosed profile support.
+
+# Evidence supporting the observation
+evidence:
+  - path: "README.md"
+    loc:
+      - "Design principle"
+    note: "States: 'Only brew-formulae and brew-cask require profile specification'"
+
+  - path: "AGENTS.md"
+    loc:
+      - "Profile Design"
+    note: "States: 'Only brew role has profile-specific configs'"
+
+  - path: "src/menv/ansible/roles/llm/config/profiles/mac-mini/models.yml"
+    loc:
+      - "File existence"
+    note: "Demonstrates that llm role uses profile-based configuration"
+
+tags:
+  - "documentation"
+  - "drift"


### PR DESCRIPTION
Reported architecture violation for 'list' command placement and documentation drift for 'llm' role profile usage.

- Created `.jules/workstreams/generic/events/pending/arch-violation-list-command.yml`
- Created `.jules/workstreams/generic/events/pending/doc-drift-profile-usage.yml`
- Updated `.jules/roles/observers/consistency/notes/project_structure.md`

---
*PR created automatically by Jules for task [12744063576868958204](https://jules.google.com/task/12744063576868958204) started by @akitorahayashi*