### PR TITLE
Consistency Observer Findings: Antigravity gap, Xcode docs, Identity drift

### DIFF
--- a/.jules/exchange/events/pending/cons001.yml
+++ b/.jules/exchange/events/pending/cons001.yml
@@ -1,0 +1,11 @@
+id: cons001
+issue_id: null
+created_at: "2026-02-13T21:00:00Z"
+author_role: consistency
+confidence: high
+title: "menv create excludes Google Antigravity setup"
+statement: "The `menv create` command omits the `antigravity` tag from its `FULL_SETUP_TAGS`, preventing Google Antigravity from being set up during full environment creation, despite being listed as a supported Editor in README.md."
+evidence:
+  - "src/menv/constants.py: FULL_SETUP_TAGS does not include 'antigravity'"
+  - "README.md: Lists 'menv make antigravity' under Editors section alongside VSCode and Cursor"
+tags: ["documentation", "create-command", "antigravity"]

--- a/.jules/exchange/events/pending/cons002.yml
+++ b/.jules/exchange/events/pending/cons002.yml
@@ -1,0 +1,12 @@
+id: cons002
+issue_id: null
+created_at: "2026-02-13T21:00:00Z"
+author_role: consistency
+confidence: medium
+title: "menv make xcode is undocumented"
+statement: "The `menv make xcode` command (tag: `xcode`) exists and is part of `FULL_SETUP_TAGS`, but is not documented in the README.md under the 'Editors' section or available commands."
+evidence:
+  - "src/menv/constants.py: FULL_SETUP_TAGS includes 'xcode'"
+  - "src/menv/ansible/roles/editor/tasks/xcode.yml: Ansible task implementation"
+  - "README.md: Editors section omits 'xcode'"
+tags: ["documentation", "make-command", "xcode"]

--- a/.jules/exchange/events/pending/cons003.yml
+++ b/.jules/exchange/events/pending/cons003.yml
@@ -1,0 +1,12 @@
+id: cons003
+issue_id: null
+created_at: "2026-02-13T21:00:00Z"
+author_role: consistency
+confidence: high
+title: "Workstation memory references non-existent menv identity command"
+statement: "The workstation memory incorrectly references a `menv identity` command (alias `id`) for managing VCS identity. The codebase implements this functionality via `menv config set`."
+evidence:
+  - "src/menv/main.py: No 'identity' command registered"
+  - "src/menv/commands/config.py: Implements 'set_config' for VCS identity"
+  - "README.md: Documents 'menv config set' for VCS identity"
+tags: ["memory-drift", "identity-command"]

--- a/.jules/workstreams/generic/workstations/consistency/perspective.yml
+++ b/.jules/workstreams/generic/workstations/consistency/perspective.yml
@@ -1,7 +1,7 @@
 schema_version: 2
 observer: "consistency"
 workstream: "generic"
-updated_at: "2026-02-08T19:07:03Z"
+updated_at: "2026-02-13T21:05:00Z"
 goals:
   - "Monitor README.md for accuracy against implementation."
   - "Verify AGENTS.md design rules are followed."
@@ -9,6 +9,8 @@ goals:
 rules: []
 ignore: []
 log:
+  - at: "2026-02-13T21:05:00Z"
+    summary: "Emitted cons001 (Antigravity create gap), cons002 (Xcode doc gap), cons003 (Identity command drift)."
   - at: "2026-02-08T19:07:03Z"
     summary: "Emitted x7k3m2 (backup.py duplicate), y9n4p1 (llm alias drift), z2q5r8 (aider doc gap)."
   - at: "2026-02-04T22:56:30Z"


### PR DESCRIPTION
Performed consistency observation on the repository.
Found and documented three inconsistencies:
1.  `menv create` does not include `antigravity` tag, despite Google Antigravity being listed as a supported Editor in README.
2.  `menv make xcode` is a valid command but not documented in README.
3.  Workstation memory references a `menv identity` command which does not exist (implemented as `menv config set`).

Emitted corresponding events in `.jules/exchange/events/pending/` and updated the role perspective.

---
*PR created automatically by Jules for task [4476570973848103907](https://jules.google.com/task/4476570973848103907) started by @akitorahayashi*