### PR TITLE
Refactor documentation to use docs/README.md as central index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,68 +5,9 @@
 Rust-first CLI for macOS dev environment setup using bundled Ansible playbooks.
 Installable as a standalone Rust binary via `install.sh`.
 
-## Architecture
+## Documentation
 
-| Layer | Path | Responsibility |
-|---|---|---|
-| Application | `src/app/` | CLI boundary, command orchestration, dependency wiring |
-| Domain | `src/domain/` | Pure rules, command invariants, execution planning, interfaces |
-| Ports | `src/domain/ports/` | Interface boundaries required by domain/application |
-| Adapters | `src/adapters/` | Process execution, file I/O, catalog loading, runtime asset materialization |
-| Internal dep | `crates/mev-internal/` | Internal command domain implementations reused by mev |
-| Source assets | `src/assets/` | Source-of-truth Ansible playbooks and roles |
-| Release assets | `GitHub Releases` | `mev-darwin-aarch64` binary distribution |
-
-## CLI Commands
-
-See [README.md](README.md) for the list of available commands and usage instructions.
-
-## Package Structure
-
-```text
-src/
-├── main.rs               # Binary entry point
-├── lib.rs                 # Library root
-├── app/
-│   ├── cli/               # clap argument contracts (1 file per command)
-│   │   └── mod.rs         # Single owner of clap parser and command dispatch
-│   ├── commands/           # Orchestration units per command domain
-│   ├── context.rs          # Dependency wiring (ports → adapters)
-│   └── api.rs              # Stable library entrypoints
-├── domain/
-│   ├── error.rs            # Typed domain errors
-│   ├── ports/              # Trait interfaces
-│   ├── profile.rs          # Profile identifiers and mapping
-│   ├── tag.rs              # Tag resolution from catalogs
-│   ├── config.rs           # VCS identity configuration model
-│   └── execution_plan.rs   # Deterministic ansible plan construction
-├── adapters/
-│   ├── ansible/            # Playbook execution, locator, runtime asset materialization
-│   ├── identity_store/     # Identity persistence and path resolution
-│   ├── macos_defaults/     # macOS defaults adapter
-│   ├── version_source/     # Update execution source
-│   ├── git/, jj/, vscode/  # External tool adapters
-│   └── fs/                 # Filesystem adapter
-├── assets/
-│   └── ansible/            # Source-of-truth ansible assets embedded into binary
-└── testing/                # In-process test doubles
-
-crates/
-└── mev-internal/          # Internal command implementations (shell, vcs)
-
-tests/
-├── harness/                # Shared fixtures (TestContext)
-├── cli.rs + cli/           # CLI behavior contracts
-├── library.rs + library/   # Public API contracts
-├── adapters.rs + adapters/ # Adapter behavior contracts
-├── runtime.rs + runtime/   # Binary invocation contracts
-└── security.rs + security/ # Input validation contracts
-```
-
-## Python Surface
-
-Python ownership is limited to development tooling (`ansible-lint`) managed by `pyproject.toml`.
-Runtime command ownership belongs to the Rust implementation.
+See [docs/README.md](docs/README.md) for detailed documentation and architecture.
 
 ## Architecture Principles
 

--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ mev list
 
 ## Documentation
 
-- [Usage](docs/usage.md): Command-line interface references, configuration examples, and environment setup guides.
+- [Documentation Index](docs/README.md): Central index routing to specific documentation areas, such as Usage and Architecture.
 - [Contributing](CONTRIBUTING.md): Development guidelines, coding standards, and testing procedures for contributors.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Documentation
+
+- [Usage](usage.md)
+- [Architecture](architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,58 @@
+# Architecture
+
+| Layer | Path | Responsibility |
+|---|---|---|
+| Application | `src/app/` | CLI boundary, command orchestration, dependency wiring |
+| Domain | `src/domain/` | Pure rules, command invariants, execution planning, interfaces |
+| Ports | `src/domain/ports/` | Interface boundaries required by domain/application |
+| Adapters | `src/adapters/` | Process execution, file I/O, catalog loading, runtime asset materialization |
+| Internal dep | `crates/mev-internal/` | Internal command domain implementations reused by mev |
+| Source assets | `src/assets/` | Source-of-truth Ansible playbooks and roles |
+| Release assets | `GitHub Releases` | `mev-darwin-aarch64` binary distribution |
+
+## Package Structure
+
+```text
+src/
+├── main.rs               # Binary entry point
+├── lib.rs                 # Library root
+├── app/
+│   ├── cli/               # clap argument contracts (1 file per command)
+│   │   └── mod.rs         # Single owner of clap parser and command dispatch
+│   ├── commands/           # Orchestration units per command domain
+│   ├── context.rs          # Dependency wiring (ports → adapters)
+│   └── api.rs              # Stable library entrypoints
+├── domain/
+│   ├── error.rs            # Typed domain errors
+│   ├── ports/              # Trait interfaces
+│   ├── profile.rs          # Profile identifiers and mapping
+│   ├── tag.rs              # Tag resolution from catalogs
+│   ├── config.rs           # VCS identity configuration model
+│   └── execution_plan.rs   # Deterministic ansible plan construction
+├── adapters/
+│   ├── ansible/            # Playbook execution, locator, runtime asset materialization
+│   ├── identity_store/     # Identity persistence and path resolution
+│   ├── macos_defaults/     # macOS defaults adapter
+│   ├── version_source/     # Update execution source
+│   ├── git/, jj/, vscode/  # External tool adapters
+│   └── fs/                 # Filesystem adapter
+├── assets/
+│   └── ansible/            # Source-of-truth ansible assets embedded into binary
+└── testing/                # In-process test doubles
+
+crates/
+└── mev-internal/          # Internal command implementations (shell, vcs)
+
+tests/
+├── harness/                # Shared fixtures (TestContext)
+├── cli.rs + cli/           # CLI behavior contracts
+├── library.rs + library/   # Public API contracts
+├── adapters.rs + adapters/ # Adapter behavior contracts
+├── runtime.rs + runtime/   # Binary invocation contracts
+└── security.rs + security/ # Input validation contracts
+```
+
+## Python Surface
+
+Python ownership is limited to development tooling (`ansible-lint`) managed by `pyproject.toml`.
+Runtime command ownership belongs to the Rust implementation.


### PR DESCRIPTION
Creates the canonical `docs/README.md` central index, migrating architecture content from `AGENTS.md` into `docs/architecture.md`, and routing all main documentation links to the new central index in accordance with documentation structure rules.

---
*PR created automatically by Jules for task [6936144802116891211](https://jules.google.com/task/6936144802116891211) started by @akitorahayashi*