### PR TITLE
Record data architecture observations

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/duplicate-config-path.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/duplicate-config-path.yml
@@ -1,0 +1,30 @@
+schema_version: 1
+
+id: "d1path"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "data_arch"
+confidence: "high"
+
+title: "Duplicate Definition of Configuration Path"
+statement: |
+  The user configuration root path `~/.config/menv` is defined redundantly in at least three different services without a shared constant or configuration object.
+
+evidence:
+  - path: "src/menv/services/config_storage.py"
+    loc:
+      - "ConfigStorage.__init__"
+    note: "Defines default config_dir path."
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "ConfigDeployer.__init__"
+    note: "Defines _local_config_root path independently."
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "AnsibleRunner.run_playbook"
+    note: "Defines local_config_root path independently."
+
+tags:
+  - "ssot-violation"
+  - "redundancy"
+  - "config-management"

--- a/.jules/workstreams/generic/exchange/events/pending/manual-toml-serialization.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/manual-toml-serialization.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+
+id: "d2toml"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "data_arch"
+confidence: "high"
+
+title: "Manual TOML Serialization"
+statement: |
+  `ConfigStorage.save` manually constructs TOML strings instead of using a serialization library, leading to potential escaping issues and maintenance fragility.
+
+evidence:
+  - path: "src/menv/services/config_storage.py"
+    loc:
+      - "save"
+    note: "Method manually concatenates strings to form TOML output."
+
+tags:
+  - "inefficient-transformation"
+  - "fragility"
+  - "serialization"

--- a/.jules/workstreams/generic/exchange/events/pending/misplaced-list-command.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/misplaced-list-command.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+
+id: "d4list"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "data_arch"
+confidence: "medium"
+
+title: "Misplaced List Command Implementation"
+statement: |
+  The `list` command logic is implemented as `list_tags` inside `src/menv/commands/make.py` instead of a dedicated module, violating the project's file-per-command structure.
+
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "list_tags"
+    note: "Command implementation resides in wrong module."
+  - path: "src/menv/main.py"
+    loc:
+      - "app.command(name=\"list\""
+    note: "Imports list_tags from menv.commands.make."
+
+tags:
+  - "coupling"
+  - "architectural-violation"
+  - "separation-of-concerns"

--- a/.jules/workstreams/generic/exchange/events/pending/unvalidated-config-model.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/unvalidated-config-model.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+
+id: "d3conf"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "data_arch"
+confidence: "high"
+
+title: "Missing Validation for Configuration Model"
+statement: |
+  `MenvConfig` is a `TypedDict` used to type-hint data loaded directly from disk without runtime validation, allowing invalid states to propagate.
+
+evidence:
+  - path: "src/menv/models/config.py"
+    loc:
+      - "MenvConfig"
+    note: "Type definition is a TypedDict with no runtime checks."
+  - path: "src/menv/services/config_storage.py"
+    loc:
+      - "load"
+    note: "Method casts loaded TOML dictionary to MenvConfig without validation."
+
+tags:
+  - "missing-validation"
+  - "type-safety"
+  - "data-integrity"

--- a/.jules/workstreams/generic/exchange/events/pending/version-check-error-suppression.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/version-check-error-suppression.yml
@@ -1,0 +1,23 @@
+schema_version: 1
+
+id: "d5vers"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "data_arch"
+confidence: "medium"
+
+title: "Error Suppression in VersionChecker"
+statement: |
+  `VersionChecker` swallows network and parsing exceptions, returning default values or `False` instead of modeling the failure state.
+
+evidence:
+  - path: "src/menv/services/version_checker.py"
+    loc:
+      - "get_latest_version"
+      - "needs_update"
+    note: "Methods catch broad exceptions and suppress errors."
+
+tags:
+  - "error-handling"
+  - "implicit-validation"
+  - "reliability"

--- a/.jules/workstreams/generic/workstations/data_arch/histories/20260202-h1st01.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/histories/20260202-h1st01.yml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+id: "h1st01"
+created_at: "2026-02-02T12:00:00Z"
+
+observer: "data_arch"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  Analyze data models and data flow efficiency.
+  Identify SSOT violations, redundancy, and validation gaps.
+  Record findings as events.
+
+actions:
+  - "Analyzed source code in src/menv/"
+  - "Identified 5 distinct architectural issues"
+  - "Created event files for each issue"
+
+outcomes:
+  summary: "Identified 5 data architecture issues including SSOT violations and missing validation."
+  emitted_events:
+    - "duplicate-config-path.yml"
+    - "manual-toml-serialization.yml"
+    - "unvalidated-config-model.yml"
+    - "misplaced-list-command.yml"
+    - "version-check-error-suppression.yml"
+  notes: |
+    Found significant redundancy in configuration path definitions.
+    Serialization and validation logic is manual and fragile.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/data_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "data_arch"
+workstream: "generic"
+
+updated_at: "2026-02-02T12:00:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-02T12:00:00Z"
+    summary: "Identified 5 data architecture issues including SSOT violations and missing validation."
+    history_path: ".jules/workstreams/generic/workstations/data_arch/histories/20260202-h1st01.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Identified and recorded 5 data architecture issues in the menv project, including redundant configuration path definitions, manual TOML serialization, missing configuration validation, misplaced command implementation, and error suppression in version checking. Initialized the data_arch observer workstation.

---
*PR created automatically by Jules for task [12797396829769772728](https://jules.google.com/task/12797396829769772728) started by @akitorahayashi*