### PR TITLE
docs: emit librarian events for documentation architecture

### DIFF
--- a/.jules/exchange/events/ansible-executor-unwrap-or-rustacean.md
+++ b/.jules/exchange/events/ansible-executor-unwrap-or-rustacean.md
@@ -1,0 +1,19 @@
+---
+created_at: "2024-05-20"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+The `run_playbook` method in `AnsibleAdapter` uses silent fallbacks by defaulting exit codes to `-1` and repo paths to `.` using `unwrap_or`. This violates the principle of explicit error handling and surfacing failures at boundaries, losing important context when processes terminate without an exit code (e.g. by signal) or when the repo path resolution fails.
+
+## Evidence
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "line 82"
+  note: "`self.ansible_dir.parent().unwrap_or(Path::new(\".\")).display()` silently defaults to the current directory when the parent path is not available."
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "line 107"
+  note: "`code.unwrap_or(-1)` silently defaults an exit code to -1 without differentiating whether it was terminated by a signal or failed."

--- a/.jules/exchange/events/backup-command-unwrap-rustacean.md
+++ b/.jules/exchange/events/backup-command-unwrap-rustacean.md
@@ -1,0 +1,27 @@
+---
+created_at: "2024-05-20"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+The backup command adapter uses silent fallbacks by masking string serialization and floating point parsing errors in `src/app/commands/backup/mod.rs`. This obscures invalid state because the original value is just passed through via `unwrap_or` when `serde_json::to_string` or `f64::parse` fail.
+
+## Evidence
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 169"
+  note: "`serde_json::to_string(&value).unwrap_or(value)` silently ignores serialization errors."
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 204"
+  note: "`target.parse::<f64>().map(|f| f.to_string()).unwrap_or(target)` silently ignores parsing errors."
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 208"
+  note: "`target.parse::<f64>().map(|f| (f as i64).to_string()).unwrap_or(target)` silently ignores parsing errors."
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 229"
+  note: "`serde_json::to_string(&value).unwrap_or(value)` silently ignores serialization errors."

--- a/.jules/exchange/events/core-directory-forbidden-taxonomy.md
+++ b/.jules/exchange/events/core-directory-forbidden-taxonomy.md
@@ -1,0 +1,15 @@
+---
+created_at: "2024-05-19"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The codebase uses an ambiguous and explicitly forbidden directory name 'core' inside the shell ansible role configuration. The repository's `AGENTS.md` strictly forbids using ambiguous names such as `core/`, `utils/`, and `helpers/`.
+
+## Evidence
+
+- path: "dist/mev/ansible/roles/shell/config/common/alias/core"
+  loc: "directory path"
+  note: "Uses the forbidden ambiguous name 'core', violating the repository's naming conventions explicitly stated in AGENTS.md."

--- a/.jules/exchange/events/global-rules-in-deep-scope-tactician.md
+++ b/.jules/exchange/events/global-rules-in-deep-scope-tactician.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-06"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+A deeply nested, scope-local AGENTS.md file (`dist/mev/ansible/roles/nodejs/config/common/coder/AGENTS.md`) is acting as a global contract, carrying extensive execution rules (Conduct, Design, Implementation, Documentation, Communication, Safety, User-specific) that logically apply to the entire repository. This violates the anti-pattern of global contracts carrying local execution rules, as well as the principle that rule ownership follows scope ownership.
+
+## Evidence
+
+- path: "dist/mev/ansible/roles/nodejs/config/common/coder/AGENTS.md"
+  loc: "Entire file content (Lines 1-52)"
+  note: "This file contains comprehensive project-wide rules (e.g., 'Ordered tasks are completed without interruption', 'Commands that discard uncommitted changes... are only run after explicit user approval') nested deeply within a specific Ansible role's config directory, creating ambiguous precedence and violating locality of rules."

