### PR TITLE
Expand analysis for CI pipeline hardening

### DIFF
--- a/.jules/workstreams/generic/exchange/issues/refacts/ci-pipeline-hardening.yml
+++ b/.jules/workstreams/generic/exchange/issues/refacts/ci-pipeline-hardening.yml
@@ -39,7 +39,7 @@ constraints:
 
 risks:
   - Pinning versions increases maintenance burden; versions must be manually updated or automated (e.g., Renovate/Dependabot).
-  - `macos-15` availability might be lower than `macos-latest` on GitHub's free tier (though usually it's fine for public repos).
+  - '`macos-15` availability might be lower than `macos-latest` on GitHub''s free tier (though usually it''s fine for public repos).'
 
 # Specifics
 affected_areas:


### PR DESCRIPTION
Expanded the CI pipeline hardening issue with detailed analysis, defining strategies for pinning dependencies, standardizing runners, deduplicating logic, and building artifacts.

---
*PR created automatically by Jules for task [5589778756694212943](https://jules.google.com/task/5589778756694212943) started by @akitorahayashi*