### PR TITLE
observer(consistency): emit events for documentation drift

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/brw001.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/brw001.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+id: "brw001"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "consistency"
+confidence: "high"
+title: "Brew Formulae Documentation Claims Profile Requirement But Implementation Uses Common Fallback"
+statement: |
+  Documentation in `README.md` and `AGENTS.md` states that `brew-formulae` requires profile specification because it has machine-specific configurations. However, the implementation shows that `brew-formulae` configuration is stored in `config/common/formulae` and the profile-specific directories (e.g., `macbook`) do not contain formulae configurations. The Ansible task logic falls back to the common configuration, making the profile specification unnecessary for obtaining correct configuration.
+evidence:
+  - path: "README.md"
+    loc:
+      - "52"
+    note: "States: 'Only brew-formulae and brew-cask require profile specification since they have machine-specific configurations.'"
+  - path: "src/menv/ansible/roles/brew/tasks/formulae.yml"
+    loc:
+      - "9-11"
+    note: "Uses `first_found` to fallback to `common/formulae/Brewfile` if profile-specific file is missing."
+  - path: "src/menv/ansible/roles/brew/config/profiles/macbook/"
+    loc:
+      - "dir"
+    note: "Does not contain `formulae` directory, only `cask`."
+tags:
+  - "documentation"
+  - "drift"
+  - "brew"

--- a/.jules/workstreams/generic/exchange/events/pending/sym001.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/sym001.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "sym001"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "consistency"
+confidence: "high"
+title: "README.md Incorrectly Claims Dotfiles Are Copied (No Symlinks)"
+statement: |
+  The README.md explicitly states that dotfiles are provisioned by copying them into the home directory (no symlinks). However, the implementation in the shell Ansible role uses `state: link`, creating symbolic links. This contradicts the documentation and misinforms users about how their environment is modified.
+evidence:
+  - path: "README.md"
+    loc:
+      - "54"
+    note: "States: 'menv provisions dotfiles by copying them into your home directory (no symlinks)'"
+  - path: "src/menv/ansible/roles/shell/tasks/main.yml"
+    loc:
+      - "6"
+      - "13"
+      - "54"
+    note: "Uses `ansible.builtin.file` with `state: link` for dotfiles."
+tags:
+  - "documentation"
+  - "drift"
+  - "shell"

--- a/.jules/workstreams/generic/workstations/consistency/perspective.yml
+++ b/.jules/workstreams/generic/workstations/consistency/perspective.yml
@@ -1,0 +1,14 @@
+schema_version: 2
+observer: "consistency"
+workstream: "generic"
+updated_at: "2026-02-04T22:56:30Z"
+goals:
+  - "Monitor README.md for accuracy against implementation."
+  - "Verify AGENTS.md design rules are followed."
+rules: []
+ignore: []
+log:
+  - at: "2026-02-04T22:56:30Z"
+    summary: "Emitted sym001 (README symlink contradiction) and brw001 (Brew formulae profile requirement)."
+  - at: "2026-02-04T22:54:48Z"
+    summary: "Initialized workstation perspective."


### PR DESCRIPTION
Emitted two events detecting drift between documentation and implementation regarding dotfile symlinks and brew-formulae profile requirements.
Initialized workstation perspective for consistency role.

---
*PR created automatically by Jules for task [5591758697831273700](https://jules.google.com/task/5591758697831273700) started by @akitorahayashi*