### PR TITLE
Add QA observer events evaluating tests

### DIFF
--- a/.jules/exchange/events/cli-harness-coupling-qa.md
+++ b/.jules/exchange/events/cli-harness-coupling-qa.md
@@ -1,0 +1,18 @@
+---
+created_at: "2025-03-05"
+author_role: "qa"
+confidence: "high"
+---
+
+## Statement
+
+The CLI tests are tightly coupled to the system state via `harness::TestContext`, which uses actual commands like `cli().assert().success()` without isolated seams for side effects. Although they cover standard path cases, this setup could lead to flakiness depending on external tool states or missing resources (e.g. Ansible assets) when running end-to-end tests that invoke internal commands.
+
+## Evidence
+
+- path: "tests/cli/backup.rs"
+  loc: "line 22"
+  note: "Test `backup_alias_bk_is_accepted` explicitly states it will fail due to missing ansible assets, proving that tests leak side effects instead of being isolated using ports/adapters."
+- path: "tests/cli/switch.rs"
+  loc: "line 28"
+  note: "Tests like `switch_without_config_fails_gracefully` depend on global or local system state. A properly configured fake harness should be used for CLI interaction tests."

--- a/.jules/exchange/events/io-boundaries-qa.md
+++ b/.jules/exchange/events/io-boundaries-qa.md
@@ -1,0 +1,21 @@
+---
+created_at: "2025-03-05"
+author_role: "qa"
+confidence: "high"
+---
+
+## Statement
+
+The application has a clear boundary design between pure logic and side effects, but it is lacking unit tests for many of the I/O adapters, meaning that the integration points with the OS and external binaries are relatively untested. Additionally, some tests directly use system commands without dependency injection.
+
+## Evidence
+
+- path: "src/adapters/macos_defaults/cli.rs"
+  loc: "line 17"
+  note: "MacosDefaultsCli adapter uses Command::new(\"defaults\") directly but has no unit or adapter tests. The failure cases (stderr checking) should be tested via a seam or a test environment."
+- path: "src/adapters/version_source/pipx.rs"
+  loc: "line 22"
+  note: "PipxVersionSource uses Command::new(\"pipx\") directly and has no integration tests to verify the upgrade path."
+- path: "src/domain/execution_plan.rs"
+  loc: "line 11"
+  note: "ExecutionPlan is pure logic, completely isolated from side effects, which is a good pattern, but it lacks dedicated unit tests to verify full_setup and make behavior."

--- a/.jules/exchange/events/redundant-domain-tests-qa.md
+++ b/.jules/exchange/events/redundant-domain-tests-qa.md
@@ -1,0 +1,18 @@
+---
+created_at: "2025-03-05"
+author_role: "qa"
+confidence: "high"
+---
+
+## Statement
+
+Redundant domain logic testing: The project has redundant tests verifying standard library integration within pure logic testing, e.g. mapping simple string enums over CLI logic. The `library_contracts` tests re-verify the same behavior that is verified in unit tests within the `domain` module, adding maintenance overhead without providing meaningful new guarantees.
+
+## Evidence
+
+- path: "tests/library/backup_target.rs"
+  loc: "line 4"
+  note: "Tests `backup_target_resolves_system` duplicate testing logic that should reside in `src/domain/backup_target.rs` unit tests (which lacks them, but the logic is entirely pure domain logic)."
+- path: "tests/library/domain_exports.rs"
+  loc: "line 5"
+  note: "Tests `domain_profile_types_are_public` explicitly test resolution logic that is already tested in `src/domain/profile.rs` unit tests (`resolves_canonical_profiles`), testing identical inputs and outputs."


### PR DESCRIPTION
Adds observer events from the `qa` role analyzing the test quality and boundaries in the codebase. Evaluates I/O boundaries, state isolation in the test harness, and redundant domain testing.

Respects all schema and content constraints.

---
*PR created automatically by Jules for task [16466296560111381571](https://jules.google.com/task/16466296560111381571) started by @akitorahayashi*