### PR TITLE
docs: add QA observations for backup command and tests

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/b4c5d6.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/b4c5d6.yml
@@ -1,0 +1,21 @@
+schema_version: 1
+id: "b4c5d6"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "qa"
+confidence: "high"
+title: "Ambiguous Module Structure for Backup Command"
+statement: |
+  The repository contains both `src/menv/commands/backup.py` and `src/menv/commands/backup/` package. This violates the "1 command per file" (or "1 domain per package") clarity and introduces potential import confusion. The package `backup/` appears to be the active implementation, while `backup.py` is likely dead code or redundant.
+evidence:
+  - path: "src/menv/commands/backup.py"
+    loc:
+      - "1"
+    note: "File exists alongside package `src/menv/commands/backup/`"
+  - path: "src/menv/commands/backup/__init__.py"
+    loc:
+      - "1"
+    note: "Package exists alongside file `src/menv/commands/backup.py`"
+tags:
+  - "architecture"
+  - "confusion"

--- a/.jules/workstreams/generic/exchange/events/pending/e7f8g9.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/e7f8g9.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+id: "e7f8g9"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "qa"
+confidence: "high"
+title: "Backup Services Violate Architecture Principles"
+statement: |
+  The new backup services (`system.py`, `vscode_extensions.py`) use functional programming and direct `subprocess` calls instead of following the established Service/Protocol pattern with Dependency Injection. This reduces testability (forcing monkeypatching) and consistency with the rest of the codebase.
+evidence:
+  - path: "src/menv/commands/backup/services/system.py"
+    loc:
+      - "1"
+    note: "Functional style, no class/Protocol, direct subprocess usage."
+  - path: "src/menv/commands/backup/services/vscode_extensions.py"
+    loc:
+      - "1"
+    note: "Functional style, no class/Protocol, direct subprocess usage."
+  - path: "tests/intg/roles/system/test_backup.py"
+    loc:
+      - "46"
+    note: "Tests rely on monkeypatching private `_run_defaults` function."
+tags:
+  - "architecture"
+  - "testability"
+  - "coupling"

--- a/.jules/workstreams/generic/exchange/events/pending/h0i1j2.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/h0i1j2.yml
@@ -1,0 +1,22 @@
+schema_version: 1
+id: "h0i1j2"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "qa"
+confidence: "high"
+title: "Fragile \"Mirror Logic\" in Integrity Tests"
+statement: |
+  `tests/intg/test_role_integrity.py` implements a custom Python parser for Ansible files (using regexes) to validate file references. This duplicates Ansible's internal logic, making the tests fragile and prone to drift or false failures if Ansible syntax evolves or complex Jinja2 expressions are used.
+evidence:
+  - path: "tests/intg/test_role_integrity.py"
+    loc:
+      - "18"
+    note: "Defines SRC_PATTERN and LOOKUP_PATTERN regexes."
+  - path: "tests/intg/test_role_integrity.py"
+    loc:
+      - "43"
+    note: "`_resolve_template_literal` attempts to mimic Jinja2 resolution manually."
+tags:
+  - "anti-pattern"
+  - "test-fragility"
+  - "mirror-logic"

--- a/.jules/workstreams/generic/workstations/qa/perspective.yml
+++ b/.jules/workstreams/generic/workstations/qa/perspective.yml
@@ -1,23 +1,15 @@
 schema_version: 2
-
 observer: "qa"
 workstream: "generic"
-
-updated_at: "2024-05-22T12:00:00Z"
-
-# Keep this list short (1-3). These goals are the continuity mechanism across runs.
+updated_at: "2024-05-23T11:00:00Z"
 goals:
-  - "Monitor the reliability of 'Mirror Logic' tests in `tests/intg/test_role_integrity.py`."
-  - "Identify opportunities to introduce minimal runtime verification for Ansible playbooks."
+  - "Advocate for refactoring 'Mirror Logic' tests in `tests/intg/test_role_integrity.py` to use `ansible-playbook --syntax-check` or similar."
+  - "Ensure new commands (like backup) adhere to the Service/Protocol architecture and dependency injection patterns."
   - "Preserve the strong boundary isolation pattern observed in unit tests."
-
-# Stable rules of thumb for producing consistent, high-signal events.
 rules: []
-
-# Explicit suppressions to prevent repeated low-value observations.
 ignore: []
-
-# Newest first; keep max 5 entries.
 log:
+  - at: "2024-05-23T11:00:00Z"
+    summary: "Identified architectural regressions in the new backup command (ambiguous module structure, lack of DI) and confirmed the persistence of the 'Mirror Logic' anti-pattern."
   - at: "2024-05-22T12:00:00Z"
     summary: "Initial analysis: identified 'Mirror Logic' anti-pattern in integrity tests and lack of runtime verification."


### PR DESCRIPTION
This PR adds QA observations regarding the recent backup command implementation and existing integrity tests.

Findings:
- **Ambiguous Module Structure:** `src/menv/commands/backup.py` conflicts with `src/menv/commands/backup/` package.
- **Architecture Violations:** New backup services use direct `subprocess` calls and functional style instead of the established Service/Protocol pattern with DI, reducing testability.
- **Mirror Logic Anti-Pattern:** `tests/intg/test_role_integrity.py` re-implements Ansible parsing in Python, which is fragile.

The QA perspective has been updated to reflect these findings and set goals for advocating refactoring.

---
*PR created automatically by Jules for task [10887564253463137163](https://jules.google.com/task/10887564253463137163) started by @akitorahayashi*