### PR TITLE
feat(observers): add data_arch events for domain terminology and boundary modeling

### DIFF
--- a/.jules/exchange/events/overloaded-config-terminology-data-arch.md
+++ b/.jules/exchange/events/overloaded-config-terminology-data-arch.md
@@ -1,0 +1,21 @@
+---
+created_at: "2024-05-24"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Statement
+
+The concept of 'Config' is overloaded in the application, conflating VCS user identity state with Ansible role configuration files. This blurs the boundary between user state management and provisioned system files, leading to overloaded command namespaces (`mev config show/set` vs `mev config create`) and overloaded structures (`MevConfig`).
+
+## Evidence
+
+- path: "src/domain/ports/config_store.rs"
+  loc: "line 29"
+  note: "Defines `MevConfig` as a model for VCS identity configuration (`personal` and `work` identities), rather than system configuration."
+- path: "src/app/commands/config/mod.rs"
+  loc: "line 12, 40"
+  note: "Implements `mev config show` and `mev config set` which mutate the `MevConfig` identity state."
+- path: "src/app/commands/config/mod.rs"
+  loc: "line 72"
+  note: "Implements `mev config create` which deploys Ansible role configuration files to the local system, completely unrelated to `MevConfig` identity state."

--- a/.jules/exchange/events/overloaded-profile-terminology-data-arch.md
+++ b/.jules/exchange/events/overloaded-profile-terminology-data-arch.md
@@ -1,0 +1,21 @@
+---
+created_at: "2024-05-24"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Statement
+
+The concept of 'Profile' is overloaded in the domain model, representing both hardware/machine targets and VCS user identities. This violates the Single Source of Truth and Boundary Sovereignty principles by conflating unrelated concepts under the same terminology and error types (`AppError::InvalidProfile`).
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "line 6, 9"
+  note: "Defines 'Profile' as hardware/machine targets (`MACHINE_PROFILES`, `VALID_PROFILES` including 'common', 'macbook', 'mac-mini')."
+- path: "src/domain/vcs_identity.rs"
+  loc: "line 12, 16"
+  note: "Defines 'Profile' as VCS user identities (`SWITCH_PROFILES` including 'personal', 'work')."
+- path: "src/domain/error.rs"
+  loc: "line 11"
+  note: "Shares the same `AppError::InvalidProfile(String)` error for both machine profiles and VCS identity profiles."

--- a/.jules/exchange/events/primitive-obsession-boundaries-data-arch.md
+++ b/.jules/exchange/events/primitive-obsession-boundaries-data-arch.md
@@ -1,0 +1,21 @@
+---
+created_at: "2024-05-24"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Statement
+
+The application exhibits primitive obsession at key boundaries, accepting primitive `&str` values for domain concepts like profiles and identities rather than leveraging type-safe domain models (e.g. Enums). This scatters validation logic, allows invalid states to be represented across boundaries, and obscures the Single Source of Truth for valid states.
+
+## Evidence
+
+- path: "src/app/api.rs"
+  loc: "line 22, 29, 64"
+  note: "Accepts `profile: &str` parameter in `create`, `make`, and `switch` APIs, bypassing boundary validation."
+- path: "src/domain/profile.rs"
+  loc: "line 32, 43"
+  note: "Defines `validate_machine_profile(input: &str)` and `validate_profile(input: &str)` functions returning primitive `Result<&'static str, AppError>` instead of a strong Enum, shifting the validation burden to call sites."
+- path: "src/domain/vcs_identity.rs"
+  loc: "line 16"
+  note: "Defines `resolve_switch_profile(input: &str)` returning primitive `Option<&'static str>` instead of a type-safe enum."


### PR DESCRIPTION
This PR introduces three observer event files identifying architectural concerns within the domain layer from the perspective of a Data Architect (`data_arch`). 

The emitted events highlight:
1. **Overloaded Profile Terminology**: The domain conflates hardware/machine targets with VCS user identities under the same 'Profile' term and error type.
2. **Overloaded Config Terminology**: The term 'Config' is overloaded between user state management (`MevConfig`) and provisioned system files (`config create`).
3. **Primitive Obsession**: Key API boundaries accept primitive strings for domain concepts rather than enforcing valid states via type-safe models (e.g., Enums).

These findings provide concrete, file-backed evidence to drive future refactoring toward clearer domain boundaries and stronger type safety.

---
*PR created automatically by Jules for task [31418820258403582](https://jules.google.com/task/31418820258403582) started by @akitorahayashi*