### PR TITLE
observer(taxonomy): emit events for config/profile overload

### DIFF
--- a/.jules/exchange/events/pending/cfgovr.yml
+++ b/.jules/exchange/events/pending/cfgovr.yml
@@ -1,0 +1,33 @@
+schema_version: 1
+id: "cfgovr"
+issue_id: ""
+created_at: "2026-02-13"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Term Overload: 'Config' used for both Identity and Role Dotfiles"
+statement: |
+  The term "Config" is overloaded and ambiguous, referring to two distinct concepts:
+  1. "User Identity" (Git name/email) managed via `menv config show/set` and `ConfigStorage`.
+  2. "Role Configuration" (dotfiles/settings) managed via `menv config create` and `ConfigDeployer`.
+  This violates the "One Concept, One Preferred Term" principle and confuses users about what `menv config` actually manages.
+
+evidence:
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "config_app (Typer app)"
+      - "show_config (command)"
+      - "create_config (command)"
+    note: "The `config` command group mixes identity management (`show`, `set`) with dotfile deployment (`create`)."
+
+  - path: "src/menv/services/config_storage.py"
+    loc:
+      - "ConfigStorage (class)"
+      - "get_identity (method)"
+    note: "`ConfigStorage` primarily manages identity profiles (personal/work) but is named generically."
+
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "ConfigDeployer (class)"
+      - "deploy_role (method)"
+    note: "`ConfigDeployer` manages role configuration files, sharing the 'Config' name but unrelated to identity."

--- a/.jules/exchange/events/pending/crdpms.yml
+++ b/.jules/exchange/events/pending/crdpms.yml
@@ -1,0 +1,24 @@
+schema_version: 1
+id: "crdpms"
+issue_id: ""
+created_at: "2026-02-13"
+author_role: "taxonomy"
+confidence: "medium"
+
+title: "Naming Mismatch: 'Create' vs 'Deploy' for Role Configs"
+statement: |
+  The CLI command `menv config create` uses the verb "Create" to describe deploying static configuration files, which clashes with the internal implementation `ConfigDeployer` and overloads the "Create" verb (also used for full machine provisioning).
+  "Deploy" or "Install" is a more accurate term for copying files.
+
+evidence:
+  - path: "src/menv/commands/config.py"
+    loc:
+      - "create_config (command)"
+    note: "Command is named 'create', but docstring says 'Deploy role configs'."
+
+  - path: "src/menv/services/config_deployer.py"
+    loc:
+      - "ConfigDeployer (class)"
+      - "deploy_role (method)"
+      - "DeployResult (class)"
+    note: "Internal service uses 'Deploy' consistently, creating a mismatch with the CLI."

--- a/.jules/exchange/events/pending/prfovr.yml
+++ b/.jules/exchange/events/pending/prfovr.yml
@@ -1,0 +1,31 @@
+schema_version: 1
+id: "prfovr"
+issue_id: ""
+created_at: "2026-02-13"
+author_role: "taxonomy"
+confidence: "high"
+
+title: "Term Overload: 'Profile' used for both Machine Targets and Identity"
+statement: |
+  The term "Profile" is overloaded and ambiguous, referring to two distinct concepts:
+  1. "Machine Target" (e.g., macbook, mac-mini) used in `menv create`.
+  2. "User Identity" (e.g., personal, work) used in `menv switch`.
+  This creates confusion (e.g., users might try to "switch" to a machine or "create" an identity).
+
+evidence:
+  - path: "src/menv/constants.py"
+    loc:
+      - "MACHINE_PROFILES"
+      - "PROFILE_ALIASES"
+    note: "Defines 'Profile' as a machine target (e.g., 'macbook')."
+
+  - path: "src/menv/commands/switch.py"
+    loc:
+      - "switch (command)"
+      - "PROFILE_ALIASES (local constant)"
+    note: "Defines 'Profile' as a user identity (e.g., 'personal')."
+
+  - path: "src/menv/services/config_storage.py"
+    loc:
+      - "get_identity (method)"
+    note: "Uses 'profile' argument to mean identity, clashing with domain constants."

--- a/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
+++ b/.jules/workstreams/generic/workstations/taxonomy/perspective.yml
@@ -1,14 +1,16 @@
 schema_version: 2
 observer: taxonomy
 workstream: generic
-updated_at: "2026-02-04T01:00:00Z"
+updated_at: "2026-02-13T21:00:00Z"
 goals:
-  - "Monitor new CLI commands for domain logic leakage."
-  - "Advocate for renaming 'MenvConfig' to 'IdentityConfig'."
-  - "Advocate for renaming 'menv config create' to 'menv config deploy'."
+  - "Advocate for splitting 'menv config' into 'menv identity' and 'menv roles' to resolve term overload."
+  - "Advocate for renaming 'Identity Profile' to 'Identity' or 'Persona' to disambiguate from 'Machine Profile'."
+  - "Advocate for renaming 'menv config create' to 'menv roles deploy' to resolve verb mismatch."
 rules: []
 ignore: []
 log:
+  - at: "2026-02-13T21:00:00Z"
+    summary: "Emitted 3 events highlighting overloads for 'Config' and 'Profile', and the 'Create' vs 'Deploy' mismatch."
   - at: "2026-02-04T01:00:00Z"
     summary: "Refined goals after confirming and emitting events for domain constants, config overload, and verb collision."
   - at: "2026-02-04T00:05:00Z"


### PR DESCRIPTION
Emitted 3 events identifying term overload for 'Config' and 'Profile', and a verb mismatch between 'Create' and 'Deploy'. Updated taxonomy perspective.

---
*PR created automatically by Jules for task [14986769870926673921](https://jules.google.com/task/14986769870926673921) started by @akitorahayashi*