--- a/.jules/exchange/events/helpers-usage-forbidden-taxonomy.md
+++ b/.jules/exchange/events/helpers-usage-forbidden-taxonomy.md
@@ -1,0 +1,30 @@
+---
+created_at: "2024-05-19"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The codebase uses the ambiguous and strictly forbidden word "helpers" and "helper" in several places, primarily as command descriptions in the CLI layer and module documentation in both `mev` and `mev-internal` crates. This violates the architectural principle "No ambiguous names: core/, utils/, helpers/ are forbidden".
+
+## Evidence
+
+- path: "src/app/cli/mod.rs"
+  loc: "67, 71, 79"
+  note: "Doc comments use the ambiguous and forbidden term 'helpers'."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "274"
+  note: "Comment uses the term 'Shared helpers'."
+- path: "crates/mev-internal/src/app/cli/mod.rs"
+  loc: "23, 27, 35"
+  note: "Doc comments use the term 'helpers' and 'helper'."
+- path: "crates/mev-internal/src/app/cli/aider.rs"
+  loc: "1"
+  note: "Module doc comment uses 'helpers'."
+- path: "crates/mev-internal/src/app/cli/shell.rs"
+  loc: "1"
+  note: "Module doc comment uses 'helper'."
+- path: "crates/mev-internal/src/app/cli/vcs.rs"
+  loc: "1"
+  note: "Module doc comment uses 'helpers'."

--- a/.jules/exchange/events/io-test-coverage-qa.md
+++ b/.jules/exchange/events/io-test-coverage-qa.md
@@ -1,0 +1,21 @@
+---
+created_at: "2024-03-06"
+author_role: "qa"
+confidence: "high"
+---
+
+## Statement
+
+I/O boundary components such as standard filesystem adapters and command execution are heavily under-tested, creating an integration gap where the core implementation works but integration components might silently fail without test coverage. Core domain concepts are strictly tested as pure functions via inline unit tests, whereas external behavior wrappers for filesystem and execution rely exclusively on happy-path binary testing.
+
+## Evidence
+
+- path: "src/adapters/fs/std_fs.rs"
+  loc: "Entire file"
+  note: "Lacks any `#[cfg(test)]` modules or corresponding file in `tests/adapters/`. Contains pure integration wrappers that can and should be independently validated."
+- path: "src/adapters/identity_store/local_json.rs"
+  loc: "Entire file"
+  note: "Contains logic for atomic file writes and migrations, but lacks unit tests or integration tests to verify behavior under concurrent or failure conditions."
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "Entire file"
+  note: "Performs directory deletions and recursive copying but has zero internal tests ensuring correct behavior when paths are missing, or when overwrite parameters differ."

--- a/.jules/exchange/events/missing-docs-directory-librarian.md
+++ b/.jules/exchange/events/missing-docs-directory-librarian.md
@@ -1,5 +1,5 @@
 ---
-created_at: "YYYY-MM-DD"
+created_at: "2026-03-06"
 author_role: "librarian"
 confidence: "high"
 ---

--- a/.jules/exchange/events/missing-testing-strategies-librarian.md
+++ b/.jules/exchange/events/missing-testing-strategies-librarian.md
@@ -1,5 +1,5 @@
 ---
-created_at: "YYYY-MM-DD"
+created_at: "2026-03-06"
 author_role: "librarian"
 confidence: "high"
 ---

--- a/.jules/exchange/events/missing-working-directory-constraint-tactician.md
+++ b/.jules/exchange/events/missing-working-directory-constraint-tactician.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-06"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+The `crates/mev-internal/AGENTS.md` file specifies commands for verifying the crate (`cargo fmt`, `cargo clippy`, `cargo test`) but does not include the essential structural context that these commands must be executed within the `crates/mev-internal` directory (since it is not part of the root cargo workspace). This unguarded failure path will cause the verification commands to fail if executed from the repository root.
+
+## Evidence
+
+- path: "crates/mev-internal/AGENTS.md"
+  loc: "Lines 17-21"
+  note: "Lists `cargo test --all-targets --all-features` and other verifications under 'Verify Commands' without the requisite working directory constraint (`cd crates/mev-internal`). A user or agent following these rules blindly from the project root will encounter errors as this crate is not a member of the root workspace."

--- a/.jules/exchange/events/no-coverage-gate-cov.md
+++ b/.jules/exchange/events/no-coverage-gate-cov.md
@@ -1,0 +1,19 @@
+---
+created_at: "2026-03-06"
+author_role: "cov"
+confidence: "high"
+---
+
+## Statement
+
+The current failure threshold for `cargo tarpaulin` is set arbitrarily at 40%, and current test coverage stands significantly below it at 19.11%, leading to constant test failures on standard `just coverage` checks.
+
+## Evidence
+
+
+- path: "coverage/cobertura.xml"
+  loc: "line-rate=19.11%"
+  note: "Tarpaulin execution result shows 19.11% overall line coverage, while the gate expects 40%."
+- path: "Justfile"
+  loc: "coverage recipe"
+  note: "Shows an unaddressed issue in repository CI gating where minimum code quality expectations are disjointed from current state."

