### PR TITLE
plan(tests): generate plan to eliminate redundant domain logic tests

### DIFF
--- a/.jules/exchange/plans/eliminate-redundant-domain-tests.md
+++ b/.jules/exchange/plans/eliminate-redundant-domain-tests.md
@@ -1,6 +1,5 @@
 ---
 label: "tests"
-implementation_ready: false
 ---
 
 ## Goal
@@ -11,18 +10,9 @@ Remove redundant domain logic tests in the `library_contracts` module that dupli
 
 Redundant domain logic testing: The project has redundant tests verifying standard library integration within pure logic testing, e.g. mapping simple string enums over CLI logic. The `library_contracts` tests re-verify the same behavior that is verified in unit tests within the `domain` module, adding maintenance overhead without providing meaningful new guarantees.
 
-## Evidence
+## Affected Areas
 
-- source_event: "redundant-domain-tests-qa.md"
-  path: "tests/library/backup_target.rs"
-  loc: "line 4"
-  note: "Tests `backup_target_resolves_system` duplicate testing logic that should reside in `src/domain/backup_target.rs` unit tests (which lacks them, but the logic is entirely pure domain logic)."
-- source_event: "redundant-domain-tests-qa.md"
-  path: "tests/library/domain_exports.rs"
-  loc: "line 5"
-  note: "Tests `domain_profile_types_are_public` explicitly test resolution logic that is already tested in `src/domain/profile.rs` unit tests (`resolves_canonical_profiles`), testing identical inputs and outputs."
-
-## Change Scope
+### Tests
 
 - `tests/library/backup_target.rs`
 - `tests/library/domain_exports.rs`
@@ -31,7 +21,19 @@ Redundant domain logic testing: The project has redundant tests verifying standa
 
 - Changes must adhere to project principles such as avoiding ambiguous names, removing technical debt, and prioritizing systemic fixes.
 
+## Risks
+
+- Removing tests without ensuring equivalent coverage in the domain module could lead to regressions in domain logic testing.
+
 ## Acceptance Criteria
 
 - Redundant tests in `tests/library/` are removed.
 - Unit tests in `src/domain/` are confirmed to cover the required logic exclusively.
+
+## Implementation Plan
+
+1. Migrate missing unit tests to `src/domain/backup_target.rs` (such as checking `backup_target_resolves_system` logic, as the requirement notes it currently lacks them but the logic is pure domain logic).
+2. Remove `backup_target_resolves_system` from `tests/library/backup_target.rs`.
+3. Verify `resolves_canonical_profiles` exists and covers identical inputs/outputs in `src/domain/profile.rs`.
+4. Remove `domain_profile_types_are_public` from `tests/library/domain_exports.rs`.
+5. Run unit tests to verify domain module logic is completely covered and no regressions are introduced.


### PR DESCRIPTION
This submission implements a task for the planner layer.

- Processes the requirement file `.jules/exchange/requirements/eliminate-redundant-domain-tests.md`.
- Generates an actionable implementation plan in `.jules/exchange/plans/eliminate-redundant-domain-tests.md` following the provided schema.
- Includes appropriate sections: Goal, Problem, Affected Areas, Constraints, Risks, Acceptance Criteria, and Implementation Plan.
- Adds `label: "tests"` to the plan's front matter.
- Removes the processed requirement file.

---
*PR created automatically by Jules for task [1610555948176498351](https://jules.google.com/task/1610555948176498351) started by @akitorahayashi*