### PR TITLE
chore(devops): emit findings on unpinned deps and missing release workflow

### DIFF
--- a/.jules/workstreams/generic/exchange/events/pending/h5j3k9.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/h5j3k9.yml
@@ -1,0 +1,33 @@
+schema_version: 1
+
+# Metadata
+id: "h5j3k9"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "devops"
+confidence: "high"
+
+# Content
+title: "Unpinned GitHub Action Dependencies in setup-base"
+statement: |
+  Critical CI actions (`actions/setup-python`, `extractions/setup-just`, `astral-sh/setup-uv`) are referenced by mutable tags (`@v5`, `@v2`), exposing the pipeline to supply-chain attacks or unexpected breaking changes.
+
+# Evidence supporting the observation
+evidence:
+  - path: ".github/actions/setup-base/action.yml"
+    loc:
+      - "7"
+    note: "uses: actions/setup-python@v5"
+  - path: ".github/actions/setup-base/action.yml"
+    loc:
+      - "12"
+    note: "uses: extractions/setup-just@v2"
+  - path: ".github/actions/setup-base/action.yml"
+    loc:
+      - "16"
+    note: "uses: astral-sh/setup-uv@v5"
+
+tags:
+  - "security"
+  - "supply-chain"
+  - "reproducibility"

--- a/.jules/workstreams/generic/exchange/events/pending/m7n2p4.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/m7n2p4.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+
+# Metadata
+id: "m7n2p4"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "devops"
+confidence: "high"
+
+# Content
+title: "Non-Deterministic Linter Installation in CI"
+statement: |
+  shellcheck and shfmt are installed via brew install without version constraints in the lint-and-test workflow. This creates potential irreproducibility if newer versions introduce stricter rules or break compatibility.
+
+# Evidence supporting the observation
+evidence:
+  - path: ".github/workflows/lint-and-test.yml"
+    loc:
+      - "19"
+    note: "run: brew install shellcheck shfmt"
+
+tags:
+  - "reproducibility"
+  - "flakiness"
+  - "toolchain"

--- a/.jules/workstreams/generic/exchange/events/pending/q8r1s5.yml
+++ b/.jules/workstreams/generic/exchange/events/pending/q8r1s5.yml
@@ -1,0 +1,25 @@
+schema_version: 1
+
+# Metadata
+id: "q8r1s5"
+issue_id: ""
+created_at: "2024-05-23"
+author_role: "devops"
+confidence: "high"
+
+# Content
+title: "Absence of Automated Artifact Release Workflow"
+statement: |
+  The repository lacks a CI workflow to build and publish release artifacts (e.g., Python wheels, sdist) to GitHub Releases or PyPI. This relies on manual processes which lack provenance and traceability.
+
+# Evidence supporting the observation
+evidence:
+  - path: ".github/workflows"
+    loc:
+      - "dir"
+    note: "absence of release.yml"
+
+tags:
+  - "automation"
+  - "artifacts"
+  - "release"

--- a/.jules/workstreams/generic/workstations/devops/perspective.yml
+++ b/.jules/workstreams/generic/workstations/devops/perspective.yml
@@ -3,7 +3,7 @@ schema_version: 2
 observer: "devops"
 workstream: "generic"
 
-updated_at: "2024-05-22T10:05:00Z"
+updated_at: "2024-05-23T10:15:00Z"
 
 goals:
   - "Secure the supply chain by pinning dependencies"
@@ -15,6 +15,8 @@ rules: []
 ignore: []
 
 log:
+  - at: "2024-05-23T10:15:00Z"
+    summary: "Emitted 3 events: unpinned actions (h5j3k9), unpinned linters (m7n2p4), missing release workflow (q8r1s5)."
   - at: "2024-05-22T10:05:00Z"
     summary: "Emitted 3 events: unpinned deps (x9y8z7), duplicate setup (m3n4o5), missing artifacts (p1q2r3)."
   - at: "2024-05-22T10:00:00Z"


### PR DESCRIPTION
Created 3 high-signal events for unpinned GitHub Actions, unpinned linter installations, and missing artifact release workflow. Updated perspective.yml.

---
*PR created automatically by Jules for task [8064144044202243419](https://jules.google.com/task/8064144044202243419) started by @akitorahayashi*