### PR TITLE
Add taxonomy event findings

### DIFF
--- a/.jules/exchange/events/core-directory-forbidden-taxonomy.md
+++ b/.jules/exchange/events/core-directory-forbidden-taxonomy.md
@@ -1,0 +1,15 @@
+---
+created_at: "2024-05-19"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The codebase uses an ambiguous and explicitly forbidden directory name 'core' inside the shell ansible role configuration. The repository's `AGENTS.md` strictly forbids using ambiguous names such as `core/`, `utils/`, and `helpers/`.
+
+## Evidence
+
+- path: "dist/mev/ansible/roles/shell/config/common/alias/core"
+  loc: "directory path"
+  note: "Uses the forbidden ambiguous name 'core', violating the repository's naming conventions explicitly stated in AGENTS.md."

--- a/.jules/exchange/events/helpers-usage-forbidden-taxonomy.md
+++ b/.jules/exchange/events/helpers-usage-forbidden-taxonomy.md
@@ -1,0 +1,30 @@
+---
+created_at: "2024-05-19"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The codebase uses the ambiguous and strictly forbidden word "helpers" and "helper" in several places, primarily as command descriptions in the CLI layer and module documentation in both `mev` and `mev-internal` crates. This violates the architectural principle "No ambiguous names: core/, utils/, helpers/ are forbidden".
+
+## Evidence
+
+- path: "src/app/cli/mod.rs"
+  loc: "67, 71, 79"
+  note: "Doc comments use the ambiguous and forbidden term 'helpers'."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "274"
+  note: "Comment uses the term 'Shared helpers'."
+- path: "crates/mev-internal/src/app/cli/mod.rs"
+  loc: "23, 27, 35"
+  note: "Doc comments use the term 'helpers' and 'helper'."
+- path: "crates/mev-internal/src/app/cli/aider.rs"
+  loc: "1"
+  note: "Module doc comment uses 'helpers'."
+- path: "crates/mev-internal/src/app/cli/shell.rs"
+  loc: "1"
+  note: "Module doc comment uses 'helper'."
+- path: "crates/mev-internal/src/app/cli/vcs.rs"
+  loc: "1"
+  note: "Module doc comment uses 'helpers'."

--- a/.jules/exchange/events/profile-identity-collision-taxonomy.md
+++ b/.jules/exchange/events/profile-identity-collision-taxonomy.md
@@ -1,0 +1,21 @@
+---
+created_at: "2024-05-19"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Statement
+
+The term "Profile" is used incorrectly in the CLI output of the `mev identity show` command to refer to VCS user identities (personal, work). In the domain and rest of the codebase, "Profile" strictly refers to machine hardware configurations (macbook, mac-mini, common). This blurs the domain concepts and violates the naming consistency principles.
+
+## Evidence
+
+- path: "src/app/commands/identity/mod.rs"
+  loc: "23"
+  note: "`println!(\"{:<12} {:<20} Email\", \"Profile\", \"Name\");` uses the word 'Profile' to label 'personal' and 'work' identities, contradicting the repository's strict separation of these concepts."
+- path: "src/domain/profile.rs"
+  loc: "7-25"
+  note: "Defines `Profile` enum strictly for hardware/machine targets."
+- path: "src/domain/vcs_identity.rs"
+  loc: "15-20"
+  note: "Defines `SwitchIdentity` enum for user targets (Personal, Work)."


### PR DESCRIPTION
Emits three `taxonomy` event findings to `.jules/exchange/events/` indicating naming and vocabulary consistency issues:

- `core-directory-forbidden-taxonomy.md`: Captures the violation of the `core` directory usage in the `shell` role configuration.
- `helpers-usage-forbidden-taxonomy.md`: Documents the usage of the ambiguous `helpers` string in CLI commands.
- `profile-identity-collision-taxonomy.md`: Documents the CLI label `Profile` mapping to domain concept `Identity`.

---
*PR created automatically by Jules for task [14909636471350741073](https://jules.google.com/task/14909636471350741073) started by @akitorahayashi*