### PR TITLE
chore(structural-arch): emit events for tool coupling and fragile implementation

### DIFF
--- a/.jules/exchange/events/pending/evt_ansible_paths.yml
+++ b/.jules/exchange/events/pending/evt_ansible_paths.yml
@@ -1,0 +1,20 @@
+schema_version: 1
+id: "evt002"
+issue_id: null
+created_at: "2026-02-13T21:00:00Z"
+author_role: "structural_arch"
+confidence: "high"
+
+title: "Fragile Resource Management in AnsiblePaths Service"
+statement: |
+  The `AnsiblePaths` service relies on `__del__` to clean up the `importlib.resources.as_file` context manager, which handles temporary directories for package resources. Python's `__del__` is not guaranteed to be called (e.g., during interpreter shutdown or circular references), leading to potential resource leaks or errors. Resource lifecycle should be explicit (e.g., via a context manager protocol on the service itself) or handled by the container.
+
+evidence:
+  - path: "src/menv/services/ansible_paths.py"
+    snippet: |
+      def __del__(self) -> None:
+          """Clean up the context manager on deletion."""
+          if self._ansible_dir_context is not None:
+              self._ansible_dir_context.__exit__(None, None, None)
+
+tags: ["resource-management", "lifecycle", "fragile-implementation"]

--- a/.jules/exchange/events/pending/evt_pipx_dep.yml
+++ b/.jules/exchange/events/pending/evt_pipx_dep.yml
@@ -1,0 +1,20 @@
+schema_version: 1
+id: "evt003"
+issue_id: null
+created_at: "2026-02-13T21:00:00Z"
+author_role: "structural_arch"
+confidence: "high"
+
+title: "Hardcoded pipx Dependency in VersionChecker Service"
+statement: |
+  The `VersionChecker` service assumes the application is installed and managed via `pipx` by directly invoking `pipx upgrade menv`. This creates a tight coupling to a specific package manager in the service layer, preventing alternative installation methods (e.g., system package, dev setup, other venv managers) or requiring them to use `pipx` just for updates. The update mechanism should be abstracted or configurable.
+
+evidence:
+  - path: "src/menv/services/version_checker.py"
+    snippet: |
+      result = subprocess.run(
+          ["pipx", "upgrade", "menv"],
+          check=False,
+      )
+
+tags: ["coupling", "external-dependency", "portability"]

--- a/.jules/exchange/events/pending/evt_uv_coupling.yml
+++ b/.jules/exchange/events/pending/evt_uv_coupling.yml
@@ -1,0 +1,23 @@
+schema_version: 1
+id: "evt001"
+issue_id: null
+created_at: "2026-02-13T21:00:00Z"
+author_role: "structural_arch"
+confidence: "high"
+
+title: "Tight Coupling to `uv` in AnsibleRunner Service"
+statement: |
+  The `AnsibleRunner` service directly invokes `uv run ansible-playbook` via `subprocess`, making the application strictly dependent on `uv` availability and location. This violates boundary principles by coupling the service layer to a specific external toolchain without abstraction. If `uv` is not installed or not in the PATH, the service fails with a misleading "ansible-playbook not found" error because the `FileNotFoundError` from the `uv` call is caught and re-raised with that message. This prevents usage in environments where `ansible-playbook` is available directly (e.g. system install or other venv).
+
+evidence:
+  - path: "src/menv/services/ansible_runner.py"
+    snippet: |
+      cmd: list[str | Path] = [
+          "uv",
+          "run",
+          "ansible-playbook",
+          str(playbook_path),
+          # ...
+      ]
+
+tags: ["coupling", "boundary-violation", "external-dependency"]

--- a/.jules/workstreams/generic/workstations/structural_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/structural_arch/perspective.yml
@@ -3,18 +3,20 @@ schema_version: 2
 observer: "structural_arch"
 workstream: "generic"
 
-updated_at: "2026-02-04T22:52:29Z"
+updated_at: "2026-02-13T21:05:00Z"
 
 goals:
   - "Identify and document structural violations in the core service layer."
-  - "Map out hidden coupling between CLI and domain logic."
-  - "Resolve ambiguous module structure and logic duplication in backup command."
+  - "Map out hidden coupling to external tools (uv, pipx, etc)."
+  - "Audit exception hierarchy usage across all services and commands."
 
 rules: []
 
 ignore: []
 
 log:
+  - at: "2026-02-13T21:05:00Z"
+    summary: "Identified structural coupling to external tools (uv, pipx) in service layer and fragile resource management in `AnsiblePaths`. Emitted events evt001, evt002, evt003."
   - at: "2026-02-04T22:52:29Z"
     summary: "Identified ambiguous module structure in `menv.commands.backup` (file vs package) and triplicated logic for system/vscode backups across scripts, services, and CLI commands. Emitted events a7m4d2 and b9x1y3."
   - at: "2026-02-04T22:52:29Z"


### PR DESCRIPTION
Emitted 3 structural architecture events:
- `evt001`: Tight coupling to `uv` in `AnsibleRunner`.
- `evt002`: Fragile resource management in `AnsiblePaths` (using `__del__`).
- `evt003`: Hardcoded `pipx` dependency in `VersionChecker`.

Updated `.jules/workstreams/generic/workstations/structural_arch/perspective.yml` with new goals and log entry.

---
*PR created automatically by Jules for task [15738323180307233027](https://jules.google.com/task/15738323180307233027) started by @akitorahayashi*