### PR TITLE
Detect and document documentation-implementation drift

### DIFF
--- a/.jules/roles/observers/consistency/notes/doc_drift_patterns.md
+++ b/.jules/roles/observers/consistency/notes/doc_drift_patterns.md
@@ -1,0 +1,18 @@
+# Documentation Drift Patterns
+
+## Observed Patterns
+
+### 1. Phantom Documentation
+Documentation (e.g., `README.md`) references commands or features that do not exist in the codebase.
+- **Example:** `menv introduce --help` is listed in `README.md` but the `introduce` command is not registered in `src/menv/main.py`.
+- **Risk:** Users attempt to run documented commands and fail, eroding trust in documentation.
+
+### 2. Inaccurate Examples
+Internal documentation (docstrings) provides usage examples that contradict the actual CLI registration.
+- **Example:** `src/menv/commands/make.py` docstring uses `menv make list`, but the command is registered as `menv list` (or `menv ls`) in `src/menv/main.py`.
+- **Risk:** Developers relying on docstrings for usage info will be misled.
+
+### 3. Unverified Wrappers
+CLI command wrappers invoke backend scripts without adhering to the script's interface, causing runtime failures.
+- **Example:** `menv backup` wrapper (`src/menv/commands/backup.py`) fails to pass the required `config_dir` argument to the underlying backend scripts (`scripts/system/backup-system.py`), causing them to crash.
+- **Root Cause:** Lack of integration tests verifying the end-to-end execution of CLI wrappers.

--- a/.jules/workstreams/generic/events/pending/docs-implementation-drift.yml
+++ b/.jules/workstreams/generic/events/pending/docs-implementation-drift.yml
@@ -1,0 +1,45 @@
+schema_version: 1
+
+# Metadata
+id: "dr1ft0"
+issue_id: "" # ID of the issue that processed this event (empty if unprocessed)
+created_at: "2024-05-22"
+author_role: "consistency"
+confidence: "high"
+
+# Content
+title: "Documentation and Implementation Drift"
+statement: |
+  Multiple inconsistencies detected between documentation (`README.md`, docstrings) and implementation (`src/menv`).
+  1. `README.md` references a non-existent `menv introduce` command.
+  2. `src/menv/commands/make.py` docstring incorrectly documents `menv make list` which is implemented as `menv list`.
+  3. `menv backup` fails at runtime because the CLI wrapper does not pass the required `config_dir` argument to backend scripts, contradicting the implied contract of a working command.
+
+# Evidence supporting the observation
+evidence:
+  - path: "README.md"
+    loc:
+      - "Show help"
+    note: "References `menv introduce --help` which does not exist in `main.py`."
+  - path: "src/menv/main.py"
+    loc:
+      - "app definition"
+    note: "No `introduce` command registered."
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "def list_tags"
+    note: "Docstring example `menv make list` conflicts with registration `menv list`."
+  - path: "src/menv/commands/backup.py"
+    loc:
+      - "subprocess.Popen"
+    note: "Calls backend script without arguments."
+  - path: "src/menv/ansible/scripts/system/backup-system.py"
+    loc:
+      - "parse_args"
+    note: "Requires `config_dir` argument."
+
+tags:
+  - "consistency"
+  - "drift"
+  - "documentation"
+  - "bug"


### PR DESCRIPTION
Created consistency observer event `dr1ft0` and note `doc_drift_patterns.md` documenting inconsistencies between documentation (`README.md`, docstrings) and implementation (`src/menv`), specifically the phantom `introduce` command, incorrect `make list` usage, and broken `backup` command.

---
*PR created automatically by Jules for task [2607339183069840225](https://jules.google.com/task/2607339183069840225) started by @akitorahayashi*