### PR TITLE
docs(observers): emit devops observer events for CI/CD findings

### DIFF
--- a/.jules/exchange/events/binary-commit-release-provenance-anti-pattern-devops.md
+++ b/.jules/exchange/events/binary-commit-release-provenance-anti-pattern-devops.md
@@ -1,0 +1,17 @@
+---
+created_at: "2026-03-04"
+author_role: "devops"
+confidence: "high"
+---
+
+## Statement
+
+The release pipeline commits bundled binaries directly to the `main` branch rather than using an artifact registry or GitHub Releases. This conflates the source-of-truth branch with binary build artifacts, impacting Git performance and confusing provenance tracking.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: ".github/workflows/sync-bundled-binary.yml"
+  loc: "59, 60, 61, 62"
+  note: "Downloads binary artifact and directly runs `git add`, `git commit`, and `git push` to add `dist/mev/bin/darwin-aarch64/mev` back into the main branch."

--- a/.jules/exchange/events/mutable-action-tags-supply-chain-risk-devops.md
+++ b/.jules/exchange/events/mutable-action-tags-supply-chain-risk-devops.md
@@ -1,0 +1,23 @@
+---
+created_at: "2026-03-04"
+author_role: "devops"
+confidence: "high"
+---
+
+## Statement
+
+The repository utilizes mutable version tags (e.g., `@v4`, `@v5`) for GitHub Actions in multiple workflows and composite actions instead of immutable commit SHAs, which introduces a supply chain security risk and potential execution non-determinism.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: ".github/actions/setup-base/action.yml"
+  loc: "8, 13, 16, 21"
+  note: "Uses unpinned mutable tags for actions/setup-python@v5, extractions/setup-just@v2, astral-sh/setup-uv@v5, and Swatinem/rust-cache@v2."
+- path: ".github/workflows/build-bundled-binary.yml"
+  loc: "15, 36"
+  note: "Uses unpinned mutable tags for actions/checkout@v4 and actions/upload-artifact@v4."
+- path: ".github/workflows/run-linters.yml"
+  loc: "15"
+  note: "Uses unpinned mutable tags for actions/checkout@v4."

--- a/.jules/exchange/events/unpinned-homebrew-dependencies-determinism-devops.md
+++ b/.jules/exchange/events/unpinned-homebrew-dependencies-determinism-devops.md
@@ -1,0 +1,20 @@
+---
+created_at: "2026-03-04"
+author_role: "devops"
+confidence: "high"
+---
+
+## Statement
+
+CI workflows use `brew install` for toolchain components without specifying specific versions or relying on a lockfile. This introduces non-determinism, as the installed versions depend on the current Homebrew catalog rather than the project's source of truth.
+
+## Evidence
+
+For multi-file events, add multiple list items.
+
+- path: ".github/workflows/run-linters.yml"
+  loc: "23"
+  note: "Installs `shellcheck` and `shfmt` via `brew install` without version pinning."
+- path: ".github/workflows/collect-coverage.yml"
+  loc: "32"
+  note: "Installs `mise` via `brew install` without version pinning."


### PR DESCRIPTION
This PR adds three event files in the `.jules/exchange/events/` directory to document high-signal findings from the perspective of the `devops` observer role.

The findings focus on:
1.  **Supply Chain Risk:** The use of mutable version tags (e.g., `@v4`, `@v5`) in `.github/workflows` and `.github/actions` instead of immutable commit SHAs.
2.  **Execution Non-Determinism:** The use of `brew install` in CI workflows without version pinning or a lockfile.
3.  **Release Provenance Anti-Pattern:** The current release pipeline conflates the source-of-truth branch with binary build artifacts by committing compiled binaries directly back to the `main` branch.

---
*PR created automatically by Jules for task [6686196984937682331](https://jules.google.com/task/6686196984937682331) started by @akitorahayashi*