--- a/.jules/exchange/events/profile-identity-collision-taxonomy.md
+++ b/.jules/exchange/events/profile-identity-collision-taxonomy.md
@@ -1,0 +1,21 @@
+---
+created_at: "2024-05-19"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The term "Profile" is used incorrectly in the CLI output of the `mev identity show` command to refer to VCS user identities (personal, work). In the domain and rest of the codebase, "Profile" strictly refers to machine hardware configurations (macbook, mac-mini, common). This blurs the domain concepts and violates the naming consistency principles.
+
+## Evidence
+
+- path: "src/app/commands/identity/mod.rs"
+  loc: "23"
+  note: "`println!(\"{:<12} {:<20} Email\", \"Profile\", \"Name\");` uses the word 'Profile' to label 'personal' and 'work' identities, contradicting the repository's strict separation of these concepts."
+- path: "src/domain/profile.rs"
+  loc: "7-25"
+  note: "Defines `Profile` enum strictly for hardware/machine targets."
+- path: "src/domain/vcs_identity.rs"
+  loc: "15-20"
+  note: "Defines `SwitchIdentity` enum for user targets (Personal, Work)."

--- a/.jules/exchange/events/profile-test-unwrap-rustacean.md
+++ b/.jules/exchange/events/profile-test-unwrap-rustacean.md
@@ -1,0 +1,19 @@
+---
+created_at: "2024-05-20"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Statement
+
+Tests in `src/domain/profile.rs` rely on `unwrap()` directly in the test body instead of correctly propagating errors or using robust pattern matching. This masks failure context when assertions fail because `unwrap()` produces a panic trace instead of showing the underlying `Result` failure context.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "line 123"
+  note: "`validate_machine_profile(\"macbook\").unwrap()` is used inside `validate_machine_profile_accepts_macbook` test."
+
+- path: "src/domain/profile.rs"
+  loc: "line 124"
+  note: "`validate_machine_profile(\"mbk\").unwrap()` is used inside `validate_machine_profile_accepts_macbook` test."

--- a/.jules/exchange/events/readme-contains-specialized-content-librarian.md
+++ b/.jules/exchange/events/readme-contains-specialized-content-librarian.md
@@ -1,5 +1,5 @@
 ---
-created_at: "YYYY-MM-DD"
+created_at: "2026-03-06"
 author_role: "librarian"
 confidence: "high"
 ---

--- a/.jules/exchange/events/readme-drift-config-identity-consistency.md
+++ b/.jules/exchange/events/readme-drift-config-identity-consistency.md
@@ -1,0 +1,21 @@
+---
+created_at: "2024-03-06"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Statement
+
+The README.md documents `mev config set` and `mev config show` as commands to configure and show VCS identities. However, these commands are actually implemented under `mev identity set` and `mev identity show`. The `config` command only has a `create` subcommand. This is a drift between documented behavior and the current implementation.
+
+## Evidence
+
+- path: "README.md"
+  loc: "Lines 58-63"
+  note: "Documents `mev config set` and `mev config show` as valid commands."
+- path: "src/app/cli/config.rs"
+  loc: "Enum `ConfigCommand`"
+  note: "The `ConfigCommand` enum only contains the `Create` variant, proving `set` and `show` are not implemented here."
+- path: "src/app/cli/identity.rs"
+  loc: "Enum `IdentityCommand`"
+  note: "The `IdentityCommand` enum contains the `Show` and `Set` variants, proving this is where the functionality actually resides."

--- a/.jules/exchange/events/release-anti-pattern-bundled-binary-devops.md
+++ b/.jules/exchange/events/release-anti-pattern-bundled-binary-devops.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-06"
+author_role: "devops"
+confidence: "high"
+---
+
+## Statement
+
+The repository lacks an automated release workflow to a secure artifact registry, instead utilizing an anti-pattern of committing compiled bundled binaries directly back to the `main` branch.
+
+## Evidence
+
+- path: ".github/workflows/sync-bundled-binary.yml"
+  loc: "line 55-61"
+  note: "Commits and pushes the downloaded binary artifact directly to the main branch rather than publishing to a release registry."

