### PR TITLE
Emit data architecture events

### DIFF
--- a/.jules/exchange/events/duplicate-copy-dir-recursive-data-arch.md
+++ b/.jules/exchange/events/duplicate-copy-dir-recursive-data-arch.md
@@ -1,0 +1,18 @@
+---
+created_at: "2024-05-15"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Statement
+
+The application models a recursive directory copy function, `copy_dir_recursive`, redundantly across two different application command modules. This violates the Single Source of Truth principle by forcing future changes or bug fixes to be duplicated across boundaries without an explicit shared capability.
+
+## Evidence
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "line 53"
+  note: "Implements `copy_dir_recursive` publicly to support the `deploy_for_tags` function."
+- path: "src/app/commands/config/mod.rs"
+  loc: "line 51"
+  note: "Implements an almost identical private `copy_dir_recursive` function to support the `create` command."

--- a/.jules/exchange/events/weak-typing-in-backup-definitions-data-arch.md
+++ b/.jules/exchange/events/weak-typing-in-backup-definitions-data-arch.md
@@ -1,0 +1,18 @@
+---
+created_at: "2024-05-15"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Statement
+
+The `SettingDefinition` struct represents data types using a primitive string (`type_name: String`) rather than an explicit strong Enum type. This causes downstream formatting logic to rely on weak string matching with a silent fallback for invalid states, which is an anti-pattern that fails to encode invariants at the system boundary.
+
+## Evidence
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 22"
+  note: "The `SettingDefinition` model defines `type_name` as a `String`."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 155"
+  note: "The `format_value` function validates type identity using implicit string matching (`\"bool\"`, `\"int\"`, `\"float\"`, `\"string\"`) with a catch-all fallback `_` that masks invalid schema states."


### PR DESCRIPTION
This branch introduces two observer events evaluating the codebase through the `data_arch` lens.

1. **`duplicate-copy-dir-recursive-data-arch.md`**: Identifies a violation of the Single Source of Truth principle by pointing out identical `copy_dir_recursive` functions in `src/app/commands/deploy_configs.rs` and `src/app/commands/config/mod.rs`.
2. **`weak-typing-in-backup-definitions-data-arch.md`**: Highlights a data modeling issue where `SettingDefinition.type_name` uses a primitive `String` instead of a strong Enum, leading to weak string matching and a catch-all silent fallback in `format_value` within `src/app/commands/backup/mod.rs`.

Both events adhere strictly to the observer constraints, modifying only files within `.jules/exchange/events/`, and using the specified schema format.

---
*PR created automatically by Jules for task [1372432655968080356](https://jules.google.com/task/1372432655968080356) started by @akitorahayashi*