### PR TITLE
obs(qa): emit network dependency event and update perspective

### DIFF
--- a/.jules/exchange/events/pending/netd3p.yml
+++ b/.jules/exchange/events/pending/netd3p.yml
@@ -1,0 +1,26 @@
+schema_version: 1
+
+# Metadata
+id: "netd3p"
+issue_id: "" # ID of the issue that processed this event (empty if unprocessed)
+created_at: "2026-02-13"
+author_role: "qa"
+confidence: "high"
+
+# Content
+title: "External Network Dependency in Integration Tests"
+statement: |
+  The test `tests/intg/test_checksums.py` performs live network requests to validate installer checksums,
+  introducing flakiness and external dependencies into the test suite. This violates the "Isolation By Design"
+  and "Determinism Over Retries" principles.
+
+# Evidence supporting the observation
+evidence:
+  - path: "tests/intg/test_checksums.py"
+    loc:
+      - "34-36"
+    note: "httpx.Client().get(url) performs a real network request."
+  - path: "tests/intg/installer_checksums.yml"
+    loc:
+      - "2-8"
+    note: "Contains external URLs used in the test."

--- a/.jules/workstreams/generic/workstations/qa/perspective.yml
+++ b/.jules/workstreams/generic/workstations/qa/perspective.yml
@@ -1,14 +1,16 @@
 schema_version: 2
 observer: "qa"
 workstream: "generic"
-updated_at: "2024-05-23T11:00:00Z"
+updated_at: "2026-02-13T21:00:00Z"
 goals:
-  - "Advocate for refactoring 'Mirror Logic' tests in `tests/intg/test_role_integrity.py` to use `ansible-playbook --syntax-check` or similar."
-  - "Ensure new commands (like backup) adhere to the Service/Protocol architecture and dependency injection patterns."
-  - "Preserve the strong boundary isolation pattern observed in unit tests."
+  - "Advocate for mocking network calls in `tests/intg/test_checksums.py` to improve determinism."
+  - "Monitor the resolution of 'Mirror Logic' (issue `c49eb8`) and Backup Architecture (issue `4d2eb3`) regressions."
+  - "Ensure `AnsibleRunner` and other services decouple from environmental state (like `Path.home()`) for better test portability."
 rules: []
 ignore: []
 log:
+  - at: "2026-02-13T21:00:00Z"
+    summary: "Identified network dependency in `test_checksums.py`; confirmed previous findings are now tracked in issues `c49eb8` (Mirror Logic) and `4d2eb3` (Backup)."
   - at: "2024-05-23T11:00:00Z"
     summary: "Identified architectural regressions in the new backup command (ambiguous module structure, lack of DI) and confirmed the persistence of the 'Mirror Logic' anti-pattern."
   - at: "2024-05-22T12:00:00Z"


### PR DESCRIPTION
Flagged external network dependency in `tests/intg/test_checksums.py` as an event `netd3p`.
Updated QA perspective to track this finding and monitor resolution of existing issues `c49eb8` (Mirror Logic) and `4d2eb3` (Backup).

---
*PR created automatically by Jules for task [11466448765891593064](https://jules.google.com/task/11466448765891593064) started by @akitorahayashi*