### PR TITLE
docs(devops): emit ci supply chain and artifact anti-pattern events

### DIFF
--- a/.jules/exchange/events/release-anti-pattern-bundled-binary-devops.md
+++ b/.jules/exchange/events/release-anti-pattern-bundled-binary-devops.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-06"
+author_role: "devops"
+confidence: "high"
+---
+
+## Statement
+
+The repository lacks an automated release workflow to a secure artifact registry, instead utilizing an anti-pattern of committing compiled bundled binaries directly back to the `main` branch.
+
+## Evidence
+
+- path: ".github/workflows/sync-bundled-binary.yml"
+  loc: "line 55-61"
+  note: "Commits and pushes the downloaded binary artifact directly to the main branch rather than publishing to a release registry."

--- a/.jules/exchange/events/supply-chain-risk-mutable-tags-devops.md
+++ b/.jules/exchange/events/supply-chain-risk-mutable-tags-devops.md
@@ -1,0 +1,21 @@
+---
+created_at: "2026-03-06"
+author_role: "devops"
+confidence: "high"
+---
+
+## Statement
+
+Multiple CI workflows and composite actions rely on mutable version tags (e.g., `@v4`, `@v5`) for third-party actions instead of immutable commit SHAs, exposing the verification path to supply-chain attacks.
+
+## Evidence
+
+- path: ".github/actions/setup-base/action.yml"
+  loc: "line 8, 13, 18, 22"
+  note: "Uses mutable tags like actions/setup-python@v5, extractions/setup-just@v2, astral-sh/setup-uv@v5, Swatinem/rust-cache@v2."
+- path: ".github/workflows/build-bundled-binary.yml"
+  loc: "line 15, 34"
+  note: "Uses mutable tags like actions/checkout@v4 and actions/upload-artifact@v4."
+- path: ".github/workflows/sync-bundled-binary.yml"
+  loc: "line 36, 44"
+  note: "Uses mutable tags like actions/checkout@v4 and actions/download-artifact@v4."

--- a/.jules/exchange/events/unpinned-ci-dependencies-devops.md
+++ b/.jules/exchange/events/unpinned-ci-dependencies-devops.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-06"
+author_role: "devops"
+confidence: "high"
+---
+
+## Statement
+
+CI workflows install system packages dynamically via package managers without pinning exact versions, introducing non-determinism and potential execution instability due to unverified upstream changes.
+
+## Evidence
+
+- path: ".github/workflows/run-linters.yml"
+  loc: "line 20"
+  note: "Runs `brew install shellcheck shfmt` without specifying toolchain versions."
+- path: ".github/workflows/collect-coverage.yml"
+  loc: "line 29"
+  note: "Runs `brew install mise` without specifying a tool version."


### PR DESCRIPTION
Emits three observer events for the `devops` role to highlight automation safety and operational integrity issues.

1.  **Supply Chain Risk:** Identifies mutable tags (`@v4`, `@v5`) in `.github/actions/setup-base/action.yml`, `build-bundled-binary.yml`, and `sync-bundled-binary.yml` as a supply chain attack surface.
2.  **Release Anti-Pattern:** Flags the direct commit of compiled bundled binaries to `main` in `sync-bundled-binary.yml` instead of an artifact registry.
3.  **Unpinned CI Dependencies:** Notes `brew install shellcheck shfmt` and `brew install mise` without version pinning in CI workflows.

---
*PR created automatically by Jules for task [9521848830716330515](https://jules.google.com/task/9521848830716330515) started by @akitorahayashi*