### PR TITLE
Emit rustacean events for error handling and fallback patterns

### DIFF
--- a/.jules/exchange/events/ansible-executor-unwrap-or-rustacean.md
+++ b/.jules/exchange/events/ansible-executor-unwrap-or-rustacean.md
@@ -1,0 +1,19 @@
+---
+created_at: "2024-05-20"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+The `run_playbook` method in `AnsibleAdapter` uses silent fallbacks by defaulting exit codes to `-1` and repo paths to `.` using `unwrap_or`. This violates the principle of explicit error handling and surfacing failures at boundaries, losing important context when processes terminate without an exit code (e.g. by signal) or when the repo path resolution fails.
+
+## Evidence
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "line 82"
+  note: "`self.ansible_dir.parent().unwrap_or(Path::new(\".\")).display()` silently defaults to the current directory when the parent path is not available."
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "line 107"
+  note: "`code.unwrap_or(-1)` silently defaults an exit code to -1 without differentiating whether it was terminated by a signal or failed."

--- a/.jules/exchange/events/backup-command-unwrap-rustacean.md
+++ b/.jules/exchange/events/backup-command-unwrap-rustacean.md
@@ -1,0 +1,27 @@
+---
+created_at: "2024-05-20"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+The backup command adapter uses silent fallbacks by masking string serialization and floating point parsing errors in `src/app/commands/backup/mod.rs`. This obscures invalid state because the original value is just passed through via `unwrap_or` when `serde_json::to_string` or `f64::parse` fail.
+
+## Evidence
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 169"
+  note: "`serde_json::to_string(&value).unwrap_or(value)` silently ignores serialization errors."
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 204"
+  note: "`target.parse::<f64>().map(|f| f.to_string()).unwrap_or(target)` silently ignores parsing errors."
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 208"
+  note: "`target.parse::<f64>().map(|f| (f as i64).to_string()).unwrap_or(target)` silently ignores parsing errors."
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 229"
+  note: "`serde_json::to_string(&value).unwrap_or(value)` silently ignores serialization errors."

--- a/.jules/exchange/events/profile-test-unwrap-rustacean.md
+++ b/.jules/exchange/events/profile-test-unwrap-rustacean.md
@@ -1,0 +1,19 @@
+---
+created_at: "2024-05-20"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+Tests in `src/domain/profile.rs` rely on `unwrap()` directly in the test body instead of correctly propagating errors or using robust pattern matching. This masks failure context when assertions fail because `unwrap()` produces a panic trace instead of showing the underlying `Result` failure context.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "line 123"
+  note: "`validate_machine_profile(\"macbook\").unwrap()` is used inside `validate_machine_profile_accepts_macbook` test."
+
+- path: "src/domain/profile.rs"
+  loc: "line 124"
+  note: "`validate_machine_profile(\"mbk\").unwrap()` is used inside `validate_machine_profile_accepts_macbook` test."


### PR DESCRIPTION
Emitted three event files as the `rustacean` observer identifying instances of silent fallbacks (`unwrap_or`) in the Ansible and Backup adapters, and improper test logic using `unwrap` in the profile validation logic.

---
*PR created automatically by Jules for task [4535363093656910773](https://jules.google.com/task/4535363093656910773) started by @akitorahayashi*