### PR TITLE
Generate documentation update artifacts

### DIFF
--- a/.jules/exchange/updates/create_docs_architecture_md.md
+++ b/.jules/exchange/updates/create_docs_architecture_md.md
@@ -1,0 +1,19 @@
+---
+created_at: "2026-03-11"
+---
+
+## Claim
+
+The repository lacks a canonical `docs/architecture.md` surface as mandated by the Canonical Documentation Structure constraint. The current architectural details, principles, and design rules are incorrectly located in `AGENTS.md`, and must be migrated here.
+
+## Points
+
+- Create `docs/architecture.md` to hold durable design aspects, boundaries, topology, and invariants.
+- Migrate the following sections from `AGENTS.md` into this new file: "Architecture", "Package Structure", "Architecture Principles", and "Design Rules".
+- Ensure that the migrated content does not contain runbooks.
+
+## Evidence
+
+- `docs/architecture.md` does not exist.
+- The Canonical Documentation Structure constraint requires `docs/architecture.md` or `docs/architecture/` for durable design.
+- `AGENTS.md` currently holds detailed architectural descriptions that belong here.

--- a/.jules/exchange/updates/create_docs_readme_md.md
+++ b/.jules/exchange/updates/create_docs_readme_md.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-11"
+---
+
+## Claim
+
+The central documentation index `docs/README.md` is missing. The Canonical Documentation Structure constraint dictates that it must be an entry point that owns the table of contents and routes to all specific areas within the `docs/` directory.
+
+## Points
+
+- Create a `docs/README.md` file.
+- Implement a clear Table of Contents (ToC) that routes to `docs/usage.md` and `docs/architecture.md`.
+- Remove any redundant ToC content from the main `README.md` or `AGENTS.md`, and point them to `docs/README.md`.
+
+## Evidence
+
+- `docs/README.md` does not exist.
+- Main `README.md` currently lists explicit links to `docs/usage.md` instead of routing through a central index.

--- a/.jules/exchange/updates/enhance_readme_md.md
+++ b/.jules/exchange/updates/enhance_readme_md.md
@@ -1,0 +1,18 @@
+---
+created_at: "2026-03-11"
+---
+
+## Claim
+
+The primary `README.md` file lacks a short canonical model, which is a required element according to the Canonical Documentation Structure constraint for the public front door. Its routing also needs adjustments to point to the central `docs/README.md` index.
+
+## Points
+
+- Add a "Short Canonical Model" to `README.md` that clearly defines the system's core entities and how they relate.
+- Update the "Documentation" section to route to `CONTRIBUTING.md`, `AGENTS.md`, and the central `docs/README.md` instead of individually listing files inside `docs/`.
+
+## Evidence
+
+- `README.md` only contains "Prerequisites", "Installation", "Verification", and a specific file-listing "Documentation" section.
+- The "Short Canonical Model" explicitly requested by the Canonical Documentation Structure constraint is absent.
+- `README.md` lists `docs/usage.md` directly instead of pointing to the required `docs/README.md` index.

--- a/.jules/exchange/updates/refactor_agents_md.md
+++ b/.jules/exchange/updates/refactor_agents_md.md
@@ -1,0 +1,19 @@
+---
+created_at: "2026-03-11"
+---
+
+## Claim
+
+`AGENTS.md` is currently overloaded with detailed architectural components, package structure, and design rules, violating the Canonical Documentation Structure constraint which mandates that it be a concise repository description with basic routing. These detailed sections must be removed and relocated to the appropriate architectural documentation surfaces.
+
+## Points
+
+- Remove the "Architecture", "Package Structure", "Architecture Principles", and "Design Rules" sections from `AGENTS.md`.
+- Keep the "Overview" and "CLI Commands" sections.
+- Ensure `AGENTS.md` explicitly routes agents to `CONTRIBUTING.md` and `docs/` as their primary sources of truth for detailed work.
+
+## Evidence
+
+- `AGENTS.md` contains 40+ lines of detailed tables outlining layers, paths, and responsibilities, which belong in `docs/architecture.md`.
+- `AGENTS.md` contains detailed package structure directory trees and internal dependency mapping.
+- The `AGENTS.md Policy` in memory specifies that documentation for LLMs must be concise for token efficiency, focusing only on essential information.


### PR DESCRIPTION
This submission addresses the Triage Documentation Work task. It inspects the current repository documentation against the required Canonical Documentation Structure and emits 4 non-overlapping update artifacts in `.jules/exchange/updates/` to seed the writer agent's work. It strictly follows layer constraints by modifying only the designated directory and avoids formatting violations like bold emphasis in Markdown.

---
*PR created automatically by Jules for task [6299592442472933111](https://jules.google.com/task/6299592442472933111) started by @akitorahayashi*