### PR TITLE
Eliminate primitive obsession at application boundaries

### DIFF
--- a/src/adapters/config_store/local_json.rs
+++ b/src/adapters/config_store/local_json.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use crate::domain::error::AppError;
 use crate::domain::ports::config_store::{ConfigStore, MevConfig};
-use crate::domain::vcs_identity::VcsIdentity;
+use crate::domain::vcs_identity::{SwitchProfile, VcsIdentity};
 
 pub struct ConfigFileStore {
     config_path: PathBuf,
@@ -48,12 +48,11 @@ impl ConfigStore for ConfigFileStore {
         Ok(())
     }
 
-    fn get_identity(&self, profile: &str) -> Result<Option<VcsIdentity>, AppError> {
+    fn get_identity(&self, profile: SwitchProfile) -> Result<Option<VcsIdentity>, AppError> {
         let config = self.load()?;
         match profile {
-            "personal" => Ok(Some(config.personal)),
-            "work" => Ok(Some(config.work)),
-            _ => Ok(None),
+            SwitchProfile::Personal => Ok(Some(config.personal)),
+            SwitchProfile::Work => Ok(Some(config.work)),
         }
     }
 

--- a/src/app/api.rs
+++ b/src/app/api.rs
@@ -15,6 +15,8 @@ pub use crate::domain::backup_target::BackupTarget;
 pub use crate::domain::error::AppError as Error;
 pub use crate::domain::execution_plan::ExecutionPlan;
 pub use crate::domain::ports::config_store::MevConfig;
+pub use crate::domain::profile::Profile;
+pub use crate::domain::vcs_identity::SwitchProfile;
 pub use crate::domain::vcs_identity::VcsIdentity;
 
 // =============================================================================
@@ -22,7 +24,7 @@ pub use crate::domain::vcs_identity::VcsIdentity;
 // =============================================================================
 
 /// Provision a complete development environment for the given profile.
-pub fn create(profile: &str, overwrite: bool, verbose: bool) -> Result<(), AppError> {
+pub fn create(profile: Profile, overwrite: bool, verbose: bool) -> Result<(), AppError> {
     let ansible_dir = locator::locate_ansible_dir()?;
     let ctx = AppContext::new(ansible_dir).map_err(|e| AppError::Config(e.to_string()))?;
     commands::create::execute(&ctx, profile, overwrite, verbose)
@@ -33,7 +35,7 @@ pub fn create(profile: &str, overwrite: bool, verbose: bool) -> Result<(), AppEr
 // =============================================================================
 
 /// Run a single Ansible task by tag within a profile.
-pub fn make(profile: &str, tag: &str, overwrite: bool, verbose: bool) -> Result<(), AppError> {
+pub fn make(profile: Profile, tag: &str, overwrite: bool, verbose: bool) -> Result<(), AppError> {
     let ansible_dir = locator::locate_ansible_dir()?;
     let ctx = AppContext::new(ansible_dir).map_err(|e| AppError::Config(e.to_string()))?;
     commands::make::execute(&ctx, profile, tag, overwrite, verbose)
@@ -78,7 +80,7 @@ pub fn config_create(role: Option<String>, overwrite: bool) -> Result<(), AppErr
 // =============================================================================
 
 /// Switch the global VCS identity between personal and work.
-pub fn switch(profile: &str) -> Result<(), AppError> {
+pub fn switch(profile: SwitchProfile) -> Result<(), AppError> {
     let ctx = AppContext::for_config().map_err(|e| AppError::Config(e.to_string()))?;
     commands::switch::execute(&ctx, profile)
 }

--- a/src/app/cli/switch.rs
+++ b/src/app/cli/switch.rs
@@ -5,6 +5,7 @@ use clap::Args;
 use crate::app::AppContext;
 use crate::app::commands;
 use crate::domain::error::AppError;
+use crate::domain::vcs_identity;
 
 #[derive(Args)]
 pub struct SwitchArgs {
@@ -14,5 +15,13 @@ pub struct SwitchArgs {
 
 pub fn run(args: SwitchArgs) -> Result<(), AppError> {
     let ctx = AppContext::for_config().map_err(|e| AppError::Config(e.to_string()))?;
-    commands::switch::execute(&ctx, &args.profile)
+
+    let resolved = vcs_identity::resolve_switch_profile(&args.profile).ok_or_else(|| {
+        AppError::InvalidProfile(format!(
+            "invalid profile '{}'. Valid: personal (p), work (w)",
+            args.profile
+        ))
+    })?;
+
+    commands::switch::execute(&ctx, resolved)
 }

--- a/src/app/commands/create/mod.rs
+++ b/src/app/commands/create/mod.rs
@@ -5,12 +5,13 @@ use crate::app::commands::deploy_configs;
 use crate::domain::error::AppError;
 use crate::domain::execution_plan::ExecutionPlan;
 use crate::domain::ports::ansible::AnsiblePort;
+use crate::domain::profile::Profile;
 use crate::domain::tag::FULL_SETUP_TAGS;
 
 /// Execute the `create` command: deploy configs and run full setup tags.
 pub fn execute(
     ctx: &AppContext,
-    profile: &str,
+    profile: Profile,
     overwrite: bool,
     verbose: bool,
 ) -> Result<(), AppError> {
@@ -27,7 +28,7 @@ pub fn execute(
     let plan = ExecutionPlan::full_setup(profile, verbose);
 
     println!();
-    println!("mev: Creating {profile} environment");
+    println!("mev: Creating {} environment", profile.as_str());
     println!("This will run {} tasks.", plan.tags.len());
     println!();
 
@@ -46,21 +47,21 @@ pub fn execute(
         let total = plan.tags.len();
         println!("[{step}/{total}] Running: {tag}");
 
-        ctx.ansible.run_playbook(profile, std::slice::from_ref(tag), plan.verbose).inspect_err(
-            |e| {
+        ctx.ansible
+            .run_playbook(profile.as_str(), std::slice::from_ref(tag), plan.verbose)
+            .inspect_err(|e| {
                 eprintln!("Failed at step {step}/{total}: {tag}: {e}");
-            },
-        )?;
+            })?;
         println!("  ✓ Completed");
     }
 
     println!();
     println!("✓ Environment created successfully!");
-    println!("Profile: {profile}");
+    println!("Profile: {}", profile.as_str());
 
     println!();
     println!("Optional steps (skipped for stability/speed):");
-    println!("  GUI Applications:  mev make brew-cask {profile}");
+    println!("  GUI Applications:  mev make brew-cask {}", profile.as_str());
     println!("  Ollama Models:     mev make ollama-models");
     println!("  MLX Models:        mev make mlx-models");
 

--- a/src/app/commands/list/mod.rs
+++ b/src/app/commands/list/mod.rs
@@ -34,11 +34,11 @@ pub fn execute(ctx: &AppContext) -> Result<(), AppError> {
 
     // Profiles
     let mut profiles_to_show = Vec::new();
-    if VALID_PROFILES.contains(&"common") {
-        profiles_to_show.push("common");
+    if VALID_PROFILES.contains(&crate::domain::profile::Profile::Common) {
+        profiles_to_show.push(crate::domain::profile::Profile::Common);
     }
     for &p in VALID_PROFILES {
-        if p != "common" {
+        if p != crate::domain::profile::Profile::Common {
             profiles_to_show.push(p);
         }
     }
@@ -52,8 +52,8 @@ pub fn execute(ctx: &AppContext) -> Result<(), AppError> {
             .collect();
         let alias_str =
             if aliases.is_empty() { String::new() } else { format!(" ({})", aliases.join(", ")) };
-        let suffix = if *p == "common" { " (default)" } else { "" };
-        profile_strs.push(format!("{p}{alias_str}{suffix}"));
+        let suffix = if *p == crate::domain::profile::Profile::Common { " (default)" } else { "" };
+        profile_strs.push(format!("{}{alias_str}{suffix}", p.as_str()));
     }
     println!("Profiles: {}", profile_strs.join(", "));
 

--- a/src/app/commands/make/mod.rs
+++ b/src/app/commands/make/mod.rs
@@ -5,12 +5,13 @@ use crate::app::commands::deploy_configs;
 use crate::domain::error::AppError;
 use crate::domain::execution_plan::ExecutionPlan;
 use crate::domain::ports::ansible::AnsiblePort;
+use crate::domain::profile::Profile;
 use crate::domain::tag;
 
 /// Execute the `make` command: deploy configs and run specified tags.
 pub fn execute(
     ctx: &AppContext,
-    profile: &str,
+    profile: Profile,
     tag_input: &str,
     overwrite: bool,
     verbose: bool,
@@ -38,12 +39,12 @@ pub fn execute(
     )?;
 
     println!("Running tags: {}", plan.tags.join(", "));
-    if profile != "common" {
-        println!("Profile: {profile}");
+    if profile != Profile::Common {
+        println!("Profile: {}", profile.as_str());
     }
     println!();
 
-    ctx.ansible.run_playbook(profile, &plan.tags, plan.verbose)?;
+    ctx.ansible.run_playbook(profile.as_str(), &plan.tags, plan.verbose)?;
 
     println!();
     println!("✓ Completed successfully!");

--- a/src/app/commands/switch/mod.rs
+++ b/src/app/commands/switch/mod.rs
@@ -5,34 +5,29 @@ use crate::domain::error::AppError;
 use crate::domain::ports::config_store::ConfigStore;
 use crate::domain::ports::git::GitPort;
 use crate::domain::ports::jj::JjPort;
-use crate::domain::vcs_identity;
+use crate::domain::vcs_identity::SwitchProfile;
 
 /// Execute the `switch` command: change global git/jj identity.
-pub fn execute(ctx: &AppContext, profile_input: &str) -> Result<(), AppError> {
+pub fn execute(ctx: &AppContext, profile: SwitchProfile) -> Result<(), AppError> {
     if !ctx.config_store.exists() {
         eprintln!("No configuration found.");
         eprintln!("Run 'mev config set' first to configure identities.");
         return Err(AppError::Config("no configuration found".to_string()));
     }
 
-    let resolved = vcs_identity::resolve_switch_profile(profile_input).ok_or_else(|| {
-        AppError::InvalidProfile(format!(
-            "invalid profile '{profile_input}'. Valid: personal (p), work (w)"
-        ))
-    })?;
-
     let identity = ctx
         .config_store
-        .get_identity(resolved)?
-        .ok_or_else(|| AppError::Config(format!("failed to load {resolved} identity")))?;
+        .get_identity(profile)?
+        .ok_or_else(|| AppError::Config(format!("failed to load {} identity", profile.as_str())))?;
 
     if identity.name.is_empty() || identity.email.is_empty() {
         return Err(AppError::Config(format!(
-            "{resolved} identity is not configured. Run 'mev config set' to configure."
+            "{} identity is not configured. Run 'mev config set' to configure.",
+            profile.as_str()
         )));
     }
 
-    println!("Switching to {resolved} identity...");
+    println!("Switching to {} identity...", profile.as_str());
 
     // Git configuration (required)
     ctx.git.set_identity(&identity.name, &identity.email)?;
@@ -47,7 +42,7 @@ pub fn execute(ctx: &AppContext, profile_input: &str) -> Result<(), AppError> {
     // Show current configuration via git (primary VCS)
     let (name, email) = ctx.git.get_identity()?;
     println!();
-    println!("Switched to {resolved} identity");
+    println!("Switched to {} identity", profile.as_str());
     println!("  Name:  {name}");
     println!("  Email: {email}");
 

--- a/src/domain/execution_plan.rs
+++ b/src/domain/execution_plan.rs
@@ -1,22 +1,24 @@
 //! Deterministic ansible execution plan construction.
 
+use crate::domain::profile::Profile;
+
 /// An execution plan describes the ordered sequence of ansible tags to run.
 #[derive(Debug, Clone)]
 pub struct ExecutionPlan {
-    pub profile: String,
+    pub profile: Profile,
     pub tags: Vec<String>,
     pub verbose: bool,
 }
 
 impl ExecutionPlan {
     /// Construct a plan for a full environment creation.
-    pub fn full_setup(profile: &str, verbose: bool) -> Self {
+    pub fn full_setup(profile: Profile, verbose: bool) -> Self {
         let tags = crate::domain::tag::FULL_SETUP_TAGS.iter().map(|s| (*s).to_string()).collect();
-        Self { profile: profile.to_string(), tags, verbose }
+        Self { profile, tags, verbose }
     }
 
     /// Construct a plan for a single make invocation.
-    pub fn make(profile: &str, tags: Vec<String>, verbose: bool) -> Self {
-        Self { profile: profile.to_string(), tags, verbose }
+    pub fn make(profile: Profile, tags: Vec<String>, verbose: bool) -> Self {
+        Self { profile, tags, verbose }
     }
 }

--- a/src/domain/ports/config_store.rs
+++ b/src/domain/ports/config_store.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 
 use crate::domain::error::AppError;
-use crate::domain::vcs_identity::VcsIdentity;
+use crate::domain::vcs_identity::{SwitchProfile, VcsIdentity};
 
 /// Persists and retrieves VCS identity configuration.
 pub trait ConfigStore {
@@ -17,7 +17,7 @@ pub trait ConfigStore {
     fn save(&self, config: &MevConfig) -> Result<(), AppError>;
 
     /// Get a specific VCS identity by profile name.
-    fn get_identity(&self, profile: &str) -> Result<Option<VcsIdentity>, AppError>;
+    fn get_identity(&self, profile: SwitchProfile) -> Result<Option<VcsIdentity>, AppError>;
 
     /// Get the configuration file path.
     fn config_path(&self) -> PathBuf;

--- a/src/domain/profile.rs
+++ b/src/domain/profile.rs
@@ -3,20 +3,44 @@
 use crate::domain::error::AppError;
 
 /// Machine-specific profiles that require explicit selection.
-pub const MACHINE_PROFILES: &[&str] = &["macbook", "mac-mini"];
+pub const MACHINE_PROFILES: &[Profile] = &[Profile::Macbook, Profile::MacMini];
 
 /// All valid profile identifiers including "common".
-pub const VALID_PROFILES: &[&str] = &["common", "macbook", "mac-mini"];
+pub const VALID_PROFILES: &[Profile] = &[Profile::Common, Profile::Macbook, Profile::MacMini];
 
 /// Profile alias mappings.
-pub const PROFILE_ALIASES: &[(&str, &str)] =
-    &[("mbk", "macbook"), ("mmn", "mac-mini"), ("cmn", "common")];
+pub const PROFILE_ALIASES: &[(&str, Profile)] =
+    &[("mbk", Profile::Macbook), ("mmn", Profile::MacMini), ("cmn", Profile::Common)];
 
-/// Resolve a profile identifier or alias to its canonical name.
-pub fn resolve_profile(input: &str) -> Option<&'static str> {
+/// Strong type for environment profiles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Profile {
+    Macbook,
+    MacMini,
+    Common,
+}
+
+impl Profile {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Profile::Macbook => "macbook",
+            Profile::MacMini => "mac-mini",
+            Profile::Common => "common",
+        }
+    }
+}
+
+impl std::fmt::Display for Profile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Resolve a profile identifier or alias to its canonical enum variant.
+pub fn resolve_profile(input: &str) -> Option<Profile> {
     // Direct match
     for &profile in VALID_PROFILES {
-        if input == profile {
+        if input == profile.as_str() {
             return Some(profile);
         }
     }
@@ -30,14 +54,15 @@ pub fn resolve_profile(input: &str) -> Option<&'static str> {
 }
 
 /// Validate that a profile is a machine-specific profile (required for `create`).
-pub fn validate_machine_profile(input: &str) -> Result<&'static str, AppError> {
+pub fn validate_machine_profile(input: &str) -> Result<Profile, AppError> {
     let resolved =
         resolve_profile(input).ok_or_else(|| AppError::InvalidProfile(input.to_string()))?;
 
     if !MACHINE_PROFILES.contains(&resolved) {
+        let valid_names: Vec<String> = MACHINE_PROFILES.iter().map(|p| p.as_str().to_string()).collect();
         return Err(AppError::InvalidProfile(format!(
             "'{input}' is not a machine profile. Valid: {}",
-            MACHINE_PROFILES.join(", ")
+            valid_names.join(", ")
         )));
     }
 
@@ -45,7 +70,7 @@ pub fn validate_machine_profile(input: &str) -> Result<&'static str, AppError> {
 }
 
 /// Validate any profile including "common" (required for `make`).
-pub fn validate_profile(input: &str) -> Result<&'static str, AppError> {
+pub fn validate_profile(input: &str) -> Result<Profile, AppError> {
     resolve_profile(input).ok_or_else(|| AppError::InvalidProfile(input.to_string()))
 }
 
@@ -55,16 +80,16 @@ mod tests {
 
     #[test]
     fn resolves_canonical_profiles() {
-        assert_eq!(resolve_profile("common"), Some("common"));
-        assert_eq!(resolve_profile("macbook"), Some("macbook"));
-        assert_eq!(resolve_profile("mac-mini"), Some("mac-mini"));
+        assert_eq!(resolve_profile("common"), Some(Profile::Common));
+        assert_eq!(resolve_profile("macbook"), Some(Profile::Macbook));
+        assert_eq!(resolve_profile("mac-mini"), Some(Profile::MacMini));
     }
 
     #[test]
     fn resolves_aliases() {
-        assert_eq!(resolve_profile("mbk"), Some("macbook"));
-        assert_eq!(resolve_profile("mmn"), Some("mac-mini"));
-        assert_eq!(resolve_profile("cmn"), Some("common"));
+        assert_eq!(resolve_profile("mbk"), Some(Profile::Macbook));
+        assert_eq!(resolve_profile("mmn"), Some(Profile::MacMini));
+        assert_eq!(resolve_profile("cmn"), Some(Profile::Common));
     }
 
     #[test]
@@ -79,7 +104,7 @@ mod tests {
 
     #[test]
     fn validate_machine_profile_accepts_macbook() {
-        assert_eq!(validate_machine_profile("macbook").unwrap(), "macbook");
-        assert_eq!(validate_machine_profile("mbk").unwrap(), "macbook");
+        assert_eq!(validate_machine_profile("macbook").unwrap(), Profile::Macbook);
+        assert_eq!(validate_machine_profile("mbk").unwrap(), Profile::Macbook);
     }
 }

--- a/src/domain/vcs_identity.rs
+++ b/src/domain/vcs_identity.rs
@@ -11,11 +11,37 @@ pub struct VcsIdentity {
 }
 
 /// Canonical switch profile identifiers and their input aliases.
-pub const SWITCH_PROFILES: &[(&str, &str)] =
-    &[("p", "personal"), ("personal", "personal"), ("w", "work"), ("work", "work")];
+pub const SWITCH_PROFILES: &[(&str, SwitchProfile)] = &[
+    ("p", SwitchProfile::Personal),
+    ("personal", SwitchProfile::Personal),
+    ("w", SwitchProfile::Work),
+    ("work", SwitchProfile::Work),
+];
 
-/// Resolve a switch profile input (alias or canonical) to its canonical name.
-pub fn resolve_switch_profile(input: &str) -> Option<&'static str> {
+/// Strong type for VCS identity switch profiles.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SwitchProfile {
+    Personal,
+    Work,
+}
+
+impl SwitchProfile {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SwitchProfile::Personal => "personal",
+            SwitchProfile::Work => "work",
+        }
+    }
+}
+
+impl std::fmt::Display for SwitchProfile {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+/// Resolve a switch profile input (alias or canonical) to its canonical enum variant.
+pub fn resolve_switch_profile(input: &str) -> Option<SwitchProfile> {
     let lower = input.to_lowercase();
     for &(alias, canonical) in SWITCH_PROFILES {
         if lower == alias {
@@ -31,10 +57,10 @@ mod tests {
 
     #[test]
     fn resolves_switch_profiles() {
-        assert_eq!(resolve_switch_profile("p"), Some("personal"));
-        assert_eq!(resolve_switch_profile("personal"), Some("personal"));
-        assert_eq!(resolve_switch_profile("w"), Some("work"));
-        assert_eq!(resolve_switch_profile("work"), Some("work"));
+        assert_eq!(resolve_switch_profile("p"), Some(SwitchProfile::Personal));
+        assert_eq!(resolve_switch_profile("personal"), Some(SwitchProfile::Personal));
+        assert_eq!(resolve_switch_profile("w"), Some(SwitchProfile::Work));
+        assert_eq!(resolve_switch_profile("work"), Some(SwitchProfile::Work));
         assert_eq!(resolve_switch_profile("unknown"), None);
     }
 }

--- a/tests/library/domain_exports.rs
+++ b/tests/library/domain_exports.rs
@@ -4,7 +4,7 @@
 fn domain_profile_types_are_public() {
     // Confirms that profile resolution is accessible from the library crate.
     let resolved = mev::domain::profile::resolve_profile("macbook");
-    assert_eq!(resolved, Some("macbook"));
+    assert_eq!(resolved, Some(mev::domain::profile::Profile::Macbook));
 }
 
 #[test]
@@ -16,5 +16,5 @@ fn domain_tag_resolution_is_public() {
 #[test]
 fn domain_config_resolution_is_public() {
     let profile = mev::domain::vcs_identity::resolve_switch_profile("p");
-    assert_eq!(profile, Some("personal"));
+    assert_eq!(profile, Some(mev::domain::vcs_identity::SwitchProfile::Personal));
 }


### PR DESCRIPTION
Refactored `Profile` and `SwitchProfile` from `&str` string representations to strongly-typed Enums (`src/domain/profile.rs` and `src/domain/vcs_identity.rs`). This eliminates primitive obsession throughout the application boundary, making `api.rs` and the `execute` commands directly consume domain models, increasing stability and correctness while ensuring proper validation occurs at the CLI/edge layer. Updated corresponding `ConfigStore` ports and adapters to use the safe typed model. Fixed downstream CLI lists to correctly reference the domain model as the Single Source of Truth, keeping with architectural constraints to never hardcode enumerables.

---
*PR created automatically by Jules for task [1410380513063330478](https://jules.google.com/task/1410380513063330478) started by @akitorahayashi*