### PR TITLE
docs: record broken backup command event and update structure notes

### DIFF
--- a/.jules/roles/observers/consistency/notes/project_structure.md
+++ b/.jules/roles/observers/consistency/notes/project_structure.md
@@ -6,6 +6,11 @@
 - **Status**: Mostly followed (backup, config, create, make, switch, update).
 - **Exceptions**: The `list` command is implemented within `src/menv/commands/make.py`.
 
+## Command Functionality Issues
+- **Backup**: Broken implementation. `menv backup` fails to pass required arguments (`config_dir`) to backend scripts.
+- **Introduce**: Missing implementation. Documented in `README.md` but does not exist in codebase.
+- **List**: Documentation error. Docstrings in `src/menv/commands/make.py` incorrectly reference `menv make list` instead of `menv list`.
+
 ## Ansible Role Configuration
 - **Pattern**: `src/menv/ansible/roles/<role>/config/{common,profiles}/`.
 - **Constraint**: Documentation claims only `brew` role uses `profiles`.

--- a/.jules/workstreams/generic/events/pending/broken-backup-command.yml
+++ b/.jules/workstreams/generic/events/pending/broken-backup-command.yml
@@ -1,0 +1,28 @@
+schema_version: 1
+id: "brk001"
+created_at: "2026-01-31"
+author_role: "consistency"
+confidence: "high"
+
+title: "Broken Backup Command Implementation"
+statement: |
+  The `menv backup` command is documented and implemented but crashes upon execution because it fails to pass required arguments (`config_dir`) to the underlying scripts `backup-system.py` and `backup-extensions.py`. The command is effectively broken.
+
+evidence:
+  - path: "src/menv/commands/backup.py"
+    loc:
+      - "process = subprocess.Popen([sys.executable, str(script_path)], ...)"
+    note: "Calls script without arguments."
+  - path: "src/menv/ansible/scripts/system/backup-system.py"
+    loc:
+      - "parser.add_argument(\"config_dir\", ...)"
+    note: "Requires config_dir argument."
+  - path: "src/menv/ansible/scripts/editor/backup-extensions.py"
+    loc:
+      - "parser.add_argument(\"config_dir\", ...)"
+    note: "Requires config_dir argument."
+
+tags:
+  - "bug"
+  - "consistency"
+  - "drift"


### PR DESCRIPTION
Identified and documented a critical issue where the `menv backup` command fails to execute because it does not pass required arguments to the underlying scripts. Also updated project structure notes to reflect this and other known command inconsistencies.

---
*PR created automatically by Jules for task [7298004483926799309](https://jules.google.com/task/7298004483926799309) started by @akitorahayashi*