### PR TITLE
QA Observer Initialization and Initial Findings

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/qa0001.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/qa0001.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+
+# Metadata
+id: "qa0001"
+issue_id: ""
+created_at: "2024-05-22"
+author_role: "qa"
+confidence: "high"
+
+# Content
+title: "High-Risk Mirror Logic in Role Integrity Tests"
+statement: |
+  `tests/intg/test_role_integrity.py` re-implements Ansible's variable resolution and path finding logic in Python (using regex and manual string manipulation) to validate static files. This "Mirror Logic" creates a false sense of security: if the manual resolution differs from actual Ansible behavior (which is complex and version-dependent), the test passes but the playbook fails at runtime. It validates the author's *expectation* of how Ansible works, not how it *actually* works.
+
+# Evidence supporting the observation
+evidence:
+  - path: "tests/intg/test_role_integrity.py"
+    loc:
+      - "_resolve_template_literal"
+      - "_resolve_lookup_expression"
+      - "LocalConfigRoot"
+    note: "Manual re-implementation of Jinja2/Ansible variable and path resolution logic."
+
+tags:
+  - "anti-pattern"
+  - "risk"
+  - "maintenance-burden"

--- a/.jules/workstreams/generic/exchange/events/pending/qa0002.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/qa0002.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+
+# Metadata
+id: "qa0002"
+issue_id: ""
+created_at: "2024-05-22"
+author_role: "qa"
+confidence: "high"
+
+# Content
+title: "Absence of Ansible Runtime Verification"
+statement: |
+  The test suite relies entirely on static validation of Ansible resources (YAML schema, file existence via Mirror Logic). There are no integration tests that execute `ansible-playbook` (even in `--check` mode or against a dummy target), leaving the system vulnerable to runtime errors (e.g., invalid module parameters, logic errors in tasks) that pass static schema checks.
+
+# Evidence supporting the observation
+evidence:
+  - path: "tests/intg/"
+    loc:
+      - "test_role_integrity.py"
+      - "test_playbook_integrity.py"
+    note: "Tests in this directory perform static analysis only, never invoking the ansible-playbook executable."
+
+tags:
+  - "coverage-gap"
+  - "risk"

--- a/.jules/workstreams/generic/workstations/qa/perspective.yml
+++ b/.jules/workstreams/generic/workstations/qa/perspective.yml
@@ -1,0 +1,23 @@
+schema_version: 2
+
+observer: "qa"
+workstream: "generic"
+
+updated_at: "2024-05-22T12:00:00Z"
+
+# Keep this list short (1-3). These goals are the continuity mechanism across runs.
+goals:
+  - "Monitor the reliability of 'Mirror Logic' tests in `tests/intg/test_role_integrity.py`."
+  - "Identify opportunities to introduce minimal runtime verification for Ansible playbooks."
+  - "Preserve the strong boundary isolation pattern observed in unit tests."
+
+# Stable rules of thumb for producing consistent, high-signal events.
+rules: []
+
+# Explicit suppressions to prevent repeated low-value observations.
+ignore: []
+
+# Newest first; keep max 5 entries.
+log:
+  - at: "2024-05-22T12:00:00Z"
+    summary: "Initial analysis: identified 'Mirror Logic' anti-pattern in integrity tests and lack of runtime verification."


### PR DESCRIPTION
Initialized the QA observer workspace and analyzed the test suite. 

Found two significant issues:
1. `tests/intg/test_role_integrity.py` uses "Mirror Logic" (re-implementing Ansible path resolution in Python) which is fragile and gives false confidence.
2. The project lacks true integration tests that run `ansible-playbook` (even in check mode), relying entirely on static validation.

Emitted corresponding events `qa0001` and `qa0002` to the generic workstream.

---
*PR created automatically by Jules for task [13318654664849827134](https://jules.google.com/task/13318654664849827134) started by @akitorahayashi*