### PR TITLE
DevOps Observer Analysis

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/floating-action-tags.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/floating-action-tags.yml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+id: "232594"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "devops"
+confidence: "high"
+
+title: "Supply Chain Risk from Floating Action Tags"
+statement: |
+  GitHub Actions workflows use mutable tags (e.g., `v4`, `v5`) instead of pinned SHAs, exposing the pipeline to supply-chain attacks or unexpected breaking changes in action dependencies.
+
+evidence:
+  - path: ".github/workflows/lint-and-test.yml"
+    loc:
+      - "12"
+    note: "Uses `actions/checkout@v4`."
+  - path: ".github/actions/setup-base/action.yml"
+    loc:
+      - "7"
+    note: "Uses `actions/setup-python@v5`."
+  - path: ".github/actions/setup-base/action.yml"
+    loc:
+      - "11"
+    note: "Uses `extractions/setup-just@v2`."
+  - path: ".github/actions/setup-base/action.yml"
+    loc:
+      - "14"
+    note: "Uses `astral-sh/setup-uv@v5`."
+
+tags:
+  - "supply-chain"
+  - "security"
+  - "pinning"

--- a/.jules/workstreams/generic/exchange/events/pending/silent-failures-justfile.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/silent-failures-justfile.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+
+id: "a26469"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "devops"
+confidence: "high"
+
+title: "Silent Failures in Build Verification"
+statement: |
+  The `justfile` uses `|| true` to suppress errors from `shfmt` and `shellcheck` when iterating over files, allowing verification steps to pass even if the tools fail or are missing.
+
+evidence:
+  - path: "justfile"
+    loc:
+      - "43"
+    note: "Suppresses `shfmt` errors."
+  - path: "justfile"
+    loc:
+      - "57"
+    note: "Suppresses `shellcheck` errors."
+
+tags:
+  - "operational-readiness"
+  - "risk"
+  - "silent-failure"

--- a/.jules/workstreams/generic/exchange/events/pending/unpinned-toolchains-ci.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/unpinned-toolchains-ci.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+
+id: "67041d"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "devops"
+confidence: "high"
+
+title: "Unpinned Toolchains and Floating Runners in CI"
+statement: |
+  The CI pipeline uses unpinned package installations (`brew install`) and floating runner tags (`macos-latest`), leading to non-deterministic builds and potential breakage from upstream changes.
+
+evidence:
+  - path: ".github/workflows/lint-and-test.yml"
+    loc:
+      - "8"
+    note: "Uses floating `runs-on: macos-latest` tag."
+  - path: ".github/workflows/lint-and-test.yml"
+    loc:
+      - "20"
+    note: "Uses unpinned `brew install shellcheck`."
+
+tags:
+  - "reproducibility"
+  - "ci"
+  - "unpinned"

--- a/.jules/workstreams/generic/workstations/devops/histories/20260202-235f82.yml
+++ b/.jules/workstreams/generic/workstations/devops/histories/20260202-235f82.yml
@@ -1,0 +1,36 @@
+schema_version: 1
+
+id: "235f82"
+created_at: "2026-02-02T19:00:00Z"
+
+observer: "devops"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  1. Analyze CI/CD workflows and justfile for reproducibility and security issues.
+  2. Create events for unpinned toolchains, silent failures, and floating tags.
+  3. Create history file and update perspective.
+
+actions:
+  - "Created event: unpinned-toolchains-ci (67041d)"
+  - "Created event: silent-failures-justfile (a26469)"
+  - "Created event: floating-action-tags (232594)"
+
+outcomes:
+  summary: "Identified critical reproducibility and security risks in CI and build scripts."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/unpinned-toolchains-ci.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/silent-failures-justfile.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/floating-action-tags.yml"
+  notes: |
+    The CI pipeline relies heavily on "latest" versions of runners and tools, making it susceptible to upstream changes.
+    The `justfile` suppresses errors for shell formatting and linting, which undermines the verification process.
+    GitHub Actions are not pinned to SHAs, presenting a supply chain risk.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/devops/perspective.yml
+++ b/.jules/workstreams/generic/workstations/devops/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "devops"
+workstream: "generic"
+
+updated_at: "2026-02-02T19:00:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-02T19:00:00Z"
+    summary: "Identified critical reproducibility and security risks in CI and build scripts."
+    history_path: ".jules/workstreams/generic/workstations/devops/histories/20260202-235f82.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Added DevOps observer analysis including event files for unpinned toolchains, silent failures, and floating tags, along with history and perspective updates.

---
*PR created automatically by Jules for task [11747575306758574272](https://jules.google.com/task/11747575306758574272) started by @akitorahayashi*