### PR TITLE
Update coverage risk documentation regarding CLI test environment leakage

### DIFF
--- a/.jules/roles/observers/cov/notes/risks.md
+++ b/.jules/roles/observers/cov/notes/risks.md
@@ -11,9 +11,12 @@
 **Evidence:** Absence of `tests/unit/services/test_ansible_runner.py`.
 
 ## 3. False Safety & Environment Leakage
-**Observation:** CLI tests (e.g., `tests/unit/commands/test_config.py`) execute against the real user filesystem (`~/.config/menv`) instead of an isolated test environment.
-**Cause:** `src/menv/main.py` instantiates dependencies (like `ConfigStorage`) with default arguments inside the `main` callback, preventing `Typer`'s `CliRunner` from injecting mocks.
+**Observation:** CLI tests execute against the real user filesystem (`~/.config/menv`) instead of an isolated test environment. This is a systemic issue affecting `test_config.py`, `test_make.py`, `test_create.py`, and likely others.
+**Cause:** `src/menv/main.py` instantiates dependencies (like `ConfigStorage`, `PlaybookService`, `AnsiblePaths`) with default arguments inside the `main` callback. The tests use `CliRunner` to invoke the app directly, which triggers this hardcoded dependency injection, bypassing any attempts at mocking.
 **Risk:**
-  - Tests passing "by accident" due to user's local config.
-  - Tests potentially modifying or deleting user's actual configuration.
-**Evidence:** `src/menv/main.py` dependency injection pattern.
+  - Tests passing "by accident" due to the developer's local environment configuration (e.g., `test_make.py` reading the real installed playbook).
+  - Tests potentially modifying or deleting user's actual configuration (`test_config.py`).
+**Evidence:**
+  - `src/menv/main.py` dependency injection pattern.
+  - `tests/unit/commands/test_config.py` relying on user config state.
+  - `tests/unit/commands/test_make.py` reading installed playbook.


### PR DESCRIPTION
Updated `.jules/roles/observers/cov/notes/risks.md` to provide a more accurate and comprehensive analysis of the testing risks, specifically focusing on the environment leakage in CLI tests due to the project's dependency injection pattern. No code changes were made; this is a documentation update for the observer role's memory.

---
*PR created automatically by Jules for task [7965456716274377607](https://jules.google.com/task/7965456716274377607) started by @akitorahayashi*