### PR TITLE
Taxonomy Observer: Initial Findings

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/c8f9s2.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/c8f9s2.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+id: "c8f9s2"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "taxonomy"
+confidence: "high"
+title: "Terminology Collision: 'Config'"
+statement: |
+  The term 'config' is overloaded, referring to both VCS Identity (user settings) and Ansible Role Configurations (deployment files).
+evidence:
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "config_app = typer.Typer(name='config')"
+    note: "CLI command 'config' manages both VCS identity (show/set) and role configs (create)."
+  - path: "src/menv/services/config_storage.py"
+    loc:
+      - "class ConfigStorage(ConfigStorageProtocol):"
+    note: "Service manages VCS identity in ~/.config/menv/config.toml."
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "class ConfigDeployer:"
+    note: "Service manages Ansible role configurations in ~/.config/menv/roles/."
+tags:
+  - "taxonomy"
+  - "naming-collision"
+  - "cli"

--- a/.jules/workstreams/generic/exchange/events/pending/d2k4m1.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/d2k4m1.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "d2k4m1"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "taxonomy"
+confidence: "high"
+title: "Domain Constants Leakage"
+statement: |
+  Domain constants `VALID_PROFILES` and `PROFILE_ALIASES` are duplicated in multiple CLI command modules instead of being defined in a shared domain model.
+evidence:
+  - path: "src/menv/commands/create.py"
+    loc:
+      - "VALID_PROFILES = {...}"
+      - "PROFILE_ALIASES = {...}"
+    note: "Constants defined locally in create command."
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "VALID_PROFILES = {...}"
+      - "PROFILE_ALIASES = {...}"
+    note: "Constants duplicated locally in make command."
+tags:
+  - "taxonomy"
+  - "boundary-violation"
+  - "dry-violation"

--- a/.jules/workstreams/generic/exchange/events/pending/v9p3l5.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/v9p3l5.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+id: "v9p3l5"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "taxonomy"
+confidence: "high"
+title: "Terminology Mismatch: 'Create' vs 'Deploy'"
+statement: |
+  The CLI command `menv config create` uses the verb "create", while the underlying service method is named `deploy_role`, causing a disconnect between user-facing and internal terminology.
+evidence:
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "@config_app.command(name='create')"
+    note: "CLI exposes the action as 'create'."
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "def deploy_role(self, role: str, overwrite: bool = False) -> DeployResult:"
+    note: "Service implements the action as 'deploy'."
+tags:
+  - "taxonomy"
+  - "vocabulary-mismatch"
+  - "cli"

--- a/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
@@ -1,0 +1,12 @@
+schema_version: 2
+observer: taxonomy
+workstream: generic
+updated_at: "2026-02-04T00:05:00Z"
+goals:
+  - "Map the divergent use of 'config' across CLI and Services."
+  - "Identify duplicates of domain constants in CLI layer."
+rules: []
+ignore: []
+log:
+  - at: "2026-02-04T00:05:00Z"
+    summary: "Emitted 3 events covering 'config' overload, domain constants leakage, and 'create' vs 'deploy' mismatch."


### PR DESCRIPTION
Emitted 3 events for taxonomy issues: config overload, domain constants leakage, and create vs deploy mismatch. Created taxonomy perspective.

---
*PR created automatically by Jules for task [3803494327253458543](https://jules.google.com/task/3803494327253458543) started by @akitorahayashi*