### PR TITLE
chore: Pythonista observer analysis and event generation

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/exception-swallowing-ansiblerunner.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/exception-swallowing-ansiblerunner.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+
+# Metadata
+id: "ev3c4d"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "pythonista"
+confidence: "high"
+
+# Content
+title: "Exception swallowing in AnsibleRunner"
+statement: |
+  `AnsibleRunner.run_playbook` catches `FileNotFoundError` and returns an integer exit code (1).
+  This swallows the exception and prevents callers from programmatically distinguishing between "command not found" and other errors.
+  It also prints to the console directly, mixing I/O with error handling.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "87-92"
+    note: "Catches FileNotFoundError, prints error, and returns 1, losing stack trace and exception type."
+
+tags:
+  - "anti-pattern"
+  - "exception-handling"
+  - "python"

--- a/.jules/workstreams/generic/exchange/events/pending/logic-leakage-make-command.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/logic-leakage-make-command.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+
+# Metadata
+id: "ev7g8h"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "pythonista"
+confidence: "medium"
+
+# Content
+title: "Business Logic Leaking into CLI Command"
+statement: |
+  The `make` command (`src/menv/commands/make.py`) implements core business logic in private helper functions.
+  `_get_roles_for_tags` and `_deploy_configs_for_roles` perform domain logic (mapping tags to roles, conditional deployment) that should reside in the service layer (e.g., `Playbook` or `ConfigDeployer` services).
+  This violation of separation of concerns makes the logic harder to reuse and test in isolation.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "33-63"
+    note: "Private helper functions implementing domain logic inside the command module."
+
+tags:
+  - "anti-pattern"
+  - "architecture"
+  - "separation-of-concerns"

--- a/.jules/workstreams/generic/exchange/events/pending/mixed-io-logic-ansiblerunner.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/mixed-io-logic-ansiblerunner.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+
+# Metadata
+id: "ev5e6f"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "pythonista"
+confidence: "medium"
+
+# Content
+title: "Mixed I/O and Logic in AnsibleRunner"
+statement: |
+  `AnsibleRunner` mixes core execution logic with direct `sys.stdout` writes.
+  This makes the class difficult to test without capturing global stdout and couples the logic to the CLI environment.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "81-83"
+    note: "Direct writes to sys.stdout inside the execution loop."
+
+tags:
+  - "anti-pattern"
+  - "io-mixing"
+  - "testability"

--- a/.jules/workstreams/generic/exchange/events/pending/unsafe-resource-cleanup-ansiblepaths.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/unsafe-resource-cleanup-ansiblepaths.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+
+# Metadata
+id: "ev1a2b"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "pythonista"
+confidence: "high"
+
+# Content
+title: "Unsafe resource cleanup using __del__ in AnsiblePaths"
+statement: |
+  The `AnsiblePaths` service uses `__del__` to clean up temporary resources (context managers), which is unreliable and swallows exceptions.
+  `__del__` is not guaranteed to be called by the interpreter, and exceptions raised within it are ignored.
+  The class should implement the context manager protocol (`__enter__`/`__exit__`) or an explicit `close()` method.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/services/ansible_paths.py"
+    loc:
+      - "42-48"
+    note: "__del__ implementation swallows exceptions and attempts cleanup unreliably."
+
+tags:
+  - "anti-pattern"
+  - "resource-management"
+  - "python"

--- a/.jules/workstreams/generic/workstations/pythonista/histories/20240523-hist01.yml
+++ b/.jules/workstreams/generic/workstations/pythonista/histories/20240523-hist01.yml
@@ -1,0 +1,32 @@
+schema_version: 1
+
+id: "hist01"
+created_at: "2024-05-23T12:00:00Z"
+
+observer: "pythonista"
+workstream: "generic"
+
+inputs: {}
+
+plan: |
+  Explore codebase for anti-patterns in exceptions, I/O, and resource management.
+
+actions:
+  - Read source files in src/menv/services and src/menv/commands.
+  - Analyzed AnsibleRunner, AnsiblePaths, ConfigDeployer, and Make command.
+
+outcomes:
+  summary: "Identified unsafe resource cleanup, exception swallowing, mixed I/O logic, and logic leakage."
+  emitted_events:
+    - "ev1a2b"
+    - "ev3c4d"
+    - "ev5e6f"
+    - "ev7g8h"
+  notes: |
+    Found critical anti-patterns in resource management (AnsiblePaths) and error handling (AnsibleRunner).
+
+perspective_updates:
+  goals_delta:
+    - "Monitor remediation of unsafe resource cleanup and exception swallowing."
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/pythonista/perspective.yml
+++ b/.jules/workstreams/generic/workstations/pythonista/perspective.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+
+observer: "pythonista"
+workstream: "generic"
+
+updated_at: "2024-05-23T12:00:00Z"
+
+goals:
+  short_term:
+    - "Monitor remediation of unsafe resource cleanup and exception swallowing."
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2024-05-23T12:00:00Z"
+    summary: "Identified unsafe resource cleanup, exception swallowing, mixed I/O logic, and logic leakage."
+    history_path: ".jules/workstreams/generic/workstations/pythonista/histories/20240523-hist01.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Performed Pythonista observer role analysis on `src/menv` codebase. Identified anti-patterns in `AnsiblePaths` (unsafe resource cleanup), `AnsibleRunner` (exception swallowing, mixed I/O), and `make` command (logic leakage). Generated event files in `.jules/workstreams/generic/exchange/events/pending/` and updated workstation history and perspective.

---
*PR created automatically by Jules for task [8011551402928438171](https://jules.google.com/task/8011551402928438171) started by @akitorahayashi*