### PR TITLE
Add runtime validation for MenvConfig

### DIFF
--- a/src/menv/models/config.py
+++ b/src/menv/models/config.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
+from typing import Any, TypedDict
+
+
+class ConfigValidationError(Exception):
+    """Configuration validation error."""
 
 
 class VcsIdentityConfig(TypedDict):
@@ -17,3 +21,44 @@ class MenvConfig(TypedDict):
 
     personal: VcsIdentityConfig
     work: VcsIdentityConfig
+
+
+def validate_config(data: Any) -> MenvConfig:
+    """Validate configuration data.
+
+    Args:
+        data: Raw configuration data.
+
+    Returns:
+        Validated configuration.
+
+    Raises:
+        ConfigValidationError: If configuration is invalid.
+    """
+    if not isinstance(data, dict):
+        raise ConfigValidationError("Configuration must be a dictionary.")
+
+    for section in ["personal", "work"]:
+        if section not in data:
+            raise ConfigValidationError(f"Missing section: '{section}'")
+
+        section_data = data[section]
+        if not isinstance(section_data, dict):
+            raise ConfigValidationError(f"Section '{section}' must be a dictionary.")
+
+        for field in ["name", "email"]:
+            if field not in section_data:
+                raise ConfigValidationError(f"Missing field in '{section}': '{field}'")
+
+            value = section_data[field]
+            if not isinstance(value, str):
+                raise ConfigValidationError(
+                    f"Field '{section}.{field}' must be a string."
+                )
+
+            if not value.strip():
+                raise ConfigValidationError(
+                    f"Field '{section}.{field}' cannot be empty."
+                )
+
+    return data  # type: ignore

--- a/src/menv/services/config_storage.py
+++ b/src/menv/services/config_storage.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import tomllib
 from pathlib import Path
 
-from menv.models.config import MenvConfig, VcsIdentityConfig
+from menv.models.config import MenvConfig, VcsIdentityConfig, validate_config
 from menv.protocols.config_storage import ConfigStorageProtocol
 
 
@@ -44,16 +44,7 @@ class ConfigStorage(ConfigStorageProtocol):
         with open(self._config_path, "rb") as f:
             data = tomllib.load(f)
 
-        return MenvConfig(
-            personal=VcsIdentityConfig(
-                name=data.get("personal", {}).get("name", ""),
-                email=data.get("personal", {}).get("email", ""),
-            ),
-            work=VcsIdentityConfig(
-                name=data.get("work", {}).get("name", ""),
-                email=data.get("work", {}).get("email", ""),
-            ),
-        )
+        return validate_config(data)
 
     def save(self, config: MenvConfig) -> None:
         """Save configuration to file.
@@ -61,6 +52,8 @@ class ConfigStorage(ConfigStorageProtocol):
         Args:
             config: Configuration to save.
         """
+        validate_config(config)
+
         self._config_dir.mkdir(parents=True, exist_ok=True)
 
         def _escape(value: str) -> str:

--- a/tests/unit/models/test_config_validation.py
+++ b/tests/unit/models/test_config_validation.py
@@ -1,0 +1,89 @@
+"""Unit tests for configuration validation."""
+
+import pytest
+
+from menv.models.config import ConfigValidationError, validate_config
+
+
+class TestConfigValidation:
+    """Tests for validate_config function."""
+
+    def test_valid_config(self) -> None:
+        """Test that valid configuration passes validation."""
+        data = {
+            "personal": {"name": "User", "email": "user@example.com"},
+            "work": {"name": "Work", "email": "work@example.com"},
+        }
+        result = validate_config(data)
+        assert result == data
+
+    def test_invalid_type_not_dict(self) -> None:
+        """Test that non-dict input raises error."""
+        with pytest.raises(
+            ConfigValidationError, match="Configuration must be a dictionary"
+        ):
+            validate_config("not a dict")
+
+    def test_missing_section(self) -> None:
+        """Test that missing section raises error."""
+        data = {
+            "personal": {"name": "User", "email": "user@example.com"},
+            # Missing work section
+        }
+        with pytest.raises(ConfigValidationError, match="Missing section: 'work'"):
+            validate_config(data)
+
+    def test_section_not_dict(self) -> None:
+        """Test that section with wrong type raises error."""
+        data = {
+            "personal": "not a dict",
+            "work": {"name": "Work", "email": "work@example.com"},
+        }
+        with pytest.raises(
+            ConfigValidationError, match="Section 'personal' must be a dictionary"
+        ):
+            validate_config(data)
+
+    def test_missing_field(self) -> None:
+        """Test that missing field raises error."""
+        data = {
+            "personal": {"name": "User"},  # Missing email
+            "work": {"name": "Work", "email": "work@example.com"},
+        }
+        with pytest.raises(
+            ConfigValidationError, match="Missing field in 'personal': 'email'"
+        ):
+            validate_config(data)
+
+    def test_field_wrong_type(self) -> None:
+        """Test that field with wrong type raises error."""
+        data = {
+            "personal": {"name": 123, "email": "user@example.com"},
+            "work": {"name": "Work", "email": "work@example.com"},
+        }
+        with pytest.raises(
+            ConfigValidationError, match="Field 'personal.name' must be a string"
+        ):
+            validate_config(data)
+
+    def test_field_empty(self) -> None:
+        """Test that empty field raises error."""
+        data = {
+            "personal": {"name": "", "email": "user@example.com"},
+            "work": {"name": "Work", "email": "work@example.com"},
+        }
+        with pytest.raises(
+            ConfigValidationError, match="Field 'personal.name' cannot be empty"
+        ):
+            validate_config(data)
+
+    def test_field_whitespace_only(self) -> None:
+        """Test that whitespace-only field raises error."""
+        data = {
+            "personal": {"name": "   ", "email": "user@example.com"},
+            "work": {"name": "Work", "email": "work@example.com"},
+        }
+        with pytest.raises(
+            ConfigValidationError, match="Field 'personal.name' cannot be empty"
+        ):
+            validate_config(data)


### PR DESCRIPTION
Resolved issue uc7h3v by implementing manual validation for `MenvConfig` `TypedDict`.
This ensures that configuration files must contain valid `personal` and `work` sections with non-empty `name` and `email` fields.
Invalid configurations now prevent the application from proceeding with potentially dangerous operations or corrupt data, and the CLI provides user-friendly error messages.

---
*PR created automatically by Jules for task [7987794527243895986](https://jules.google.com/task/7987794527243895986) started by @akitorahayashi*