### PR TITLE
Synthesize requirement into plan for fixing positional context override

### DIFF
--- a/.jules/exchange/plans/fix-positional-context-override.md
+++ b/.jules/exchange/plans/fix-positional-context-override.md
@@ -1,6 +1,5 @@
 ---
 label: "refacts"
-implementation_ready: false
 ---
 
 ## Goal
@@ -11,14 +10,9 @@ Refactor the `make` command's `profile` argument from a positional argument to a
 
 The `make` command defines `profile` as a positional argument rather than an explicit option, violating the structural separation of target objects and context overrides, which creates a rigid, over-parameterized interface.
 
-## Evidence
+## Affected Areas
 
-- source_event: "positional-context-override-cli-sentinel.md"
-  path: "src/app/cli/make.rs"
-  loc: "16-17"
-  note: "The `profile` argument is defined as a positional string with a default value of 'common', functioning as an implicit context override rather than an explicit option (e.g., `--profile`)."
-
-## Change Scope
+### CLI Module
 
 - `src/app/cli/make.rs`
 
@@ -26,7 +20,18 @@ The `make` command defines `profile` as a positional argument rather than an exp
 
 - Changes must adhere to project principles such as avoiding ambiguous names, removing technical debt, and prioritizing systemic fixes.
 
+## Risks
+
+- Existing scripts or automated tooling that invoke `mev make <tag> <profile>` positionally will fail and need to be updated to `mev make <tag> --profile <profile>`.
+
 ## Acceptance Criteria
 
 - The `profile` parameter is parsed as an explicit flag (e.g., `--profile`) rather than a positional argument.
 - The CLI structural separation of objects and options is maintained.
+
+## Implementation Plan
+
+1. Modify `src/app/cli/make.rs` to update the `profile` field in the `MakeArgs` struct. Add the `#[arg(long, default_value = "common")]` macro attribute to convert it into an explicit option flag.
+2. Search the codebase for any test cases or integrations that invoke the `make` command with a positional profile argument.
+3. Update any discovered invocations to use the `--profile` flag format.
+4. Run the test suite using `cargo test` to ensure that argument parsing works correctly and no regressions are introduced.


### PR DESCRIPTION
Synthesized the requirement for fixing the positional context override into a detailed implementation plan in `.jules/exchange/plans/fix-positional-context-override.md` and deleted the source requirement file from `.jules/exchange/requirements/`. The plan strictly follows the schema without introducing any bold formatting.

---
*PR created automatically by Jules for task [785185267699688183](https://jules.google.com/task/785185267699688183) started by @akitorahayashi*