### PR TITLE
feat(ci): Pin CI dependencies and add release workflow

### DIFF
--- a/.github/actions/setup-base/action.yml
+++ b/.github/actions/setup-base/action.yml
@@ -5,15 +5,15 @@ runs:
   using: "composite"
   steps:
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.1.0
       with:
         python-version: '3.12'
 
     - name: Setup just
-      uses: extractions/setup-just@v2
+      uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2.0.0
 
     - name: Setup uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081 # v5.0.0
       with:
         enable-cache: true
 

--- a/.github/workflows/jules-automerge.yml
+++ b/.github/workflows/jules-automerge.yml
@@ -51,7 +51,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0

--- a/.github/workflows/jules-implementer-label.yml
+++ b/.github/workflows/jules-implementer-label.yml
@@ -31,7 +31,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           # Checkout worker; label definitions and contracts are read from the worker branch.
           ref: 'jules'

--- a/.github/workflows/jules-mock-cleanup.yml
+++ b/.github/workflows/jules-mock-cleanup.yml
@@ -37,7 +37,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0

--- a/.github/workflows/jules-run-implementer.yml
+++ b/.github/workflows/jules-run-implementer.yml
@@ -43,7 +43,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0

--- a/.github/workflows/jules-run-planner.yml
+++ b/.github/workflows/jules-run-planner.yml
@@ -43,7 +43,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0

--- a/.github/workflows/jules-sync.yml
+++ b/.github/workflows/jules-sync.yml
@@ -31,7 +31,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'main'
           fetch-depth: 0

--- a/.github/workflows/jules-workflows.yml
+++ b/.github/workflows/jules-workflows.yml
@@ -101,7 +101,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'main'
           fetch-depth: 0
@@ -163,7 +163,7 @@ jobs:
       JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
       GH_TOKEN: ${{ secrets.JLO_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -252,7 +252,7 @@ jobs:
     outputs:
       json: ${{ steps.matrix.outputs.json }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -285,7 +285,7 @@ jobs:
       JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
       GH_TOKEN: ${{ secrets.JLO_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -327,7 +327,7 @@ jobs:
       JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
       GH_TOKEN: ${{ secrets.JLO_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -478,7 +478,7 @@ jobs:
       JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
       GH_TOKEN: ${{ secrets.JLO_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -569,7 +569,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.JLO_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -606,7 +606,7 @@ jobs:
     outputs:
       json: ${{ steps.matrix.outputs.json }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -642,7 +642,7 @@ jobs:
       JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
       GH_TOKEN: ${{ secrets.JLO_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -735,7 +735,7 @@ jobs:
     outputs:
       json: ${{ steps.matrix.outputs.json }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -771,7 +771,7 @@ jobs:
       JULES_API_KEY: ${{ secrets.JULES_API_KEY }}
       GH_TOKEN: ${{ secrets.JLO_BOT_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0
@@ -868,7 +868,7 @@ jobs:
       GH_TOKEN: ${{ secrets.JLO_BOT_TOKEN }}
       TARGET_BRANCH: 'main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: 'jules'
           fetch-depth: 0

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -10,15 +10,29 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.7
         with:
           submodules: recursive
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base
 
-      - name: Install shell tools
-        run: brew install shellcheck shfmt
+      - name: Setup shfmt
+        uses: mfinelli/setup-shfmt@36a296dd392ba4e3bbe7a5eaa6e7a97f8fbbd894 # v3.2.1
+        with:
+          shfmt-version: "3.8.0"
+
+      - name: Install ShellCheck
+        run: |
+          scversion="v0.10.0"
+          arch=$(uname -m)
+          if [ "$arch" = "arm64" ]; then
+            arch="aarch64"
+          fi
+          echo "Downloading ShellCheck ${scversion} for ${arch}..."
+          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion}/shellcheck-${scversion}.darwin.${arch}.tar.xz" | tar -xJv
+          sudo cp "shellcheck-${scversion}/shellcheck" /usr/local/bin/
+          shellcheck --version
 
       - name: Run tests
         run: just test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.1.7
+
+      - name: Setup base environment
+        uses: ./.github/actions/setup-base
+
+      - name: Build
+        run: uv build
+
+      - name: Create Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.0.8
+        with:
+          files: dist/*
+          generate_release_notes: true

--- a/.github/workflows/setup-ide.yml
+++ b/.github/workflows/setup-ide.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base

--- a/.github/workflows/setup-nodejs.yml
+++ b/.github/workflows/setup-nodejs.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base

--- a/.github/workflows/setup-python.yml
+++ b/.github/workflows/setup-python.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base

--- a/.github/workflows/setup-runtime.yml
+++ b/.github/workflows/setup-runtime.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base

--- a/.github/workflows/setup-system.yml
+++ b/.github/workflows/setup-system.yml
@@ -10,7 +10,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup base environment
         uses: ./.github/actions/setup-base


### PR DESCRIPTION
This PR enhances the CI/CD pipeline by:
- Pinning all GitHub Actions to immutable SHAs to prevent supply chain attacks.
- Replacing non-deterministic `brew install` for linters with pinned versions of `shellcheck` (v0.10.0) and `shfmt` (v3.8.0).
- Adding a release workflow (`.github/workflows/release.yml`) that triggers on tag push to build and publish artifacts to GitHub Releases.

Closes #027e6b

---
*PR created automatically by Jules for task [4202198800184032952](https://jules.google.com/task/4202198800184032952) started by @akitorahayashi*