### PR TITLE
Fix incorrect list command documentation

### DIFF
--- a/src/menv/commands/make.py
+++ b/src/menv/commands/make.py
@@ -67,8 +67,8 @@ def list_tags(ctx: typer.Context) -> None:
     """List all available tags that can be used with 'menv make'.
 
     Example:
-        menv make list
-        menv mk ls
+        menv list
+        menv ls
     """
     app_ctx: AppContext = ctx.obj
     tags_map = app_ctx.playbook.get_tags_map()
@@ -119,7 +119,7 @@ def make(
         menv make python-tools      # Run python-tools with common profile
         menv make brew-cask mmn     # Run brew-cask with mac-mini profile
         menv make shell macbook     # Run shell with macbook profile
-        menv mk list                # List available tags
+        menv list                   # List available tags
     """
     # Resolve profile aliases
     resolved_profile = PROFILE_ALIASES.get(profile, profile)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -46,4 +46,4 @@ class MockContextCliRunner(CliRunner):
 @pytest.fixture
 def cli_runner(mock_app_context: AppContext) -> "MockContextCliRunner":
     """Create a CLI runner for testing Typer commands."""
-    return MockContextCliRunner(mock_app_context, mix_stderr=False)
+    return MockContextCliRunner(mock_app_context)


### PR DESCRIPTION
The documentation for `list_tags` incorrectly referenced `menv make list` which is not a valid command. The correct command is `menv list`.

This change:
- Updates `list_tags` docstring in `src/menv/commands/make.py`.
- Updates `make` docstring in `src/menv/commands/make.py` to fix the example there as well.
- Fixes `tests/unit/conftest.py` to fix a `TypeError` with `CliRunner` due to `click` version updates.

Testing:
- Ran `pytest tests/unit/commands/test_make.py` and passed.
- Ran static analysis (`ruff`, `mypy`) and passed.

---
*PR created automatically by Jules for task [6708053332171419523](https://jules.google.com/task/6708053332171419523) started by @akitorahayashi*