### PR TITLE
Initialize Taxonomy Observer Workstation

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/misplaced-command-list.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/misplaced-command-list.yml
@@ -1,0 +1,29 @@
+schema_version: 1
+
+# Metadata
+id: "j0k1l2"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "taxonomy"
+confidence: "medium"
+
+# Content
+title: "Misplaced Command: 'list' at root level"
+statement: |
+  The `list` command is exposed at the root level (`menv list`) but strictly lists tags for the `make` command (`menv make`).
+  This violates command hierarchy expectations. It should likely be a subcommand of `make` (e.g., `menv make list`) or renamed to reflect the resource it lists (e.g., `menv tags`).
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "def list_tags(ctx: typer.Context) -> None:"
+    note: "Function defined in make.py but registered as root command"
+  - path: "src/menv/main.py"
+    loc:
+      - "app.command(name=\"list\", ...)(list_tags)"
+    note: "Registered at root level"
+
+tags:
+  - "cli"
+  - "command-structure"

--- a/.jules/workstreams/generic/exchange/events/pending/overloaded-term-config.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/overloaded-term-config.yml
@@ -1,0 +1,36 @@
+schema_version: 1
+
+# Metadata
+id: "g7h8i9"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Overloaded Term: 'config'"
+statement: |
+  The term "config" is overloaded to refer to two distinct concepts:
+  1. User Identity (Git name/email) managed by `ConfigStorage` and `menv config` command.
+  2. Ansible Role Configuration files (dotfiles) managed by `ConfigDeployer` and `menv config create`.
+  This violates the "One Concept, One Preferred Term" principle and creates ambiguity.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "class VcsIdentityConfig(TypedDict):"
+    note: "Refers to User Identity"
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "class ConfigDeployer:"
+    note: "Refers to Ansible Role Configuration (dotfiles)"
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "@config_app.command(name=\"create\")"
+    note: "Command mixes both concepts under 'config' namespace"
+
+tags:
+  - "overloaded-term"
+  - "ambiguity"
+  - "architecture"

--- a/.jules/workstreams/generic/exchange/events/pending/vocabulary-mismatch-create-deploy.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/vocabulary-mismatch-create-deploy.yml
@@ -1,0 +1,35 @@
+schema_version: 1
+
+# Metadata
+id: "d4e5f6"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Vocabulary Mismatch: CLI 'create' vs Internal 'deploy'"
+statement: |
+  The user-facing CLI command `menv config create` maps to the internal service method `ConfigDeployer.deploy_role`.
+  "Create" implies generating new content, whereas "Deploy" implies copying/installing existing content to a target.
+  The internal naming "deploy" more accurately reflects the operation (copying config files), making the CLI term "create" misleading.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "def create_config("
+    note: "CLI command defined as 'create'"
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "def deploy_role("
+    note: "Internal service method named 'deploy_role'"
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "app_ctx.config_deployer.deploy_role("
+    note: "Usage site showing the mapping from 'create' to 'deploy'"
+
+tags:
+  - "vocabulary-mismatch"
+  - "cli"
+  - "internal-consistency"

--- a/.jules/workstreams/generic/exchange/events/pending/vocabulary-mismatch-make-run.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/vocabulary-mismatch-make-run.yml
@@ -1,0 +1,35 @@
+schema_version: 1
+
+# Metadata
+id: "a1b2c3"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Vocabulary Mismatch: CLI 'make' vs Internal 'run'"
+statement: |
+  The user-facing CLI command `menv make` maps to the internal service method `AnsibleRunner.run_playbook`.
+  The term "make" is used in the CLI to trigger Ansible playbook execution, while the internal code consistently uses "run".
+  This inconsistency creates a cognitive dissonance between the user interface and the implementation.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "def make("
+    note: "CLI command defined as 'make'"
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "def run_playbook("
+    note: "Internal service method named 'run_playbook'"
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "app_ctx.ansible_runner.run_playbook("
+    note: "Usage site showing the mapping from 'make' to 'run'"
+
+tags:
+  - "vocabulary-mismatch"
+  - "cli"
+  - "internal-consistency"

--- a/.jules/workstreams/generic/workstations/taxonomy/histories/20260203-abcdef.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/histories/20260203-abcdef.yml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+id: "abcdef"
+created_at: "2026-02-03T22:55:42Z"
+
+observer: "taxonomy"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  1. Analyze codebase for taxonomy issues.
+  2. Create missing perspective file.
+  3. Emit event findings.
+  4. Record history and update perspective.
+
+actions:
+  - description: "Created perspective file."
+  - description: "Analyzed src/menv/ for naming inconsistencies."
+  - description: "Created 4 event files."
+
+outcomes:
+  summary: "Initialized taxonomy workstation and identified 4 vocabulary/naming issues."
+  emitted_events:
+    - "a1b2c3"
+    - "d4e5f6"
+    - "g7h8i9"
+    - "j0k1l2"
+  notes: |
+    Found significant inconsistencies between CLI and internal service terminology ('make' vs 'run', 'create' vs 'deploy').
+    Also identified 'config' as an overloaded term used for both identity and dotfiles.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "taxonomy"
+workstream: "generic"
+
+updated_at: "2026-02-03T22:55:42Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-03T22:55:42Z"
+    summary: "Initialized taxonomy workstation and identified 4 vocabulary/naming issues."
+    history_path: ".jules/workstreams/generic/workstations/taxonomy/histories/20260203-abcdef.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Initialized the taxonomy observer workstation and conducted an initial analysis of the codebase. Identified and documented 4 key taxonomy issues: vocabulary mismatches between CLI and internal services, an overloaded term, and a misplaced command.

---
*PR created automatically by Jules for task [5423102734960929591](https://jules.google.com/task/5423102734960929591) started by @akitorahayashi*