### PR TITLE
Report Python architectural issues (ConfigDeployer IO, Make Logic)

### DIFF
--- a/.jules/roles/observers/pythonista/notes/structure.md
+++ b/.jules/roles/observers/pythonista/notes/structure.md
@@ -7,11 +7,13 @@
   - `VersionChecker`: Swallowed exceptions hiding failures.
   - `ConfigStorage`: Fragile manual TOML serialization.
   - `AnsibleRunner`: I/O mixing (direct `sys.stdout` and `subprocess`).
+  - `ConfigDeployer`: Unsafe I/O operations (missing exception handling).
 
 ## Commands (`src/menv/commands/`)
 - Uses `Typer` for CLI.
 - Dependency injection via `AppContext`.
 - Architecture violation: `list` command logic resides in `make.py`.
+- Architecture violation: `make` command contains business logic and hardcoded data.
 - Boundary issue: `TypedDict` (`MenvConfig`) used without runtime validation at IO boundary.
 
 ## Models (`src/menv/models/`)

--- a/.jules/workstreams/generic/events/pending/logic-leakage-make-command.yml
+++ b/.jules/workstreams/generic/events/pending/logic-leakage-make-command.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+
+# Metadata
+id: "b9q3fz"
+issue_id: ""
+created_at: "2024-10-24"
+author_role: "pythonista"
+confidence: "high"
+
+# Content
+title: "Logic Leakage in Make Command"
+statement: |
+  The `make` command module (`src/menv/commands/make.py`) contains significant business logic and hardcoded configuration data. It defines `TAG_GROUPS` and `VALID_PROFILES` locally instead of retrieving them from a Single Source of Truth (SSOT), and implements logic for role discovery and config deployment (`_get_roles_for_tags`, `_deploy_configs_for_roles`) that belongs in the service layer.
+
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "TAG_GROUPS"
+      - "_get_roles_for_tags"
+      - "_deploy_configs_for_roles"
+    note: "Hardcoded data structures and private methods implementing domain logic within the command layer, violating separation of concerns."
+
+tags:
+  - "python"
+  - "architecture"
+  - "separation-of-concerns"

--- a/.jules/workstreams/generic/events/pending/unsafe-io-config-deployer.yml
+++ b/.jules/workstreams/generic/events/pending/unsafe-io-config-deployer.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+
+# Metadata
+id: "7d9x2a"
+issue_id: ""
+created_at: "2024-10-24"
+author_role: "pythonista"
+confidence: "high"
+
+# Content
+title: "Unsafe I/O in ConfigDeployer"
+statement: |
+  The `ConfigDeployer` service performs file system operations (copying trees, reading directories) without any exception handling. This allows raw `OSError` exceptions to propagate up to the CLI, causing crashes instead of controlled failures, and violates the principle that exceptions are part of the API.
+
+evidence:
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "deploy_role"
+      - "roles_with_config"
+    note: "Methods use shutil.copytree, shutil.rmtree, and Path.iterdir without try/except blocks, swallowing context and leaking implementation details."
+
+tags:
+  - "python"
+  - "exception-handling"
+  - "boundary-violation"


### PR DESCRIPTION
Reported two new architectural issues found during Python codebase analysis:
1. Unsafe I/O operations in `ConfigDeployer` (missing exception handling).
2. Business logic leakage and hardcoded data in `make` command module.

Updated the `structure.md` declarative memory to reflect these findings.

---
*PR created automatically by Jules for task [9893420137786171234](https://jules.google.com/task/9893420137786171234) started by @akitorahayashi*