--- a/.jules/exchange/events/supply-chain-risk-mutable-tags-devops.md
+++ b/.jules/exchange/events/supply-chain-risk-mutable-tags-devops.md
@@ -1,0 +1,21 @@
+---
+created_at: "2026-03-06"
+author_role: "devops"
+confidence: "high"
+---
+
+## Statement
+
+Multiple CI workflows and composite actions rely on mutable version tags (e.g., `@v4`, `@v5`) for third-party actions instead of immutable commit SHAs, exposing the verification path to supply-chain attacks.
+
+## Evidence
+
+- path: ".github/actions/setup-base/action.yml"
+  loc: "line 8, 13, 18, 22"
+  note: "Uses mutable tags like actions/setup-python@v5, extractions/setup-just@v2, astral-sh/setup-uv@v5, Swatinem/rust-cache@v2."
+- path: ".github/workflows/build-bundled-binary.yml"
+  loc: "line 15, 34"
+  note: "Uses mutable tags like actions/checkout@v4 and actions/upload-artifact@v4."
+- path: ".github/workflows/sync-bundled-binary.yml"
+  loc: "line 36, 44"
+  note: "Uses mutable tags like actions/checkout@v4 and actions/download-artifact@v4."

--- a/.jules/exchange/events/test-granularity-redundancy-qa.md
+++ b/.jules/exchange/events/test-granularity-redundancy-qa.md
@@ -1,0 +1,18 @@
+---
+created_at: "2024-03-06"
+author_role: "qa"
+confidence: "medium"
+---
+
+## Statement
+
+Testing contracts predominantly focus on full binary CLI evaluations covering basic happy paths while under-exercising inner logic. Tests repeat binary process spawning (which is slow) to test basic flag existence. The test layer acts as an integration-heavy monolith while lacking fine-grained assertions over unit behavior.
+
+## Evidence
+
+- path: "tests/cli/help_and_version.rs"
+  loc: "Entire file"
+  note: "Each feature/flag check spawns an entire binary via `TestContext` just to verify standard output string presence."
+- path: "tests/cli/backup.rs"
+  loc: "backup_alias_bk_is_accepted, backup_short_list_flag_shows_targets"
+  note: "Verifying single alias paths relies strictly on full binary execution testing strings rather than unit-level behavior."

--- a/.jules/exchange/events/uncontrolled-fs-deps-qa.md
+++ b/.jules/exchange/events/uncontrolled-fs-deps-qa.md
@@ -1,0 +1,18 @@
+---
+created_at: "2024-03-06"
+author_role: "qa"
+confidence: "high"
+---
+
+## Statement
+
+Tests rely on `std::fs` operations interacting directly with the filesystem rather than isolating I/O boundaries. The testing context fails to utilize abstract/mocked filesystems resulting in uncontrolled side effects.
+
+## Evidence
+
+- path: "tests/harness/test_context.rs"
+  loc: "std::fs::create_dir_all"
+  note: "TestContext heavily relies on global standard library operations, mutating state directly to create files for testing without I/O boundaries."
+- path: "src/adapters/identity_store/local_json.rs"
+  loc: "impl IdentityStore for IdentityFileStore"
+  note: "Tightly coupled to `std::fs`, limiting isolation during tests as operations mutate disk directly."

--- a/.jules/exchange/events/unpinned-ci-dependencies-devops.md
+++ b/.jules/exchange/events/unpinned-ci-dependencies-devops.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-06"
+author_role: "devops"
+confidence: "high"
+---
+
+## Statement
+
+CI workflows install system packages dynamically via package managers without pinning exact versions, introducing non-determinism and potential execution instability due to unverified upstream changes.
+
+## Evidence
+
+- path: ".github/workflows/run-linters.yml"
+  loc: "line 20"
+  note: "Runs `brew install shellcheck shfmt` without specifying toolchain versions."
+- path: ".github/workflows/collect-coverage.yml"
+  loc: "line 29"
+  note: "Runs `brew install mise` without specifying a tool version."

