### PR TITLE
Emit events from librarian observer on documentation structure

### DIFF
--- a/.jules/exchange/events/contributing-mixed-responsibilities-librarian.md
+++ b/.jules/exchange/events/contributing-mixed-responsibilities-librarian.md
@@ -1,0 +1,21 @@
+---
+created_at: "2026-03-04"
+author_role: "librarian"
+confidence: "high"
+---
+
+## Statement
+
+The `CONTRIBUTING.md` file incorrectly merges distinct document responsibilities by co-locating coding standards (policy) and verification commands (procedure) within the same file. This mixes policy and procedure and fails to separate concerns, violating the mandate that a document should have one distinct structural responsibility. These topics should be split into canonical documents under a dedicated documentation hierarchy.
+
+## Evidence
+
+- path: "CONTRIBUTING.md"
+  loc: "lines 5-29"
+  note: "Policy content declaring coding standards and naming conventions, representing static rules."
+- path: "CONTRIBUTING.md"
+  loc: "lines 31-41"
+  note: "Procedural content mapping configuration files to their purposes, serving as orientation or reference."
+- path: "CONTRIBUTING.md"
+  loc: "lines 45-56"
+  note: "Verification procedures and command invocations (`just check`, `just test`), which are dynamic actions distinct from coding policy."

--- a/.jules/exchange/events/missing-docs-directory-librarian.md
+++ b/.jules/exchange/events/missing-docs-directory-librarian.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-04"
+author_role: "librarian"
+confidence: "high"
+---
+
+## Statement
+
+The repository lacks a dedicated `docs/` directory, forcing all documentation, regardless of responsibility, to accumulate at the top-level namespace. This violates the architectural principle that the root namespace is scarce and reserved for cross-cutting entry points, and it necessitates scaffolding a structural foundation from scratch.
+
+## Evidence
+
+- path: "docs/"
+  loc: "directory level"
+  note: "Directory does not exist, confirming the absence of a structured documentation foundation."
+- path: "."
+  loc: "top-level"
+  note: "The top-level contains multiple Markdown files (`README.md`, `CONTRIBUTING.md`, `AGENTS.md`) without a dedicated subtree for specialized content, indicating a flat accumulation anti-pattern."

--- a/.jules/exchange/events/readme-mixed-responsibilities-librarian.md
+++ b/.jules/exchange/events/readme-mixed-responsibilities-librarian.md
@@ -1,0 +1,21 @@
+---
+created_at: "2026-03-04"
+author_role: "librarian"
+confidence: "high"
+---
+
+## Statement
+
+The `README.md` file inappropriately mixes structural responsibilities by co-locating orientation content (project purpose and architecture) with detailed procedural instructions (installation, distribution synchronization, and exhaustive usage commands). This violates the principle that one document must have one structural responsibility, inflating navigation cost and hiding placement intent.
+
+## Evidence
+
+- path: "README.md"
+  loc: "lines 1-4"
+  note: "Orientation content outlining the project purpose and Rust-first architecture."
+- path: "README.md"
+  loc: "lines 6-27"
+  note: "Procedural content providing detailed prerequisites and installation steps, which should reside in specialized documentation."
+- path: "README.md"
+  loc: "lines 35-86"
+  note: "Exhaustive command reference and usage procedures that clutter the cross-cutting entry point and should be separated into a distinct specification or procedural guide."


### PR DESCRIPTION
This submission introduces three observer events from the `librarian` role focused on the repository's documentation architecture.

Key findings emitted:
- **Missing `docs/` directory**: Flags the lack of a structured documentation foundation, leading to a flat accumulation of specialized files at the root level.
- **Mixed responsibilities in `README.md`**: Highlights the co-location of project orientation with detailed procedural instructions, which inflates navigation cost.
- **Mixed responsibilities in `CONTRIBUTING.md`**: Points out the blending of coding standard policies with dynamic verification commands.

These events provide the necessary evidence and structured requests to guide the scaffolding of a robust documentation directory and to separate concerns within human-facing project files.

---
*PR created automatically by Jules for task [4372339989767189339](https://jules.google.com/task/4372339989767189339) started by @akitorahayashi*