### PR TITLE
Record Mirror Logic Anti-Pattern in QA Observer

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/test-mirror-logic-integrity.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/test-mirror-logic-integrity.yml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+# Metadata
+id: "qa7x2b"
+issue_id: ""
+created_at: "2024-10-26"
+author_role: "qa"
+confidence: "high"
+
+# Content
+title: "Mirror Logic in Ansible Integrity Tests"
+statement: |
+  tests/intg/test_role_integrity.py re-implements Ansible's variable resolution and Jinja2 templating logic in Python to validate configuration files. This "Mirror Logic" pattern creates a high maintenance burden and risk of drift, as the test verifies a simulation of the behavior rather than the behavior itself. The test relies on brittle regex parsing of YAML which is prone to false negatives/positives compared to actual Ansible execution.
+
+# Evidence supporting the observation
+evidence:
+  - path: "tests/intg/test_role_integrity.py"
+    loc:
+      - "_resolve_template_literal"
+    note: "Manually replaces Jinja variables, duplicating Ansible logic."
+  - path: "tests/intg/test_role_integrity.py"
+    loc:
+      - "SRC_PATTERN"
+    note: "Uses regex to parse YAML src keys, ignoring full YAML spec."
+  - path: "tests/intg/test_role_integrity.py"
+    loc:
+      - "_resolve_lookup_expression"
+    note: "Implements eval to simulate lookup(), a security risk and logic duplication."
+
+tags:
+  - "test-quality"
+  - "anti-pattern"
+  - "mirror-logic"
+  - "fragility"

--- a/.jules/workstreams/generic/workstations/qa/histories/20241026-run001.yml
+++ b/.jules/workstreams/generic/workstations/qa/histories/20241026-run001.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+
+id: "run001"
+created_at: "2024-10-26T12:00:00Z"
+
+observer: "qa"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ".jules/changes/latest.yml"
+
+plan: |
+  Analyze test structure and quality. Identify anti-patterns.
+
+actions: []
+
+outcomes:
+  summary: "Identified Mirror Logic anti-pattern in integration tests."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/test-mirror-logic-integrity.yml"
+  notes: |
+    Found that tests/intg/test_role_integrity.py re-implements Ansible logic instead of testing behavior.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/qa/perspective.yml
+++ b/.jules/workstreams/generic/workstations/qa/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "qa"
+workstream: "generic"
+
+updated_at: "2024-10-26T12:00:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2024-10-26T12:00:00Z"
+    summary: "Identified Mirror Logic anti-pattern in integration tests."
+    history_path: ".jules/workstreams/generic/workstations/qa/histories/20241026-run001.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Created QA observer perspective, history, and event documenting the "Mirror Logic" anti-pattern in `tests/intg/test_role_integrity.py`. This pattern involves re-implementing Ansible logic in Python tests, leading to fragility and maintenance burden.

---
*PR created automatically by Jules for task [5022580906284458316](https://jules.google.com/task/5022580906284458316) started by @akitorahayashi*