### PR TITLE
Add structural arch observer events

### DIFF
--- a/.jules/exchange/events/api_boundary_isolation_structural_arch.md
+++ b/.jules/exchange/events/api_boundary_isolation_structural_arch.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2026-03-11"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+The API layer directly re-exports domain types instead of mapping them to API-specific structs/enums.
+
+## Goal
+
+Map domain types to API-specific structs/enums instead of directly re-exporting them, ensuring strict boundary isolation.
+
+## Context
+
+The repository architecture enforces a strict boundary isolation where the API layer must not expose domain-internal implementations directly. Instead, domain types must be mapped to specific API data transfer objects. Directly exporting domain types means internal domain changes could implicitly break external consumers, coupling internal logic to the public API contract.
+
+## Evidence
+
+- path: "src/app/api.rs"
+  loc: "14-19"
+  note: "Direct `pub use` exports of `BackupTarget`, `ExecutionPlan`, `IdentityState`, `Profile`, `SwitchIdentity`, and `VcsIdentity` expose domain types directly to the API consumers."
+
+## Change Scope
+
+- `src/app/api.rs`
+- `src/domain/backup_target.rs`
+- `src/domain/execution_plan.rs`
+- `src/domain/ports/identity_store.rs`
+- `src/domain/profile.rs`
+- `src/domain/vcs_identity.rs`

--- a/.jules/exchange/events/domain_ports_std_path_structural_arch.md
+++ b/.jules/exchange/events/domain_ports_std_path_structural_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2026-03-11"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+Domain ports are using `std::path::Path` and `std::path::PathBuf` types, introducing I/O coupling into pure logic boundaries.
+
+## Goal
+
+Abstract file system concepts away by replacing `std::path` types in domain logic ports with primitive types like `&str` or `String`.
+
+## Context
+
+The architecture rules enforce that domain pure logic ports must abstract file system concepts away and avoid `std::path` types. This decouples I/O concerns from domain logic, making testing and portability simpler while keeping domain boundaries clean. Currently, several core ports reference standard library path types directly.
+
+## Evidence
+
+- path: "src/domain/ports/fs.rs"
+  loc: "5"
+  note: "`use std::path::{Path, PathBuf};` directly relies on `std::path` types for the `FsPort` trait."
+- path: "src/domain/ports/identity_store.rs"
+  loc: "5"
+  note: "`use std::path::PathBuf;` directly relies on `std::path` types for the `IdentityStore` trait."
+
+## Change Scope
+
+- `src/domain/ports/fs.rs`
+- `src/domain/ports/identity_store.rs`


### PR DESCRIPTION
- Add `api_boundary_isolation_structural_arch.md` to flag `pub use` of domain types in the API layer.
- Add `domain_ports_std_path_structural_arch.md` to flag I/O coupling (`std::path`) in pure logic domain boundaries.

---
*PR created automatically by Jules for task [3818888496948653568](https://jules.google.com/task/3818888496948653568) started by @akitorahayashi*