### PR TITLE
Record structural and architectural violations

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/backup-logic-split-broken.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/backup-logic-split-broken.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+id: "bkp001"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "structural_arch"
+confidence: "high"
+title: "Backup logic split causes runtime failure"
+statement: |
+  The backup functionality is distributed across the CLI wrapper (`menv/commands/backup.py`) and external scripts (`menv/ansible/scripts/`), creating a fragile process boundary. The CLI fails to pass the mandatory `config_dir` argument required by the backend scripts, causing the command to fail. This violates boundary enforcement (hiding internals) and cohesion (logic split).
+evidence:
+  - path: "src/menv/commands/backup.py"
+    loc:
+      - "line 87"
+    note: "subprocess call to script fails to pass arguments"
+  - path: "src/menv/ansible/scripts/system/backup-system.py"
+    loc:
+      - "line 190"
+    note: "script requires 'config_dir' positional argument"
+tags:
+  - "boundary-violation"
+  - "cohesion"
+  - "broken-feature"

--- a/.jules/workstreams/generic/exchange/events/pending/misplaced-list-command.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/misplaced-list-command.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+id: "lst001"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "structural_arch"
+confidence: "high"
+title: "List command violates structure"
+statement: |
+  The `list` command, exposed as `menv list`, is implemented as `list_tags` within `src/menv/commands/make.py`. This violates the project's implicit 'one command per file' architecture and hinders findability.
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "line 77"
+    note: "list_tags function defined here"
+  - path: "src/menv/main.py"
+    loc:
+      - "line 96"
+    note: "imports list_tags from menv.commands.make"
+tags:
+  - "structure"
+  - "findability"

--- a/.jules/workstreams/generic/exchange/events/pending/missing-ansible-just.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/missing-ansible-just.yml
@@ -1,0 +1,17 @@
+schema_version: 1
+id: "inf001"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "structural_arch"
+confidence: "high"
+title: "Missing ansible.just infrastructure file"
+statement: |
+  The file `src/menv/ansible/ansible.just` is missing from the repository, causing potential failures in `justfile` recipes that attempt to import it.
+evidence:
+  - path: "src/menv/ansible/"
+    loc:
+      - "dir"
+    note: "ansible.just is absent"
+tags:
+  - "infrastructure"
+  - "missing-file"

--- a/.jules/workstreams/generic/exchange/events/pending/overloaded-config-term.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/overloaded-config-term.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+id: "cfg001"
+issue_id: ""
+created_at: "2026-02-02"
+author_role: "structural_arch"
+confidence: "medium"
+title: "Overloaded 'config' terminology"
+statement: |
+  The term "config" is architecturally overloaded, referring to both User Identity (managed by `ConfigStorage`) and Ansible Role Configurations (managed by `ConfigDeployer`). This ambiguity affects the CLI (`menv config` vs `menv make` deployment) and internal service naming.
+evidence:
+  - path: "src/menv/services/config_storage.py"
+    loc:
+      - "line 11"
+    note: "Manages personal/work identity"
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "line 1"
+    note: "Manages Ansible dotfiles"
+tags:
+  - "naming"
+  - "ambiguity"

--- a/.jules/workstreams/generic/workstations/structural_arch/histories/20260202-hist01.yml
+++ b/.jules/workstreams/generic/workstations/structural_arch/histories/20260202-hist01.yml
@@ -1,0 +1,42 @@
+schema_version: 1
+
+id: "hist01"
+created_at: "2026-02-02T19:05:00Z"
+
+observer: "structural_arch"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  1. Initialize workstation perspective.
+  2. Analyze codebase for structural violations (backup logic, list command, config terminology, missing files).
+  3. Emit events for findings.
+  4. Update workstation history.
+
+actions:
+  - "Created perspective.yml"
+  - "Analyzed src/menv/commands/backup.py and src/menv/ansible/scripts/"
+  - "Analyzed src/menv/commands/make.py"
+  - "Analyzed src/menv/services/"
+  - "Checked src/menv/ansible/ for missing files"
+  - "Created 4 pending events"
+
+outcomes:
+  summary: "Identified 4 structural/architectural issues including a broken feature."
+  emitted_events:
+    - "bkp001"
+    - "lst001"
+    - "cfg001"
+    - "inf001"
+  notes: |
+    The backup feature is currently broken due to argument mismatch across the process boundary.
+    The list command location is a minor structural violation but affects findability.
+    The config terminology overload is a semantic architectural issue.
+    The missing ansible.just is a concrete missing file issue.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/structural_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/structural_arch/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "structural_arch"
+workstream: "generic"
+
+updated_at: "2026-02-02T19:05:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-02T19:05:00Z"
+    summary: "Identified 4 structural/architectural issues including a broken feature."
+    history_path: ".jules/workstreams/generic/workstations/structural_arch/histories/20260202-hist01.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Recorded 4 architectural violations identified by the structural_arch observer.

- bkp001: Backup logic split causes runtime failure.
- lst001: List command violates structure (findability).
- cfg001: Overloaded 'config' terminology (ambiguity).
- inf001: Missing ansible.just infrastructure file.

Also initialized workstation perspective and history.

---
*PR created automatically by Jules for task [5206404982914195221](https://jules.google.com/task/5206404982914195221) started by @akitorahayashi*