### PR TITLE
Consistency Observer: Initial Analysis and Drift Detection

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/broken-agents-md.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/broken-agents-md.yml
@@ -1,0 +1,33 @@
+schema_version: 1
+
+# Metadata
+id: "2903b6"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "consistency"
+confidence: "high"
+
+# Content
+title: "Root AGENTS.md contains invalid relative links"
+statement: |
+  The AGENTS.md file in the root directory appears to be misplaced or copied incorrectly.
+  It references a "root AGENTS.md" at `../../../../AGENTS.md` (which is impossible from root)
+  and `src/AGENTS.md` (which does not exist). It also describes the `.jules` scaffold,
+  duplicating content likely meant for `.jules/README.md`.
+
+# Evidence supporting the observation
+evidence:
+  - path: "AGENTS.md"
+    loc:
+      - "3"
+    note: "Link `../../../../AGENTS.md` is invalid from root."
+
+  - path: "AGENTS.md"
+    loc:
+      - "106"
+    note: "Link `src/AGENTS.md` points to a non-existent file."
+
+tags:
+  - "documentation"
+  - "broken-links"
+  - "jules"

--- a/.jules/workstreams/generic/exchange/events/pending/symlink-drift.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/symlink-drift.yml
@@ -1,0 +1,34 @@
+schema_version: 1
+
+# Metadata
+id: "96b4f2"
+issue_id: ""
+created_at: "2026-02-03"
+author_role: "consistency"
+confidence: "high"
+
+# Content
+title: "README.md claims no symlinks, but shell role creates them"
+statement: |
+  The README.md explicitly states that menv provisions dotfiles by copying them (no symlinks),
+  but the implementation of the shell role uses `ansible.builtin.file` with `state: link`
+  to create symlinks for .zprofile and .zshrc pointing to the config directory.
+
+# Evidence supporting the observation
+evidence:
+  - path: "README.md"
+    loc:
+      - "48" # Approximate line number based on previous read
+    note: "Text: 'menv provisions dotfiles by copying them into your home directory (no symlinks)...'"
+
+  - path: "src/menv/ansible/roles/shell/tasks/main.yml"
+    loc:
+      - "2"
+      - "8"
+      - "40"
+    note: "Tasks explicitly use `state: link`."
+
+tags:
+  - "documentation"
+  - "drift"
+  - "shell"

--- a/.jules/workstreams/generic/workstations/consistency/histories/20260203-1d1ba8.yml
+++ b/.jules/workstreams/generic/workstations/consistency/histories/20260203-1d1ba8.yml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+id: "1d1ba8"
+created_at: "2026-02-03T22:59:25Z"
+
+observer: "consistency"
+workstream: "generic"
+
+inputs:
+  # change_summary_path: ".jules/changes/latest.yml" # Not present
+
+plan: |
+  1. Initialize Workstation (create directory and perspective.yml).
+  2. Analyze codebase for documentation drift.
+  3. Create events for identified drift.
+  4. Update workstation history and perspective.
+
+actions:
+  - "Created .jules/workstreams/generic/workstations/consistency/perspective.yml"
+  - "Analyzed README.md vs implementation"
+  - "Analyzed AGENTS.md vs file structure"
+  - "Created event symlink-drift.yml"
+  - "Created event broken-agents-md.yml"
+
+outcomes:
+  summary: "Identified 2 documentation drift issues."
+  emitted_events:
+    - ".jules/workstreams/generic/exchange/events/pending/symlink-drift.yml"
+    - ".jules/workstreams/generic/exchange/events/pending/broken-agents-md.yml"
+  notes: |
+    Found incorrect claim about symlinks in README.md.
+    Found broken AGENTS.md in root with invalid links.
+
+perspective_updates:
+  goals_delta: []
+  learned_exclusions_delta: []
+  bias_adjustments: []

--- a/.jules/workstreams/generic/workstations/consistency/perspective.yml
+++ b/.jules/workstreams/generic/workstations/consistency/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+
+observer: "consistency"
+workstream: "generic"
+
+updated_at: "2026-02-03T22:59:25Z"
+
+goals:
+  short_term: []
+
+biases:
+  assumptions: []
+  blind_spots: []
+  heuristics: []
+
+recent_runs:
+  - created_at: "2026-02-03T22:59:25Z"
+    summary: "Identified 2 documentation drift issues."
+    history_path: ".jules/workstreams/generic/workstations/consistency/histories/20260203-1d1ba8.yml"
+
+learned_exclusions: []


### PR DESCRIPTION
Initialized the consistency observer workstation and analyzed the codebase for documentation drift. Identified two issues:
1. `README.md` incorrectly claims "no symlinks" for dotfiles, while the implementation uses them.
2. Root `AGENTS.md` contains broken relative links and references missing files.

Created event files in `.jules/workstreams/generic/exchange/events/pending/` and recorded the run in history.

---
*PR created automatically by Jules for task [10328134879316137607](https://jules.google.com/task/10328134879316137607) started by @akitorahayashi*