### PR TITLE
obs(taxonomy): emit events for CLI inconsistencies

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/c9l3n6.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/c9l3n6.yml
@@ -1,0 +1,35 @@
+schema_version: 1
+
+# Metadata
+id: "c9l3n6"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Ambiguous Usage of 'Config' Terminology"
+statement: |
+  The term "Config" is overloaded to mean both "User Identity" (git/vcs config) and "Application Configuration" (dotfiles). `MenvConfig` and `VcsIdentityConfig` in `src/menv/models/config.py` refer solely to identity, while `app_ctx.config_deployer` manages dotfiles. This ambiguity creates confusion about the scope and responsibility of "config" related components.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/models/config.py"
+    loc:
+      - "17-21"
+    note: "MenvConfig defined as VcsIdentityConfig container (Identity)"
+
+  - path: "src/menv/commands/backup/command.py"
+    loc:
+      - "87"
+    note: "local_config_dir variable used to refer to dotfiles configuration"
+
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "11"
+    note: "MenvConfig imported but 'config create' refers to dotfiles deployment"
+
+tags:
+  - "taxonomy"
+  - "terminology"
+  - "ambiguity"

--- a/.jules/workstreams/generic/exchange/events/pending/d8k2m5.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/d8k2m5.yml
@@ -1,0 +1,30 @@
+schema_version: 1
+
+# Metadata
+id: "d8k2m5"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Duplicate Domain Constants Leaked to CLI"
+statement: |
+  Domain logic constants `VALID_PROFILES`, `PROFILE_ALIASES`, `TAG_GROUPS`, `FULL_SETUP_TAGS`, and `OPTIONAL_TASKS` are duplicated and hardcoded in CLI commands `create.py` and `make.py`. This creates inconsistencies (e.g., `make` includes "common" in profiles while `create` does not) and scatters domain knowledge across the presentation layer.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/commands/create.py"
+    loc:
+      - "16-52"
+    note: "Constants FULL_SETUP_TAGS and OPTIONAL_TASKS defined in create.py"
+
+  - path: "src/menv/commands/make.py"
+    loc:
+      - "16-29"
+    note: "Constants TAG_GROUPS, VALID_PROFILES, PROFILE_ALIASES defined in make.py (duplicated from create.py)"
+
+tags:
+  - "taxonomy"
+  - "domain-leakage"
+  - "duplication"

--- a/.jules/workstreams/generic/exchange/events/pending/f0g4h7.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/f0g4h7.yml
@@ -1,0 +1,30 @@
+schema_version: 1
+
+# Metadata
+id: "f0g4h7"
+issue_id: ""
+created_at: "2026-02-04"
+author_role: "taxonomy"
+confidence: "high"
+
+# Content
+title: "Inconsistent Semantics of 'create' Verb"
+statement: |
+  The verb "create" is used with significantly different meanings in the CLI. `menv create` provisions a full environment (idempotent, complex), while `menv config create` copies default configuration files (scaffolding/deployment). This overload dilutes the meaning of "create" and confuses users about the scope of the command.
+
+# Evidence supporting the observation
+evidence:
+  - path: "src/menv/commands/create.py"
+    loc:
+      - "113"
+    note: "menv create: provisions full environment"
+
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "95"
+    note: "menv config create: copies/deploys config files"
+
+tags:
+  - "taxonomy"
+  - "cli-design"
+  - "verbs"

--- a/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
@@ -1,12 +1,15 @@
 schema_version: 2
 observer: taxonomy
 workstream: generic
-updated_at: "2026-02-04T00:05:00Z"
+updated_at: "2026-02-04T01:00:00Z"
 goals:
-  - "Map the divergent use of 'config' across CLI and Services."
-  - "Identify duplicates of domain constants in CLI layer."
+  - "Monitor new CLI commands for domain logic leakage."
+  - "Advocate for renaming 'MenvConfig' to 'IdentityConfig'."
+  - "Advocate for renaming 'menv config create' to 'menv config deploy'."
 rules: []
 ignore: []
 log:
+  - at: "2026-02-04T01:00:00Z"
+    summary: "Refined goals after confirming and emitting events for domain constants, config overload, and verb collision."
   - at: "2026-02-04T00:05:00Z"
     summary: "Emitted 3 events covering 'config' overload, domain constants leakage, and 'create' vs 'deploy' mismatch."


### PR DESCRIPTION
This change emits 3 taxonomy events identifying terminology and domain logic issues in the CLI, and updates the observer perspective.

---
*PR created automatically by Jules for task [12440802688974239781](https://jules.google.com/task/12440802688974239781) started by @akitorahayashi*