### PR TITLE
Add rustacean observer events for error handling, safety, and cloning

### DIFF
--- a/.jules/exchange/events/avoid-unsafe-unwrap-mev-internal-rustacean.md
+++ b/.jules/exchange/events/avoid-unsafe-unwrap-mev-internal-rustacean.md
@@ -1,0 +1,23 @@
+---
+created_at: "2024-03-04"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+The CLI commands in `mev-internal` use `unwrap()` and `expect()` directly, especially around JSON parsing and filesystem operations, bypassing proper error handling and propagation which violates the principle of "errors are part of the contract".
+
+## Evidence
+
+- path: "crates/mev-internal/src/app/cli/shell.rs"
+  loc: "line 85"
+  note: "`output_path.file_name().unwrap().to_string_lossy()` assumes the output path will always have a valid file name which could panic."
+
+- path: "crates/mev-internal/src/app/cli/ssh.rs"
+  loc: "line 265, 267"
+  note: "Using `unwrap()` on `tempfile::tempdir()` and `collect_hosts` in tests hides failure modes instead of using proper `Result` propagation or more explicit assertions."
+
+- path: "src/domain/profile.rs"
+  loc: "line 82, 83"
+  note: "Tests in domain profile contain multiple `unwrap()` usages directly."

--- a/.jules/exchange/events/domain-error-simplification-rustacean.md
+++ b/.jules/exchange/events/domain-error-simplification-rustacean.md
@@ -1,0 +1,15 @@
+---
+created_at: "2024-03-04"
+author_role: "rustacean"
+confidence: "medium"
+---
+
+## Statement
+
+The application error handling model uses a manual implementation of `std::fmt::Display` and `std::error::Error` for `AppError`, whereas using a specialized library like `thiserror` would remove boilerplate, reduce errors, and compose meanings preserving their context effortlessly. Notably, `thiserror` is already downloaded as a crate as per `Cargo.toml`/`Cargo.lock` checks.
+
+## Evidence
+
+- path: "src/domain/error.rs"
+  loc: "line 8-30"
+  note: "Manual definition of `AppError` and subsequent manual implementations for `Display` and `Error` traits. Can be simplified using `#[derive(thiserror::Error)]`."

--- a/.jules/exchange/events/unnecessary-cloning-in-ansible-adapter-rustacean.md
+++ b/.jules/exchange/events/unnecessary-cloning-in-ansible-adapter-rustacean.md
@@ -1,0 +1,23 @@
+---
+created_at: "2024-03-04"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+The `AnsibleAdapter` creates unnecessary clones of `.clone()` values that could either use references, or be refactored to transfer ownership or utilize more optimal borrowing. E.g., `.clone()` sprinkled to appease the borrow checker during serialization value mapping.
+
+## Evidence
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "line 184"
+  note: "`Some(serde_yaml::Value::String(s)) => vec![s.clone()]` clones the string instead of directly passing or mapping to owned if really needed, but it shows `clone()` on `s` without checking if ownership can be taken."
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "line 198"
+  note: "`tag_to_role.insert(tag.clone(), name.clone());` clones tag and name inside a loop when loading catalog, when those values could probably be borrowed or ownership passed down differently."
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "line 147"
+  note: "`self.tags_by_role.clone()` clone is returned in `tags_by_role()` implementation of `AnsiblePort`. The trait requires returning `HashMap<String, Vec<String>>` rather than `&HashMap<String, Vec<String>>`, forcing a heavy allocation copy."


### PR DESCRIPTION
This adds three events under `.jules/exchange/events/` conforming to the role of a Rust observer focusing on ownership, safety, and error composition. They highlight unneeded cloning in `AnsibleAdapter`, `unwrap()` usage in internal CLI helpers that break the error contract, and recommend leveraging `thiserror` for `AppError` domain mapping.

---
*PR created automatically by Jules for task [13871272222708862881](https://jules.google.com/task/13871272222708862881) started by @akitorahayashi*