### PR TITLE
observer(structural_arch): report violations

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/application-logic-misplaced-in-ansible-scripts.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/application-logic-misplaced-in-ansible-scripts.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+
+# Metadata
+id: "ev001a"
+issue_id: ""
+created_at: "2024-10-18"
+author_role: "structural_arch"
+confidence: "high"
+
+# Content
+title: "Application Logic Misplaced in Ansible Scripts"
+statement: |
+  Python application logic (e.g., backup functionality) is located in `src/menv/ansible/scripts/`, disconnecting it from the core application structure and hiding it from standard discovery and testing workflows.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/ansible/scripts/system/backup-system.py"
+    loc:
+      - "1-140"
+    note: "Entire file is Python application logic for backing up system settings, placed in Ansible scripts directory."
+
+tags:
+  - "architecture-violation"
+  - "cohesion"
+  - "findability"

--- a/.jules/workstreams/generic/exchange/events/pending/business-logic-leaking-into-cli-command.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/business-logic-leaking-into-cli-command.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+
+# Metadata
+id: "ev001b"
+issue_id: ""
+created_at: "2024-10-18"
+author_role: "structural_arch"
+confidence: "high"
+
+# Content
+title: "Business Logic Leaking into CLI Command"
+statement: |
+  The `make` command contains private methods implementing core business logic (role resolution and configuration deployment), violating separation of concerns and making this logic unavailable to other parts of the application.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "33-66"
+    note: "Methods `_get_roles_for_tags` and `_deploy_configs_for_roles` implement business logic inside the command layer."
+
+tags:
+  - "architecture-violation"
+  - "separation-of-concerns"

--- a/.jules/workstreams/generic/exchange/events/pending/implicit-coupling-to-directory-structure-in-ansible-runner.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/implicit-coupling-to-directory-structure-in-ansible-runner.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+
+# Metadata
+id: "ev001c"
+issue_id: ""
+created_at: "2024-10-18"
+author_role: "structural_arch"
+confidence: "medium"
+
+# Content
+title: "Implicit Coupling to Directory Structure in AnsibleRunner"
+statement: |
+  `AnsibleRunner` enforces an implicit directory structure for configuration files via the `local_config_root` variable, creating a hidden contract between the Python service and Ansible roles.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "38"
+    note: "Hardcoded path construction for `local_config_root` which is passed to Ansible."
+
+tags:
+  - "coupling"
+  - "implicit-contract"

--- a/.jules/workstreams/generic/workstations/structural_arch/histories/20241018-hist01.yml
+++ b/.jules/workstreams/generic/workstations/structural_arch/histories/20241018-hist01.yml
@@ -1,0 +1,35 @@
+schema_version: 1
+
+id: "hist01"
+created_at: "2024-10-18T10:00:00Z"
+
+observer: "structural_arch"
+workstream: "generic"
+
+inputs:
+  change_summary_path: ""
+
+plan: |
+  1. Analyze codebase for structural issues focusing on dependency direction, cohesion, and boundaries.
+  2. Create events for identified violations.
+  3. Initialize workstation state.
+
+actions:
+  - "Analyzed src/menv/ansible/scripts/ and identified misplaced application logic."
+  - "Analyzed src/menv/commands/make.py and identified business logic leakage."
+  - "Analyzed src/menv/services/ansible_runner.py and identified implicit coupling."
+  - "Created 3 event files."
+
+outcomes:
+  summary: "Identified 3 structural violations regarding misplaced logic and coupling."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/application-logic-misplaced-in-ansible-scripts.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/business-logic-leaking-into-cli-command.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/implicit-coupling-to-directory-structure-in-ansible-runner.yml"
+  notes: |
+    Found significant architectural drift where core logic is hidden in scripts or leaked into CLI commands.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/structural_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/structural_arch/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "structural_arch"
+workstream: "generic"
+
+updated_at: "2024-10-18T10:00:00Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2024-10-18T10:00:00Z"
+    summary: "Identified 3 structural violations regarding misplaced logic and coupling."
+    history_path: ".jules/workstreams/generic/workstations/structural_arch/histories/20241018-hist01.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Report architectural violations including misplaced application logic in scripts, business logic leakage in CLI, and implicit coupling in AnsibleRunner. Initialize the structural_arch workstation state.

---
*PR created automatically by Jules for task [6607274388376397084](https://jules.google.com/task/6607274388376397084) started by @akitorahayashi*