### PR TITLE
data_arch: Emit events for Brew duplication, Tag SSOT, and Model validation

### DIFF
--- a/.jules/exchange/events/pending/a1b2c3.yml
+++ b/.jules/exchange/events/pending/a1b2c3.yml
@@ -1,0 +1,23 @@
+schema_version: 1
+
+# Metadata
+id: "a1b2c3"
+issue_id: ""
+created_at: "2026-02-13"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "Brew Configuration Duplication"
+statement: |
+  The Ansible Brew role forces configuration duplication by using `first_found` lookup, which selects only the first matching Brewfile (profile-specific OR common) rather than merging them. This prevents compositional configuration and requires profile-specific configurations to duplicate all common dependencies.
+
+evidence:
+  - path: "src/menv/ansible/roles/brew/tasks/formulae.yml"
+    loc:
+      - "11-13"
+    note: "Uses `first_found` to pick a single Brewfile, ignoring others."
+  - path: "src/menv/ansible/roles/brew/tasks/cask.yml"
+    loc:
+      - "11-13"
+    note: "Same pattern for casks prevents composition."

--- a/.jules/exchange/events/pending/d4e5f6.yml
+++ b/.jules/exchange/events/pending/d4e5f6.yml
@@ -1,0 +1,19 @@
+schema_version: 1
+
+# Metadata
+id: "d4e5f6"
+issue_id: ""
+created_at: "2026-02-13"
+author_role: "data_arch"
+confidence: "high"
+
+# Content
+title: "Tag Groups SSOT Violation"
+statement: |
+  `TAG_GROUPS` definitions are hardcoded in `menv.constants`, creating a split authority for tag definitions. While `playbook.yml` (via `Playbook` service) is the SSOT for tags, tag *aggregations* are externalized, causing coupling between CLI and constants.
+
+evidence:
+  - path: "src/menv/constants.py"
+    loc:
+      - "25-30"
+    note: "`TAG_GROUPS` defines tag aggregations independently of the Playbook service."

--- a/.jules/exchange/events/pending/g7h8i9.yml
+++ b/.jules/exchange/events/pending/g7h8i9.yml
@@ -1,0 +1,19 @@
+schema_version: 1
+
+# Metadata
+id: "g7h8i9"
+issue_id: ""
+created_at: "2026-02-13"
+author_role: "data_arch"
+confidence: "medium"
+
+# Content
+title: "Fragile Model Validation"
+statement: |
+  `src/menv/models/config.py` relies on manual, imperative validation logic and `TypedDict` instead of a robust validation library like Pydantic. This increases maintenance effort and risk of validation gaps.
+
+evidence:
+  - path: "src/menv/models/config.py"
+    loc:
+      - "26-64"
+    note: "Manual `validate_config` function checks dictionary keys and types explicitly."

--- a/.jules/workstreams/generic/workstations/data_arch/perspective.yml
+++ b/.jules/workstreams/generic/workstations/data_arch/perspective.yml
@@ -3,20 +3,21 @@ schema_version: 2
 observer: "data_arch"
 workstream: "generic"
 
-updated_at: "2024-05-23T11:00:00Z"
+updated_at: "2026-02-13T20:55:00Z"
 
 goals:
-  - "Eliminate manual TOML serialization in ConfigStorage."
-  - "Resolve duplicate backup logic and dead code in `menv.commands.backup`."
-  - "Migrate domain constants (TAG_GROUPS, VALID_PROFILES) from CLI to Service layer."
-  - "Consolidate redundant configuration paths to establish SSOT."
+  - "Advocate for compositional configuration pattern in Ansible roles (e.g. Brew)."
+  - "Monitor migration of Tag Groups to Playbook Service SSOT."
+  - "Promote Pydantic adoption for strict model validation."
 
 rules: []
 
 ignore: []
 
 log:
-  - at: "2024-05-23T11:00:00Z"
-    summary: "Emitted events for manual TOML serialization, backup logic duplication, and redundant domain constants. Confirmed severe code duplication in backup command."
+  - at: "2026-02-13T20:55:00Z"
+    summary: "Emitted events for Brew config duplication, Tag Groups coupling, and fragile model validation. Verified backup/constants issues have existing open refactors."
   - at: "2026-02-04T22:53:12Z"
     summary: "Initial inspection identified manual TOML serialization, SSOT violations in config paths, and domain logic leakage in CLI."
+  - at: "2024-05-23T11:00:00Z"
+    summary: "Emitted events for manual TOML serialization, backup logic duplication, and redundant domain constants. Confirmed severe code duplication in backup command."


### PR DESCRIPTION
Executed the data_arch observer cycle. Identified three architectural issues:
1. Brew role forces configuration duplication due to `first_found` usage.
2. Tag Groups are coupled to `constants.py` instead of Playbook SSOT.
3. Model validation in `config.py` is manual and fragile.

Created corresponding event files in `.jules/exchange/events/pending/`.
Updated `.jules/workstreams/generic/workstations/data_arch/perspective.yml` with new findings and goals.
Verified that previous findings (Backup duplication, Constants centralization) have active refactor issues.

---
*PR created automatically by Jules for task [6859749472940547835](https://jules.google.com/task/6859749472940547835) started by @akitorahayashi*