### PR TITLE
Fix Documentation Drift: Aider and LLM Aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,22 @@ menv make --help
 menv create macbook --overwrite  # Force overwrite all configs during setup
 menv cr mbk -o                 # Shorthand with overwrite
 ```
+
+**Shell Aliases:**
+
+`menv` provides several useful aliases via the `shell` role.
+
+**Aider (AI Pair Programmer)**
+
+| Alias | Command | Description |
+|-------|---------|-------------|
+| `ai` | `menv internal aider run` | Run aider on specified files/dirs |
+| `ai-st <model>` | `menv internal aider set-model` | Set default Ollama model for aider |
+| `ai-ls` | `menv internal aider list-models` | List available Ollama models |
+| `ai-us` | `menv internal aider unset-model` | Unset default model |
+
+**Context Management**
+
+| Alias | Description |
+|-------|-------------|
+| `cld-ln` | Symlinks `AGENTS.md` (priority) or `README.md` to `.claude/CLAUDE.md` for Claude CLI context. |

--- a/src/menv/ansible/roles/shell/config/common/alias/llm/llm.sh
+++ b/src/menv/ansible/roles/shell/config/common/alias/llm/llm.sh
@@ -10,22 +10,27 @@ alias cld-m-a="claude mcp add"
 alias cld-m-rm="claude mcp remove"
 alias cld-m-ls="claude mcp list"
 
-# Link AGENTS.md to .claude/CLAUDE.md
+# Link AGENTS.md or README.md to .claude/CLAUDE.md
 alias cld-ln=cld_ln
 cld_ln() {
+	local target_file="AGENTS.md"
 	if [ ! -f "AGENTS.md" ]; then
-		echo "❌ AGENTS.md not found in the project root. Please run this command from the repository root." >&2
-		return 1
+		if [ -f "README.md" ]; then
+			target_file="README.md"
+		else
+			echo "❌ Neither AGENTS.md nor README.md found in the project root. Please run this command from the repository root." >&2
+			return 1
+		fi
 	fi
 
 	# Ensure directory exists
 	mkdir -p .claude
 
 	# Create relative symlink (force overwrite)
-	# Target: ../AGENTS.md (relative from .claude/CLAUDE.md)
-	ln -sf ../AGENTS.md .claude/CLAUDE.md
+	# Target: ../<target_file> (relative from .claude/CLAUDE.md)
+	ln -sf "../${target_file}" .claude/CLAUDE.md
 
-	echo "🔗 Linked .claude/CLAUDE.md -> ../AGENTS.md"
+	echo "🔗 Linked .claude/CLAUDE.md -> ../${target_file}"
 }
 
 alias cdx="codex"


### PR DESCRIPTION
Updated README.md to document aider integration and updated llm.sh to support both AGENTS.md and README.md for context linking. This resolves the discrepancy between the implementation and the intended behavior/documentation.

---
*PR created automatically by Jules for task [1563971622976561965](https://jules.google.com/task/1563971622976561965) started by @akitorahayashi*