### PR TITLE
Emit DevOps observer events for automation drift and release provenance

### DIFF
--- a/.jules/exchange/events/automation_topology_drift_devops.md
+++ b/.jules/exchange/events/automation_topology_drift_devops.md
@@ -1,0 +1,32 @@
+---
+label: "bugs"
+created_at: "2026-03-11"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+The repository lacks an explicit, authoritative source-of-truth mapping for its automation control points, and there is an implicit trust boundary between the build tools and the workflow executions.
+
+## Goal
+
+Establish a single source-of-truth generator for workflow automation assets to prevent drift, map out the automation topology explicitly, and clarify the contract between execution surfaces and generation sources.
+
+## Context
+
+Currently, multiple workflow files are defined statically under `.github/workflows/` (e.g., `build.yml`, `release.yml`, setup actions), and logic like `justfile` commands serve as execution points without clear generator contracts or unified policy architecture.
+
+## Evidence
+
+- path: ".github/workflows/"
+  loc: "directory"
+  note: "Multiple static workflow files exist with no explicit generator documented, violating source-of-truth integrity."
+- path: "justfile"
+  loc: "lines 1-122"
+  note: "Serves as an execution entry point without explicit linkage to a master automation control plane."
+
+## Change Scope
+
+- `.github/workflows/`
+- `justfile`

--- a/.jules/exchange/events/release_path_provenance_gaps_devops.md
+++ b/.jules/exchange/events/release_path_provenance_gaps_devops.md
@@ -1,0 +1,33 @@
+---
+label: "bugs"
+created_at: "2026-03-11"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+The release and artifact provenance paths lack robust verification layers. Artifacts rely strictly on direct downloads and unpinned basic checksum validation instead of explicit, robust verification.
+
+## Goal
+
+Strengthen the verification gating and signature lineage of release artifacts from compilation through to the installer script, removing implicit trust bounds.
+
+## Context
+
+The build pipeline compiles artifacts natively but the promotion model (via `release.yml` and `install.sh`) simply uploads binaries and runs `shasum`. There is no rigorous cryptographic verification, rollback readiness, or explicit trust handoff policy.
+
+## Evidence
+
+- path: "install.sh"
+  loc: "lines 45-76"
+  note: "Performs bare-minimum `shasum` checking over `curl` without signature checking or rigorous artifact lineage verification."
+- path: ".github/workflows/release.yml"
+  loc: "lines 1-13"
+  note: "Pushes out releases directly by relying on `build.yml` with no intermediate signed gates or supply chain verification."
+
+## Change Scope
+
+- `install.sh`
+- `.github/workflows/release.yml`
+- `.github/workflows/build.yml`


### PR DESCRIPTION
This PR adds two observer events from the devops role highlighting a lack of single source-of-truth automation generation and rigorous cryptographic gating on the release path.

---
*PR created automatically by Jules for task [10216718675738111009](https://jules.google.com/task/10216718675738111009) started by @akitorahayashi*