### PR TITLE
Fix unhandled exceptions in ConfigDeployer and VersionChecker

### DIFF
--- a/src/menv/services/config_deployer.py
+++ b/src/menv/services/config_deployer.py
@@ -76,15 +76,22 @@ class ConfigDeployer:
                 path=local_config,
             )
 
-        # Create parent directories
-        local_config.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            # Create parent directories
+            local_config.parent.mkdir(parents=True, exist_ok=True)
 
-        # Remove existing if overwrite
-        if local_config.exists() and overwrite:
-            shutil.rmtree(local_config)
+            # Remove existing if overwrite
+            if local_config.exists() and overwrite:
+                shutil.rmtree(local_config)
 
-        # Copy config directory
-        shutil.copytree(package_config, local_config)
+            # Copy config directory
+            shutil.copytree(package_config, local_config)
+        except OSError as e:
+            return DeployResult(
+                role=role,
+                success=False,
+                message=f"Failed to deploy config: {e}",
+            )
 
         return DeployResult(
             role=role,

--- a/src/menv/services/version_checker.py
+++ b/src/menv/services/version_checker.py
@@ -47,7 +47,7 @@ class VersionChecker(VersionCheckerProtocol):
         """Return True if latest > current."""
         try:
             return Version(latest) > Version(current)
-        except Exception:
+        except (ValueError, TypeError):
             return False
 
     def run_pipx_upgrade(self) -> int:
@@ -63,4 +63,7 @@ class VersionChecker(VersionCheckerProtocol):
             self._console.print(
                 "[bold red]Error:[/] pipx not found. Please ensure pipx is installed."
             )
+            return 1
+        except OSError as e:
+            self._console.print(f"[bold red]Error:[/] Failed to run pipx: {e}")
             return 1

--- a/tests/unit/services/test_config_deployer.py
+++ b/tests/unit/services/test_config_deployer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -185,6 +186,16 @@ class TestConfigDeployer:
 
         assert result.success is False
         assert "does not have a config directory" in result.message
+
+    def test_deploy_role_handles_oserror(self, deployer: ConfigDeployer) -> None:
+        """Test that deploy_role handles OSError during file operations."""
+        role = "rust"
+
+        with patch("menv.services.config_deployer.shutil.copytree", side_effect=OSError("Permission denied")):
+            result = deployer.deploy_role(role)
+
+            assert result.success is False
+            assert "Permission denied" in result.message
 
     def test_deploy_all_deploys_all_roles(self, deployer: ConfigDeployer) -> None:
         """Test that deploy_all deploys all roles."""

--- a/tests/unit/services/test_version.py
+++ b/tests/unit/services/test_version.py
@@ -78,3 +78,13 @@ class TestVersionManagement:
 
             result = VersionChecker().get_latest_version()
             assert result == "0.2.0"
+
+    def test_run_pipx_upgrade_handles_oserror(self) -> None:
+        """Test that run_pipx_upgrade handles generic OSError."""
+        from menv.services.version_checker import VersionChecker
+
+        checker = VersionChecker()
+        with patch("menv.services.version_checker.subprocess.run", side_effect=OSError("Exec format error")):
+            result = checker.run_pipx_upgrade()
+            # Should return a non-zero exit code (e.g. 1) instead of crashing
+            assert result == 1


### PR DESCRIPTION
Addressed issue us3b8t where core services swallowed exceptions or failed to handle OSError. Implemented exception handling in ConfigDeployer and VersionChecker, and improved exception specificity. Verified with unit tests.

---
*PR created automatically by Jules for task [15880414396298059300](https://jules.google.com/task/15880414396298059300) started by @akitorahayashi*