### PR TITLE
obs(devops): emit findings on ci/cd practices

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/duplicate-setup.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/duplicate-setup.yml
@@ -1,0 +1,29 @@
+schema_version: 1
+
+id: "m3n4o5"
+issue_id: ""
+created_at: "2024-05-22"
+author_role: "devops"
+confidence: "high"
+
+title: "Duplicate setup logic for mlx-lm virtual environment"
+statement: |
+  The logic to provision the `mlx-lm` virtual environment is duplicated across multiple workflows, increasing maintenance burden and risk of drift.
+  `lint-and-test.yml` and `setup-python.yml` both manually construct the environment using identical shell commands.
+
+evidence:
+  - path: ".github/workflows/lint-and-test.yml"
+    loc:
+      - "Create mlx-lm venv"
+      - "Install mlx dependencies"
+    note: "Manual venv creation and syncing duplicate logic found elsewhere."
+
+  - path: ".github/workflows/setup-python.yml"
+    loc:
+      - "Create mlx-lm venv"
+      - "Install mlx dependencies"
+    note: "Identical setup block to lint-and-test.yml."
+
+tags:
+  - "maintenance"
+  - "dry"

--- a/.jules/workstreams/generic/exchange/events/pending/missing-artifacts.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/missing-artifacts.yml
@@ -1,0 +1,27 @@
+schema_version: 1
+
+id: "p1q2r3"
+issue_id: ""
+created_at: "2024-05-22"
+author_role: "devops"
+confidence: "high"
+
+title: "Missing immutable artifact promotion pipeline"
+statement: |
+  The project relies on users installing directly from git source (`pipx install git+...`), bypassing artifact versioning and integrity checks.
+  There is no automated release workflow to build, sign, and publish wheels/sdists to GitHub Releases or PyPI.
+
+evidence:
+  - path: "README.md"
+    loc:
+      - "pipx install git+https://github.com/akitorahayashi/menv.git"
+    note: "Installation instructions direct users to mutable git references."
+
+  - path: ".github/workflows/"
+    loc:
+      - "ci-workflows.yml"
+    note: "No release or publish workflow exists in the CI directory."
+
+tags:
+  - "architecture"
+  - "delivery"

--- a/.jules/workstreams/generic/exchange/events/pending/unpinned-deps.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/unpinned-deps.yml
@@ -1,0 +1,31 @@
+schema_version: 1
+
+id: "x9y8z7"
+issue_id: ""
+created_at: "2024-05-22"
+author_role: "devops"
+confidence: "high"
+
+title: "Unpinned toolchains and dependencies in CI"
+statement: |
+  Critical CI components use floating tags or 'latest' versions, creating supply chain risks and non-deterministic builds.
+  GitHub Actions references are pinned to mutable tags (v4, v5) instead of SHAs.
+  Homebrew installations use implicit 'latest'.
+
+evidence:
+  - path: ".github/actions/setup-base/action.yml"
+    loc:
+      - "uses: actions/setup-python@v5"
+      - "uses: extractions/setup-just@v2"
+      - "uses: astral-sh/setup-uv@v5"
+    note: "Actions pinned to mutable tags allow upstream supply chain attacks."
+
+  - path: ".github/workflows/lint-and-test.yml"
+    loc:
+      - "run: brew install shellcheck shfmt"
+    note: "Implicit 'latest' from Homebrew means linting rules can change unexpectedly."
+
+tags:
+  - "security"
+  - "reproducibility"
+  - "supply-chain"

--- a/.jules/workstreams/generic/workstations/devops/perspective.yml
+++ b/.jules/workstreams/generic/workstations/devops/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 2
+
+observer: "devops"
+workstream: "generic"
+
+updated_at: "2024-05-22T10:05:00Z"
+
+goals:
+  - "Secure the supply chain by pinning dependencies"
+  - "Reduce maintenance overhead by consolidating setup logic"
+  - "Establish immutable artifact promotion"
+
+rules: []
+
+ignore: []
+
+log:
+  - at: "2024-05-22T10:05:00Z"
+    summary: "Emitted 3 events: unpinned deps (x9y8z7), duplicate setup (m3n4o5), missing artifacts (p1q2r3)."
+  - at: "2024-05-22T10:00:00Z"
+    summary: "Initialized devops perspective."


### PR DESCRIPTION
Initialize devops workstation perspective and emit three high-signal events regarding:
1. Unpinned toolchains and dependencies (supply chain risk).
2. Duplicate setup logic for mlx-lm environments (maintenance burden).
3. Missing immutable artifact promotion pipeline (delivery architecture).

Update perspective.yml with analysis logs.

---
*PR created automatically by Jules for task [3803494327253457179](https://jules.google.com/task/3803494327253457179) started by @akitorahayashi*