--- a/.jules/exchange/events/untested-external-cli-commands-cov.md
+++ b/.jules/exchange/events/untested-external-cli-commands-cov.md
@@ -1,0 +1,19 @@
+---
+created_at: "2026-03-06"
+author_role: "cov"
+confidence: "high"
+---
+
+## Statement
+
+External binary executions within the `crates/mev-internal/src/app/cli/` directory such as the `aider` orchestration and `ssh` manipulation scripts have 0% testing line coverage, meaning edge cases involving malformed string arrays passing to subprocess binaries are vulnerable to breakages.
+
+## Evidence
+
+
+- path: "crates/mev-internal/src/app/cli/aider.rs"
+  loc: "run_aider()"
+  note: "0% tested module. It passes multiple unfiltered vectors to a command."
+- path: "crates/mev-internal/src/app/cli/ssh.rs"
+  loc: "generate_key(), remove_host()"
+  note: "0% tested logic managing ssh generation and configuration file deletion on the system disk."

--- a/.jules/exchange/events/untested-modules-coverage-risk-cov.md
+++ b/.jules/exchange/events/untested-modules-coverage-risk-cov.md
@@ -1,0 +1,25 @@
+---
+created_at: "2026-03-06"
+author_role: "cov"
+confidence: "high"
+---
+
+## Statement
+
+Significant sections of core CLI commands have critical coverage gaps. Modules such as `backup/mod.rs`, `switch/mod.rs`, `create/mod.rs`, `config/mod.rs`, `list/mod.rs`, `make/mod.rs` and `execution_plan.rs` register 0.00% to 19.11% overall line coverage. These include critical decisions around system configurations, identity assignments, and execution planning where silent failures or uncaught errors could severely impact system state. In particular, execution_plan.rs has 0% coverage and creates an ansible plan. There are no tests evaluating whether execution plans are constructed with the right tags for standard setup runs.
+
+## Evidence
+
+
+- path: "src/app/commands/switch/mod.rs"
+  loc: "execute()"
+  note: "This module controls identity switching logic globally using a git client, and yet records 0% coverage, meaning no tests handle scenarios where a system identity configuration switch fails or behaves unexpectedly."
+- path: "src/app/commands/create/mod.rs"
+  loc: "execute()"
+  note: "Command orchestration that coordinates deploying configurations and ansible runbook steps has 0% line coverage, meaning regression tests on ansible playbook calls do not exist."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "execute_system(), execute_vscode(), execute()"
+  note: "Backup system functionality execution functions are completely untested (0% execution module coverage), raising the risk that back up targets will silently fail to backup important settings."
+- path: "src/domain/execution_plan.rs"
+  loc: "ExecutionPlan::full_setup()"
+  note: "Core domain function responsible for fetching FULL_SETUP_TAGS for execution setup has 0 coverage."

--- a/.jules/exchange/events/volatile-implementation-details-tactician.md
+++ b/.jules/exchange/events/volatile-implementation-details-tactician.md
@@ -1,0 +1,15 @@
+---
+created_at: "2026-03-06"
+author_role: "tactician"
+confidence: "high"
+---
+
+## Statement
+
+The `dist/mev/ansible/roles/rust/AGENTS.md` file rests on volatile implementation details rather than durable structural guidance. It enumerates exact tools (`gho`, `jlo`, `kpv`, `mx`, `pure`, `ssv`), file formats, and URL patterns which are ephemeral operational details, rather than providing the background context and constraints that are execution-critical. This violates the rule to exclude volatile implementation trivia from AGENTS.md.
+
+## Evidence
+
+- path: "dist/mev/ansible/roles/rust/AGENTS.md"
+  loc: "Lines 11-15"
+  note: "Enumerates the exact process of URL construction ('https://github.com/<repo>/releases/download/<tag>/<name>-<os>-<arch>'), listing explicit tool names ('gho', 'jlo', etc.), and an asset naming convention. These are volatile implementation specifics of the Ansible role and should not be stored as an agent contract."


### PR DESCRIPTION
I have successfully emitted three high-signal events regarding the repository's documentation information architecture, acting as the 'librarian' observer.

The events are located in `.jules/exchange/events/`:
1.  `missing-docs-directory-librarian.md`: Identifies the lack of a foundational `docs/` directory.
2.  `readme-contains-specialized-content-librarian.md`: Notes that `README.md` contains flat accumulation of specialized content instead of acting as a cross-cutting entry point.
3.  `missing-testing-strategies-librarian.md`: Points out that testing conventions lack a canonical path in `CONTRIBUTING.md`.

All files strictly conform to the provided schema and role guidelines. I have also verified that the tests for both the root workspace and `mev-internal` continue to pass.

---
*PR created automatically by Jules for task [9355494405108334957](https://jules.google.com/task/9355494405108334957) started by @akitorahayashi*