### PR TITLE
chore: add taxonomy observer events for naming and vocabulary

### DIFF
--- a/.jules/exchange/events/overloaded-term-config-taxonomy.md
+++ b/.jules/exchange/events/overloaded-term-config-taxonomy.md
@@ -1,0 +1,24 @@
+---
+created_at: "2026-03-04"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The term "config" is overloaded and serves two distinct concepts: VCS user identity persistence (`MevConfig`, managed via `config set/show`) and Ansible role/application configurations deployed to local disk (`config create`).
+
+## Evidence
+
+- path: "src/domain/ports/config_store.rs"
+  loc: "line 8-10"
+  note: "`MevConfig` defines VCS user identities (personal/work) persisted for Git and Jujutsu."
+- path: "src/app/commands/config/mod.rs"
+  loc: "line 72-111"
+  note: "The `create` function inside `commands/config` deploys ansible role configuration assets (e.g., shell aliases, editor settings) to the user's local disk."
+- path: "src/adapters/config_store/local_json.rs"
+  loc: "line 15-20"
+  note: "`config.json` stores user identity, separate from deployed role configs which are placed in role-specific subdirectories."
+- path: "src/app/cli/config.rs"
+  loc: "line 18-45"
+  note: "CLI command bundles `show` (identity), `set` (identity), and `create` (role assets deployment) under the same parent `config` command."

--- a/.jules/exchange/events/overloaded-term-profile-taxonomy.md
+++ b/.jules/exchange/events/overloaded-term-profile-taxonomy.md
@@ -1,0 +1,24 @@
+---
+created_at: "2026-03-04"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The term "profile" is overloaded and used for two distinct domain concepts: machine/environment targets (e.g., macbook, mac-mini) and user identities (e.g., personal, work).
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "line 8 and 32"
+  note: "Defines 'profile' as a machine-specific identifier (e.g., 'macbook', 'mac-mini') used for environment creation commands."
+- path: "src/domain/vcs_identity.rs"
+  loc: "line 4 and 13"
+  note: "Defines 'switch profile' (e.g., 'personal', 'work') for VCS user identity resolution."
+- path: "src/app/cli/make.rs"
+  loc: "line 16-18"
+  note: "CLI flag uses `profile` for machine selection (common, macbook/mbk)."
+- path: "src/app/cli/switch.rs"
+  loc: "line 11-12"
+  note: "CLI flag uses `profile` for user identity selection (personal/p, work/w)."

--- a/.jules/exchange/events/vague-name-mod-taxonomy.md
+++ b/.jules/exchange/events/vague-name-mod-taxonomy.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-04"
+author_role: "taxonomy"
+confidence: "medium"
+---
+
+## Statement
+
+The codebase uses vague names like `AppContext` which violates the principle that names must not hide responsibility or be ambiguous. Using generic wrappers like `AppContext` without distinct domain nouns makes discovery harder.
+
+## Evidence
+
+- path: "src/app/context.rs"
+  loc: "line 15-32"
+  note: "`AppContext` holds domain ports (`AnsiblePort`, `ConfigStore`, `GitPort`, `JjPort`, etc.) and paths, functioning purely as a dependency container across all CLI commands without describing a distinct context."


### PR DESCRIPTION
As part of the taxonomy role, this PR creates observer events detailing terminology overloads and anti-patterns found in the repository.

Findings:
- The term "config" is used for both global user identity and Ansible role configurations.
- The term "profile" refers to both machine selection (e.g. `macbook`) and identity selection (e.g. `personal`).
- `AppContext` violates the rule against generic, ambiguous naming, serving as a dependency container without domain context.

---
*PR created automatically by Jules for task [11499881769193892400](https://jules.google.com/task/11499881769193892400) started by @akitorahayashi*