### PR TITLE
DevOps Observer: Critique CI/CD for Artifact Promotion Gaps

### DIFF
--- a/.jules/roles/observers/devops/notes/ci_architecture.md
+++ b/.jules/roles/observers/devops/notes/ci_architecture.md
@@ -29,3 +29,4 @@ The project uses GitHub Actions for CI/CD, heavily relying on the `menv` CLI too
 
 ### Artifacts
 - **No Build Artifacts**: The pipelines currently run scripts and verifications but do not produce immutable artifacts (e.g., binaries, containers) for promotion. The "artifact" is implicitly the source code or the PyPI package (not yet seen in release workflow).
+- **Violation of "Ship Artifacts, Not Scripts"**: Without a build step producing a versioned artifact (e.g., Wheel, PEX), deployments rely on checking out source code, which risks "prod is different" drift and makes rollback difficult.

--- a/.jules/workstreams/generic/events/pending/ci-missing-artifact-promotion.yml
+++ b/.jules/workstreams/generic/events/pending/ci-missing-artifact-promotion.yml
@@ -1,0 +1,19 @@
+workstream: generic
+type: observation
+severity: medium
+title: Missing Artifact Promotion Pipeline
+description: >
+  The current CI/CD pipeline runs tests and checks but does not produce immutable build artifacts (e.g., Python wheels, PEX binaries, or Docker images).
+  Deployment relies on source code or implicit "latest" state, violating the "Ship artifacts, not scripts" principle.
+  This makes it impossible to cryptographically verify what code is running in an environment or to rollback to a specific known-good binary.
+evidence:
+  - file: .github/workflows/ci-workflows.yml
+    line: 1
+    content: "name: MacOS Environment Setup CI Pipeline"
+  - file: .github/workflows/ci-workflows.yml
+    line: 11
+    content: "uses: ./.github/workflows/lint-and-test.yml"
+recommendation: >
+  Implement a `build` job that produces a versioned Python Wheel (`.whl`) or PEX binary.
+  Upload this artifact to GitHub Actions Artifacts or a package registry.
+  Subsequent steps (e.g., release, deploy) should consume this exact artifact rather than checking out source code again.


### PR DESCRIPTION
Identified that the CI/CD pipeline does not produce immutable artifacts (e.g., wheels, PEX) and relies on source code, which violates DevOps principles. Created a pending event to track this finding and updated the DevOps role notes. Confirmed other potential findings were duplicates of existing events.

---
*PR created automatically by Jules for task [5659507154369268027](https://jules.google.com/task/5659507154369268027) started by @akitorahayashi*