### PR TITLE
docs: Add cli_sentinel observer events

### DIFF
--- a/.jules/exchange/events/destructive_operation_safety_backup_cli_sentinel.md
+++ b/.jules/exchange/events/destructive_operation_safety_backup_cli_sentinel.md
@@ -1,0 +1,35 @@
+---
+label: "bugs"
+created_at: "2026-03-11"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+The `backup` command performs destructive file writes (overwriting existing backup files) without prompting for confirmation or requiring a safety override flag like `--overwrite`.
+
+## Goal
+
+Add an `--overwrite` flag to the `backup` command and enforce it or a confirmation prompt when the target destination file already exists.
+
+## Context
+
+Destructive operations (such as file writes that replace existing data) must employ uniform safety contracts. Other commands like `create`, `make`, and `config create` already utilize the `--overwrite` flag to prevent accidental data loss. The `backup` command performs file overwrites directly but lacks this required safety measure.
+
+## Evidence
+
+- path: "src/app/cli/backup.rs"
+  loc: "pub struct BackupArgs"
+  note: "The `--overwrite` flag is missing from the CLI arguments definition."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "ctx.fs.write(output_file, lines.join(\"\\n\").as_bytes())?;"
+  note: "The command writes system backup directly without checking if the file exists or requiring an overwrite flag."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "ctx.fs.write(output_file, format!(\"{content}\\n\").as_bytes())?;"
+  note: "The command writes vscode extension backups directly without any safety checks."
+
+## Change Scope
+
+- `src/app/cli/backup.rs`
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/io_separation_operational_logs_cli_sentinel.md
+++ b/.jules/exchange/events/io_separation_operational_logs_cli_sentinel.md
@@ -1,0 +1,45 @@
+---
+label: "bugs"
+created_at: "2026-03-11"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+Operational logs, progress updates, and success messages are written to `stdout` instead of `stderr`, mixing diagnostic information with result data.
+
+## Goal
+
+Migrate all operational logs, progress messages, and non-result output to `stderr` (e.g., using `eprintln!`), reserving `stdout` strictly for command result data.
+
+## Context
+
+The `cli_sentinel` contract mandates strict I/O separation: `stdout` must carry only result data, while `stderr` carries warnings, logs, and errors. Currently, commands like `create`, `make`, `backup`, and `update` use `println!` for logging progress and status updates. Mixed streams cause automation failures, as piped output will include non-data logs rather than pure result streams.
+
+## Evidence
+
+- path: "src/app/commands/create/mod.rs"
+  loc: "println!(\"[{step}/{total}] Running: {tag}\");"
+  note: "Progress logs are emitted to stdout."
+- path: "src/app/commands/make/mod.rs"
+  loc: "println!(\"Running tags: {}\", plan.tags.join(\", \"));"
+  note: "Operation logs are emitted to stdout."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "println!(\"Running backup: {}\", target.description());"
+  note: "Start logs are emitted to stdout."
+- path: "src/app/commands/update/mod.rs"
+  loc: "println!(\"Running upgrade...\");"
+  note: "Process logs are emitted to stdout."
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "println!(\"  Deployed config for {role}\");"
+  note: "Deployment progress logs are emitted to stdout."
+
+## Change Scope
+
+- `src/app/commands/create/mod.rs`
+- `src/app/commands/make/mod.rs`
+- `src/app/commands/backup/mod.rs`
+- `src/app/commands/update/mod.rs`
+- `src/app/commands/deploy_configs.rs`
+- `src/app/commands/config/mod.rs`

--- a/.jules/exchange/events/mandatory_options_config_cli_sentinel.md
+++ b/.jules/exchange/events/mandatory_options_config_cli_sentinel.md
@@ -1,0 +1,32 @@
+---
+label: "bugs"
+created_at: "2026-03-11"
+author_role: "cli_sentinel"
+confidence: "medium"
+---
+
+## Problem
+
+The `config create` command violates the structural consistency rule (verb + [object] + arguments) by using `create` as a subcommand rather than a verb on an object.
+
+## Goal
+
+Restructure the `config create` command to conform to standard verb-object forms, potentially extracting `role` into an explicit positional argument or subcommand structure aligned with `identity set`/`identity show`.
+
+## Context
+
+Commands should follow standard sentence structures. The CLI uses `mev identity set` and `mev identity show` for configuration tasks, while `mev config create` acts more as an imperative verb. To prevent structural drift and naming vocabulary dispersion, the CLI structure should be evaluated and aligned with established norms.
+
+## Evidence
+
+- path: "src/app/cli/config.rs"
+  loc: "pub enum ConfigCommand { Create { role: Option<String>, overwrite: bool } }"
+  note: "The command structure uses 'config' as the verb/object and 'create' as the action, whereas other areas like 'identity' use 'set'/'show'."
+- path: "src/app/cli/mod.rs"
+  loc: "Config(config::ConfigCommand),"
+  note: "Top-level command configuration."
+
+## Change Scope
+
+- `src/app/cli/config.rs`
+- `src/app/cli/mod.rs`


### PR DESCRIPTION
Added three event files as the `cli_sentinel` observer to document issues with the CLI design.

1. `.jules/exchange/events/io_separation_operational_logs_cli_sentinel.md` documents a violation of the I/O separation contract where progress logs are written to stdout instead of stderr.
2. `.jules/exchange/events/destructive_operation_safety_backup_cli_sentinel.md` documents a safety gap where the `backup` command destructively overwrites files without a prompt or `--overwrite` flag.
3. `.jules/exchange/events/mandatory_options_config_cli_sentinel.md` documents a structural inconsistency where `config create` violates the standard verb-object form.

---
*PR created automatically by Jules for task [10267555644395268939](https://jules.google.com/task/10267555644395268939) started by @akitorahayashi*