### PR TITLE
observer(data_arch): analyze src/menv data architecture

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/domain-data-leaking-into-cli.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/domain-data-leaking-into-cli.yml
@@ -1,0 +1,30 @@
+schema_version: 1
+
+# Metadata
+id: "domcli"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "Domain Data Leaking into CLI"
+statement: |
+  Domain concepts `TAG_GROUPS` (role aggregation) and `VALID_PROFILES` (execution targets) are defined in the CLI layer `commands/make.py` instead of the service layer. This violates Boundary Sovereignty, making the domain model dependent on the CLI implementation and preventing reusability in other interfaces.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "lines 17-23"
+    note: "Defines `TAG_GROUPS`."
+
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "lines 27"
+    note: "Defines `VALID_PROFILES`."
+
+tags:
+  - "boundary-sovereignty"
+  - "coupling"
+  - "cli-leakage"

--- a/.jules/workstreams/generic/exchange/events/pending/manual-serialization-config-storage.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/manual-serialization-config-storage.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+
+# Metadata
+id: "manser"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "data_arch"
+confidence: "medium"
+
+# Content
+title: "Risky Manual Serialization in ConfigStorage"
+statement: |
+  `ConfigStorage.save` manually constructs TOML strings instead of using a serializer. This duplicates the schema structure defined in `MenvConfig` within the storage logic and introduces risk of malformed output or escaping issues.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/services/config_storage.py"
+    loc:
+      - "lines 60-76"
+    note: "Manually constructs TOML string."
+
+tags:
+  - "inefficient-transformation"
+  - "validation"
+  - "fragility"

--- a/.jules/workstreams/generic/exchange/events/pending/redundant-local-config-path.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/redundant-local-config-path.yml
@@ -1,0 +1,30 @@
+schema_version: 1
+
+# Metadata
+id: "loccfg"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "Redundant Definition of Local Config Path"
+statement: |
+  The path `~/.config/menv/roles` is hardcoded in both `AnsibleRunner` and `ConfigDeployer`, violating Single Source of Truth. If the path changes, both services require modification.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "line 39"
+    note: "Hardcodes `local_config_root`."
+
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "line 27"
+    note: "Hardcodes `_local_config_root`."
+
+tags:
+  - "ssot"
+  - "redundancy"
+  - "coupling"

--- a/.jules/workstreams/generic/workstations/data_arch/histories/20260203-hist01.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/histories/20260203-hist01.yml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+id: "hist01"
+created_at: "2026-02-03T12:00:00Z"
+
+observer: "data_arch"
+workstream: "generic"
+
+inputs:
+  change_summary_path: null
+
+plan: |
+  Analyze src/menv for data model inefficiencies, SSOT violations, and boundary leakage.
+
+actions:
+  - "Analyzed src/menv/services/ansible_runner.py"
+  - "Analyzed src/menv/services/config_deployer.py"
+  - "Analyzed src/menv/services/config_storage.py"
+  - "Analyzed src/menv/commands/make.py"
+
+outcomes:
+  summary: "Identified 3 architectural issues regarding SSOT and boundary sovereignty."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/redundant-local-config-path.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/domain-data-leaking-into-cli.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/manual-serialization-config-storage.yml"
+  notes: |
+    Found clear violations of SSOT for the local config path (~/.config/menv/roles).
+    Found significant domain logic (Tag Groups, Profiles) leaking into the CLI layer.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/data_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "data_arch"
+workstream: "generic"
+
+updated_at: "2026-02-03T12:00:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-03T12:00:00Z"
+    summary: "Identified 3 architectural issues regarding SSOT and boundary sovereignty."
+    history_path: ".jules/workstreams/generic/workstations/data_arch/histories/20260203-hist01.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Analyzed src/menv for data model inefficiencies and SSOT violations. Identified redundant config path definitions, domain logic leakage in CLI, and risky manual serialization.

---
*PR created automatically by Jules for task [825379052435621897](https://jules.google.com/task/825379052435621897) started by @akitorahayashi*