### PR TITLE
chore: emit tactician observer events for AGENTS.md

### DIFF
--- a/.jules/exchange/events/duplicated-architecture-context-tactician.md
+++ b/.jules/exchange/events/duplicated-architecture-context-tactician.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-04"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+The `src/AGENTS.md` file contains a "Architecture" table that duplicates the "Architecture" table found in the root `AGENTS.md` file. The local copy in `src/AGENTS.md` exhibits wording variances only without providing meaningful local scope differentiation. This violates the anti-pattern of duplicating directives across scopes with wording variance only.
+
+## Evidence
+
+- path: "src/AGENTS.md"
+  loc: "5-15"
+  note: "Contains the `## Architecture` table which is substantially the same as the table in the root `AGENTS.md` file, providing redundant structural background context."
+- path: "AGENTS.md"
+  loc: "8-18"
+  note: "Contains the authoritative `## Architecture` table that defines the structural ownership and intent for the whole project."

--- a/.jules/exchange/events/misplaced-global-rules-tactician.md
+++ b/.jules/exchange/events/misplaced-global-rules-tactician.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-04"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+The `dist/mev/ansible/roles/nodejs/config/common/coder/AGENTS.md` file contains repository-wide conduct, design, and implementation rules that are not specific to its local scope (`nodejs` role config for `coder`). This violates the "ownership boundary" constraint where rule ownership must follow scope ownership and global contracts must not carry local execution rules (or vice versa).
+
+## Evidence
+
+- path: "dist/mev/ansible/roles/nodejs/config/common/coder/AGENTS.md"
+  loc: "1-40"
+  note: "This file contains sections like `## Conduct`, `### Design`, `### Implementation`, `### Documentation`, and `### Communication`, which describe global repository rules rather than nodejs/coder-specific behavior."


### PR DESCRIPTION
Adds tactician observer events highlighting misplaced and duplicated AGENTS.md rules across the project.

---
*PR created automatically by Jules for task [6922128170328754479](https://jules.google.com/task/6922128170328754479) started by @akitorahayashi*