### PR TITLE
Update taxonomy observer notes and events

### DIFF
--- a/.jules/roles/observers/taxonomy/notes/project_structure.md
+++ b/.jules/roles/observers/taxonomy/notes/project_structure.md
@@ -9,7 +9,9 @@
 ## Services
 *   **Location:** `src/menv/services/`
 *   **Convention:** One class per file, matching the service name (e.g., `config_storage.py` -> `ConfigStorage`).
-*   **Status:** Consistent.
+*   **Violations:**
+    *   `PlaybookService` in `playbook.py` (filename mismatch).
+    *   `PlaybookService` uses generic "Service" suffix unlike other domain services.
 
 ## Protocols
 *   **Location:** `src/menv/protocols/`

--- a/.jules/roles/observers/taxonomy/notes/vocabulary.md
+++ b/.jules/roles/observers/taxonomy/notes/vocabulary.md
@@ -25,5 +25,19 @@
 *   **Internal Term:** `run` (`AnsibleRunner.run_playbook`).
 *   **Status:** **Inconsistent**.
 
+### System
+*   **Concept 1:** macOS Defaults/Preferences.
+    *   *Managed by:* `roles/system`.
+*   **Concept 2:** General Unix Utilities.
+    *   *Managed by:* `roles/shell/config/common/alias/system/macos.sh`.
+*   **Status:** **Overloaded**. "System" is used for both OS preferences and basic shell tools.
+
+### Apple vs MacOS
+*   **Concept 1:** Development Tools (Xcode, Swift).
+    *   *Term:* `Apple` (`alias/apple.sh`).
+*   **Concept 2:** System/Unix Utilities.
+    *   *Term:* `MacOS` (`alias/system/macos.sh`).
+*   **Status:** **Vague**. "Apple" and "MacOS" are overlapping terms used for distinct but adjacent categories.
+
 ## Phantom Terms
 *   `introduce`: Referenced in documentation but does not exist.

--- a/.jules/workstreams/generic/events/pending/generic-service-name-playbook.yml
+++ b/.jules/workstreams/generic/events/pending/generic-service-name-playbook.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "ev_playbook_service_name"
+issue_id: ""
+created_at: "2026-05-22"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Generic Service Name: PlaybookService"
+statement: |
+  The class `PlaybookService` in `src/menv/services/playbook.py` uses the generic suffix "Service" despite being a domain model wrapper/registry. This is inconsistent with other service names (e.g., `AnsibleRunner`, `ConfigDeployer`) which describe their specific function. Additionally, the filename `playbook.py` does not match the class name `PlaybookService` (expected `playbook_service.py` or class `Playbook`).
+
+evidence:
+  - path: "src/menv/services/playbook.py"
+    loc:
+      - "class PlaybookService"
+    note: "Class name includes generic 'Service' suffix."
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "class AnsibleRunner"
+    note: "Other services use specific functional names."
+
+tags:
+  - "naming"
+  - "consistency"

--- a/.jules/workstreams/generic/events/pending/overloaded-system-terminology.yml
+++ b/.jules/workstreams/generic/events/pending/overloaded-system-terminology.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "ev_system_terminology"
+issue_id: ""
+created_at: "2026-05-22"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Overloaded Terminology: System"
+statement: |
+  The term "system" is used for the Ansible role managing macOS defaults (`roles/system`) and simultaneously for a category of shell aliases (`roles/shell/config/common/alias/system`) containing general Unix utilities. This creates ambiguity about the boundary of "system" responsibilities and violates "One Concept, One Preferred Term".
+
+evidence:
+  - path: "src/menv/ansible/roles/system"
+    loc:
+      - "tasks/main.yml"
+    note: "Manages macOS defaults (Finder, Dock, etc.)."
+  - path: "src/menv/ansible/roles/shell/config/common/alias/system"
+    loc:
+      - "macos.sh"
+    note: "Contains general Unix utilities like cat, echo, mkdir."
+
+tags:
+  - "naming"
+  - "ambiguity"

--- a/.jules/workstreams/generic/events/pending/vague-apple-terminology.yml
+++ b/.jules/workstreams/generic/events/pending/vague-apple-terminology.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "ev_apple_terminology"
+issue_id: ""
+created_at: "2026-05-22"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Vague Terminology: Apple vs MacOS"
+statement: |
+  The shell alias file `apple.sh` groups development tools (Xcode, Swift) under the vendor name "Apple", while system utilities are grouped under "MacOS" (`system/macos.sh`). This overlapping terminology violates "One Concept, One Preferred Term" and creates vague boundaries. "Apple" is too broad, and "MacOS" is used for Unix utilities rather than OS specifics.
+
+evidence:
+  - path: "src/menv/ansible/roles/shell/config/common/alias/apple.sh"
+    loc:
+      - "alias sw=swift"
+    note: "Contains Xcode and Swift aliases."
+  - path: "src/menv/ansible/roles/shell/config/common/alias/system/macos.sh"
+    loc:
+      - "alias mkd=mkdir"
+    note: "Contains generic Unix aliases."
+
+tags:
+  - "naming"
+  - "ambiguity"


### PR DESCRIPTION
Identified and documented three new taxonomy violations:
1.  `PlaybookService` uses a generic suffix and has a filename mismatch (`playbook.py` vs `PlaybookService`).
2.  "System" is overloaded between the Ansible role (macOS defaults) and shell aliases (Unix utils).
3.  "Apple" vs "MacOS" terminology in shell aliases is vague and overlapping.

Updated declarative memory (`vocabulary.md`, `project_structure.md`) and created corresponding event files in `.jules/workstreams/generic/events/pending/`.

---
*PR created automatically by Jules for task [15764727279089965373](https://jules.google.com/task/15764727279089965373) started by @akitorahayashi*