### PR TITLE
Remove phantom `menv introduce` command from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,6 @@ menv u
 
 ```sh
 menv --help
-menv introduce --help
 menv make --help
 ```
 


### PR DESCRIPTION
Removed a reference to a non-existent `menv introduce` command in `README.md` to avoid user confusion. Verified via `just check` (manual equivalent) and code review.

---
*PR created automatically by Jules for task [4368828118922148316](https://jules.google.com/task/4368828118922148316) started by @akitorahayashi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an example from the help command documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->