### PR TITLE
Report untested critical path in AnsibleRunner

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/critical-path-ansible-runner-untested.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/critical-path-ansible-runner-untested.yml
@@ -1,0 +1,30 @@
+schema_version: 1
+
+# Metadata
+id: "arun01"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "cov"
+confidence: "high"
+
+# Content
+title: "Critical path AnsibleRunner.run_playbook is mocked but untested"
+statement: |
+  The `AnsibleRunner` service, responsible for executing Ansible playbooks, has 28% coverage. Its core method `run_playbook` is skipped in tests because the CLI test suite relies entirely on `MockAnsibleRunner`. This creates a false safety signal where CLI commands appear to work but the actual execution logic (command construction, process handling, stream redirection) is unverified.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "35-95"
+    note: "The `run_playbook` method contains critical logic for constructing the `ansible-playbook` command, managing the subprocess, and handling output streaming, but it is completely uncovered."
+
+  - path: "tests/unit/conftest.py"
+    loc:
+      - "24-34"
+    note: "The `mock_app_context` fixture unconditionally injects `MockAnsibleRunner` into the application context, ensuring that no unit test exercises the real `AnsibleRunner` implementation."
+
+tags:
+  - "coverage-gap"
+  - "critical-path"
+  - "testing-strategy"

--- a/.jules/workstreams/generic/workstations/cov/histories/20260203-hist01.yml
+++ b/.jules/workstreams/generic/workstations/cov/histories/20260203-hist01.yml
@@ -1,0 +1,32 @@
+schema_version: 1
+
+id: "hist01"
+created_at: "2026-02-03T00:00:00Z"
+
+observer: "cov"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  Analyze test coverage using `pytest-cov` to identify critical path gaps and mock-heavy testing patterns.
+
+actions:
+  - "Initialized workstation perspective."
+  - "Ran `pytest` with coverage collection."
+  - "Analyzed `coverage.xml` and terminal output."
+  - "Identified `AnsibleRunner.run_playbook` as a critical uncovered path."
+  - "Verified `tests/unit/conftest.py` confirms mock injection."
+
+outcomes:
+  summary: "Identified critical coverage gap in AnsibleRunner due to excessive mocking."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/critical-path-ansible-runner-untested.yml"
+  notes: |
+    The `AnsibleRunner` service is a critical component that interfaces with the system via `subprocess`. Its low coverage (28%) combined with the unconditional mocking in unit tests creates a significant risk of regression in the core execution logic.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/cov/perspective.yml
+++ b/.jules/workstreams/generic/workstations/cov/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "cov"
+workstream: "generic"
+
+updated_at: "2026-02-03T00:00:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-03T00:00:00Z"
+    summary: "Identified critical coverage gap in AnsibleRunner due to excessive mocking."
+    history_path: ".jules/workstreams/generic/workstations/cov/histories/20260203-hist01.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Identified that `AnsibleRunner.run_playbook` is skipped in tests due to unconditional mocking in `MockContextCliRunner`. Created event `critical-path-ansible-runner-untested.yml` and updated `cov` workstation history and perspective.

---
*PR created automatically by Jules for task [18144176865887167118](https://jules.google.com/task/18144176865887167118) started by @akitorahayashi*