### PR TITLE
docs(observers): emit tactician events for AGENTS.md violations

### DIFF
--- a/.jules/exchange/events/global-rules-in-deep-scope-tactician.md
+++ b/.jules/exchange/events/global-rules-in-deep-scope-tactician.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-06"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+A deeply nested, scope-local AGENTS.md file (`dist/mev/ansible/roles/nodejs/config/common/coder/AGENTS.md`) is acting as a global contract, carrying extensive execution rules (Conduct, Design, Implementation, Documentation, Communication, Safety, User-specific) that logically apply to the entire repository. This violates the anti-pattern of global contracts carrying local execution rules, as well as the principle that rule ownership follows scope ownership.
+
+## Evidence
+
+- path: "dist/mev/ansible/roles/nodejs/config/common/coder/AGENTS.md"
+  loc: "Entire file content (Lines 1-52)"
+  note: "This file contains comprehensive project-wide rules (e.g., 'Ordered tasks are completed without interruption', 'Commands that discard uncommitted changes... are only run after explicit user approval') nested deeply within a specific Ansible role's config directory, creating ambiguous precedence and violating locality of rules."

--- a/.jules/exchange/events/missing-working-directory-constraint-tactician.md
+++ b/.jules/exchange/events/missing-working-directory-constraint-tactician.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-06"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+The `crates/mev-internal/AGENTS.md` file specifies commands for verifying the crate (`cargo fmt`, `cargo clippy`, `cargo test`) but does not include the essential structural context that these commands must be executed within the `crates/mev-internal` directory (since it is not part of the root cargo workspace). This unguarded failure path will cause the verification commands to fail if executed from the repository root.
+
+## Evidence
+
+- path: "crates/mev-internal/AGENTS.md"
+  loc: "Lines 17-21"
+  note: "Lists `cargo test --all-targets --all-features` and other verifications under 'Verify Commands' without the requisite working directory constraint (`cd crates/mev-internal`). A user or agent following these rules blindly from the project root will encounter errors as this crate is not a member of the root workspace."

--- a/.jules/exchange/events/volatile-implementation-details-tactician.md
+++ b/.jules/exchange/events/volatile-implementation-details-tactician.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-06"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+The `dist/mev/ansible/roles/rust/AGENTS.md` file rests on volatile implementation details rather than durable structural guidance. It enumerates exact tools (`gho`, `jlo`, `kpv`, `mx`, `pure`, `ssv`), file formats, and URL patterns which are ephemeral operational details, rather than providing the background context and constraints that are execution-critical. This violates the rule to exclude volatile implementation trivia from AGENTS.md.
+
+## Evidence
+
+- path: "dist/mev/ansible/roles/rust/AGENTS.md"
+  loc: "Lines 11-15"
+  note: "Enumerates the exact process of URL construction ('https://github.com/<repo>/releases/download/<tag>/<name>-<os>-<arch>'), listing explicit tool names ('gho', 'jlo', etc.), and an asset naming convention. These are volatile implementation specifics of the Ansible role and should not be stored as an agent contract."


### PR DESCRIPTION
Emits three high-signal events from the tactician observer to flag violations of AGENTS.md rules:
- `global-rules-in-deep-scope-tactician.md`: Flags `dist/mev/ansible/roles/nodejs/config/common/coder/AGENTS.md` for containing global rules in a nested scope.
- `volatile-implementation-details-tactician.md`: Flags `dist/mev/ansible/roles/rust/AGENTS.md` for containing volatile implementation details.
- `missing-working-directory-constraint-tactician.md`: Flags `crates/mev-internal/AGENTS.md` for missing the working directory constraint on cargo verification commands.

---
*PR created automatically by Jules for task [12587863658283493567](https://jules.google.com/task/12587863658283493567) started by @akitorahayashi*