### PR TITLE
Report structural violations in backup command

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/ambiguous-module-structure.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/ambiguous-module-structure.yml
@@ -1,0 +1,32 @@
+schema_version: 1
+
+id: "a7m4d2"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "structural_arch"
+confidence: "high"
+
+title: "Ambiguous module structure in backup command"
+statement: |
+  The `menv.commands.backup` namespace is implemented as both a single file module (`src/menv/commands/backup.py`) and a package directory (`src/menv/commands/backup/`). This creates ambiguity in import resolution, potential for dead code, and confusion about the authoritative implementation. The single file appears to be a legacy implementation while the package contains a newer, service-based approach.
+
+evidence:
+  - path: "src/menv/commands/backup.py"
+    loc:
+      - "1-149"
+    note: "Single file implementation of backup command using direct subprocess calls. Has 0% test coverage."
+
+  - path: "src/menv/commands/backup/__init__.py"
+    loc:
+      - "1-5"
+    note: "Package initialization which exports `backup` from `menv.commands.backup.command`."
+
+  - path: "src/menv/commands/backup/command.py"
+    loc:
+      - "1-100"
+    note: "Package-based implementation using `menv.commands.backup.services`. Has 92% test coverage."
+
+tags:
+  - "ambiguity"
+  - "module-structure"
+  - "dead-code"

--- a/.jules/workstreams/generic/exchange/events/pending/logic-duplication-ssot-violation.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/logic-duplication-ssot-violation.yml
@@ -1,0 +1,37 @@
+schema_version: 1
+
+id: "b9x1y3"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "structural_arch"
+confidence: "high"
+
+title: "Logic duplication in backup command"
+statement: |
+  The backup command logic (specifically for system defaults and VSCode extensions) is implemented in three separate locations: as standalone scripts in `src/menv/ansible/scripts`, as a single-file CLI command in `src/menv/commands/backup.py`, and as service modules in `src/menv/commands/backup/services/`. This violates the Single Source of Truth principle and makes maintenance error-prone.
+
+evidence:
+  - path: "src/menv/commands/backup.py"
+    loc:
+      - "126-149"
+    note: "Backup implementation using subprocess to call scripts."
+
+  - path: "src/menv/ansible/scripts/system/backup-system.py"
+    loc:
+      - "1-140"
+    note: "Standalone script implementation of system backup."
+
+  - path: "src/menv/commands/backup/services/system.py"
+    loc:
+      - "1-140"
+    note: "Service-based implementation of system backup (near-duplicate of script)."
+
+  - path: "src/menv/commands/backup/services/vscode_extensions.py"
+    loc:
+      - "1-60"
+    note: "Service-based implementation of VSCode backup."
+
+tags:
+  - "duplication"
+  - "ssot-violation"
+  - "maintenance"

--- a/.jules/workstreams/generic/workstations/structural_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/structural_arch/perspective.yml
@@ -8,11 +8,14 @@ updated_at: "2026-02-04T22:52:29Z"
 goals:
   - "Identify and document structural violations in the core service layer."
   - "Map out hidden coupling between CLI and domain logic."
+  - "Resolve ambiguous module structure and logic duplication in backup command."
 
 rules: []
 
 ignore: []
 
 log:
+  - at: "2026-02-04T22:52:29Z"
+    summary: "Identified ambiguous module structure in `menv.commands.backup` (file vs package) and triplicated logic for system/vscode backups across scripts, services, and CLI commands. Emitted events a7m4d2 and b9x1y3."
   - at: "2026-02-04T22:52:29Z"
     summary: "Initial structural audit of menv package."


### PR DESCRIPTION
Identified and documented two structural violations in the `menv.commands.backup` implementation:
1.  **Ambiguous Module Structure**: The command exists as both a file (`src/menv/commands/backup.py`) and a package (`src/menv/commands/backup/`). The file appears to be dead code (0% coverage) while the package is the active implementation.
2.  **Logic Duplication**: Backup logic is triplicated across standalone scripts, the dead CLI file, and the active service modules.

These findings are recorded in `.jules/workstreams/generic/exchange/events/pending/` and the workstation perspective.

---
*PR created automatically by Jules for task [1291332626619769402](https://jules.google.com/task/1291332626619769402) started by @akitorahayashi*