### PR TITLE
chore: add coverage observer artifacts

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/92nxg4.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/92nxg4.yml
@@ -1,0 +1,32 @@
+schema_version: 1
+
+# Metadata
+id: "92nxg4"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "cov"
+confidence: "high"
+
+# Content
+title: "Low Coverage in User-Facing CLI Commands"
+statement: |
+  Several key CLI commands (`update`, `switch`, `create`) have dangerously low test coverage (< 35%). This exposes the application to regressions in user interactions, particularly in the self-update and environment switching workflows.
+
+evidence:
+  - path: "src/menv/commands/update.py"
+    loc:
+      - "21-57"
+    note: "Update command logic (18% coverage)."
+  - path: "src/menv/commands/switch.py"
+    loc:
+      - "36-163"
+    note: "Switch command logic (26% coverage)."
+  - path: "src/menv/commands/create.py"
+    loc:
+      - "91-249"
+    note: "Create command logic (31% coverage)."
+
+tags:
+  - "coverage"
+  - "cli"
+  - "risk"

--- a/.jules/workstreams/generic/exchange/events/pending/fev6uq.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/fev6uq.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+
+# Metadata
+id: "fev6uq"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "cov"
+confidence: "high"
+
+# Content
+title: "Critical Coverage Gap in AnsibleRunner"
+statement: |
+  The AnsibleRunner service, which is central to the application's core function of executing playbooks, has only 28% test coverage. The actual execution logic (`run_playbook`) is almost entirely skipped in tests due to reliance on mocks, leaving error handling and process execution unverified.
+
+evidence:
+  - path: "src/menv/services/ansible_runner.py"
+    loc:
+      - "35-95"
+    note: "Core `run_playbook` implementation is uncovered."
+
+tags:
+  - "coverage"
+  - "risk"
+  - "testing"

--- a/.jules/workstreams/generic/workstations/cov/perspective.yml
+++ b/.jules/workstreams/generic/workstations/cov/perspective.yml
@@ -1,0 +1,21 @@
+schema_version: 2
+
+observer: "cov"
+workstream: "generic"
+
+updated_at: "2026-02-04T22:52:48Z"
+
+goals:
+  - "Close critical coverage gap in AnsibleRunner service (currently 28%)"
+  - "Establish baseline coverage for CLI commands (update, switch, create)"
+  - "Prevent regression of overall coverage below 65%"
+
+rules:
+  - "Flag any service with < 50% coverage as high risk"
+  - "Require integration tests for external process execution (Ansible, pipx)"
+
+ignore: []
+
+log:
+  - at: "2026-02-04T22:52:48Z"
+    summary: "Initial coverage analysis reveals 65% global coverage with critical gaps in runner and CLI."


### PR DESCRIPTION
Initializes the coverage observer workstation and emits events for critical coverage gaps found in `AnsibleRunner` and CLI commands.

---
*PR created automatically by Jules for task [17436963097335537952](https://jules.google.com/task/17436963097335537952) started by @akitorahayashi*