### PR TITLE
docs(cov): emit test coverage risk events

### DIFF
--- a/.jules/exchange/events/no-coverage-gate-cov.md
+++ b/.jules/exchange/events/no-coverage-gate-cov.md
@@ -1,0 +1,19 @@
+---
+created_at: "2026-03-06"
+author_role: "cov"
+confidence: "high"
+---
+
+## Statement
+
+The current failure threshold for `cargo tarpaulin` is set arbitrarily at 40%, and current test coverage stands significantly below it at 19.11%, leading to constant test failures on standard `just coverage` checks.
+
+## Evidence
+
+
+- path: "coverage/cobertura.xml"
+  loc: "line-rate=19.11%"
+  note: "Tarpaulin execution result shows 19.11% overall line coverage, while the gate expects 40%."
+- path: "Justfile"
+  loc: "coverage recipe"
+  note: "Shows an unaddressed issue in repository CI gating where minimum code quality expectations are disjointed from current state."

--- a/.jules/exchange/events/untested-external-cli-commands-cov.md
+++ b/.jules/exchange/events/untested-external-cli-commands-cov.md
@@ -1,0 +1,19 @@
+---
+created_at: "2026-03-06"
+author_role: "cov"
+confidence: "high"
+---
+
+## Statement
+
+External binary executions within the `crates/mev-internal/src/app/cli/` directory such as the `aider` orchestration and `ssh` manipulation scripts have 0% testing line coverage, meaning edge cases involving malformed string arrays passing to subprocess binaries are vulnerable to breakages.
+
+## Evidence
+
+
+- path: "crates/mev-internal/src/app/cli/aider.rs"
+  loc: "run_aider()"
+  note: "0% tested module. It passes multiple unfiltered vectors to a command."
+- path: "crates/mev-internal/src/app/cli/ssh.rs"
+  loc: "generate_key(), remove_host()"
+  note: "0% tested logic managing ssh generation and configuration file deletion on the system disk."

--- a/.jules/exchange/events/untested-modules-coverage-risk-cov.md
+++ b/.jules/exchange/events/untested-modules-coverage-risk-cov.md
@@ -1,0 +1,25 @@
+---
+created_at: "2026-03-06"
+author_role: "cov"
+confidence: "high"
+---
+
+## Statement
+
+Significant sections of core CLI commands have critical coverage gaps. Modules such as `backup/mod.rs`, `switch/mod.rs`, `create/mod.rs`, `config/mod.rs`, `list/mod.rs`, `make/mod.rs` and `execution_plan.rs` register 0.00% to 19.11% overall line coverage. These include critical decisions around system configurations, identity assignments, and execution planning where silent failures or uncaught errors could severely impact system state. In particular, execution_plan.rs has 0% coverage and creates an ansible plan. There are no tests evaluating whether execution plans are constructed with the right tags for standard setup runs.
+
+## Evidence
+
+
+- path: "src/app/commands/switch/mod.rs"
+  loc: "execute()"
+  note: "This module controls identity switching logic globally using a git client, and yet records 0% coverage, meaning no tests handle scenarios where a system identity configuration switch fails or behaves unexpectedly."
+- path: "src/app/commands/create/mod.rs"
+  loc: "execute()"
+  note: "Command orchestration that coordinates deploying configurations and ansible runbook steps has 0% line coverage, meaning regression tests on ansible playbook calls do not exist."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "execute_system(), execute_vscode(), execute()"
+  note: "Backup system functionality execution functions are completely untested (0% execution module coverage), raising the risk that back up targets will silently fail to backup important settings."
+- path: "src/domain/execution_plan.rs"
+  loc: "ExecutionPlan::full_setup()"
+  note: "Core domain function responsible for fetching FULL_SETUP_TAGS for execution setup has 0 coverage."


### PR DESCRIPTION
This submission generates three `cov` observer role event markdown files in the `.jules/exchange/events/` directory.

- `untested-modules-coverage-risk-cov.md`: Identifies critical command orchestration modules (e.g., switch, create, backup) that have zero test coverage and handle significant system changes.
- `untested-external-cli-commands-cov.md`: Highlights completely untested shell orchestrations and ssh key generation operations.
- `no-coverage-gate-cov.md`: Points out that the current `cargo tarpaulin` coverage gate fails since actual coverage is significantly below the configured 40% threshold.

All findings adhere to the layer constraints and the event markdown schema.

---
*PR created automatically by Jules for task [9462191503197662858](https://jules.google.com/task/9462191503197662858) started by @akitorahayashi*