### PR TITLE
docs: conform documentation to canonical structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,18 +28,6 @@ Rust:
 - Modules: `snake_case`, organized by layer (`app/`, `domain/`, `adapters/`)
 - Constants: `UPPER_SNAKE_CASE`
 
-### Configuration Files
-
-| File | Purpose |
-|------|---------|
-| `Cargo.toml` | Rust package metadata and dependencies |
-| `clippy.toml` | Clippy linter configuration |
-| `rustfmt.toml` | Rust formatter configuration |
-| `rust-toolchain.toml` | Rust toolchain version pinning |
-| `mise.toml` | Development tool version management |
-| `pyproject.toml` | Development Python dependency groups (`ansible-lint`) |
-| `justfile` | Development task automation |
-
 ### Testing Strategies
 
 Domain logic tests reside as self-contained unit tests within their respective `src/domain/` modules inside a `#[cfg(test)]` block. Redundant logic coverage in external `tests/library/` integration tests is avoided.
@@ -47,6 +35,12 @@ Domain logic tests reside as self-contained unit tests within their respective `
 ## Procedural Verification
 
 ### Verify Commands
+
+Local execution:
+
+```bash
+just run <args>
+```
 
 All commands are run before submitting changes:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# mev Documentation
+
+## Table of Contents
+
+- [Usage](usage.md): Step-by-step user flows and CLI-facing guidance.
+- [Architecture](architecture.md): Boundaries, topology, and invariants.
+- [Configuration](configuration/): Configuration surfaces, environment variables, secrets, and branch-policy contracts.
+  - [Files](configuration/files.md): Configuration files.
+  - [Release](configuration/release.md): Release pipeline configuration.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,9 +74,3 @@ tests/
 Two-stage config deployment:
 1. Package → `~/.config/mev/roles/{role}/`: Copy via `mev config create` or auto-deploy on `mev make`
 2. `~/.config/mev/roles/{role}/` → Local destinations: Symbolic links
-
-### Development
-- `just run <args>`: Run mev in dev mode
-- `just check`: Format and lint
-- `just test`: Run all Rust tests
-- `v*` tag push: `.github/workflows/release.yml` delegates to `.github/workflows/build.yml`, and the build job attaches `mev-darwin-aarch64` plus its SHA256 file directly to GitHub Releases

--- a/docs/configuration/files.md
+++ b/docs/configuration/files.md
@@ -1,0 +1,11 @@
+# Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `Cargo.toml` | Rust package metadata and dependencies |
+| `clippy.toml` | Clippy linter configuration |
+| `rustfmt.toml` | Rust formatter configuration |
+| `rust-toolchain.toml` | Rust toolchain version pinning |
+| `mise.toml` | Development tool version management |
+| `pyproject.toml` | Development Python dependency groups (`ansible-lint`) |
+| `justfile` | Development task automation |

--- a/docs/configuration/release.md
+++ b/docs/configuration/release.md
@@ -1,0 +1,3 @@
+# Release
+
+`v*` tag push: `.github/workflows/release.yml` delegates to `.github/workflows/build.yml`, and the build job attaches `mev-darwin-aarch64` plus its SHA256 file directly to GitHub Releases


### PR DESCRIPTION
Conforms the repository's documentation to the Canonical Documentation Structure.

- **`docs/README.md`**: Established as the central documentation index.
- **`docs/configuration/`**: Created the new subtree to house configuration surfaces.
  - **`docs/configuration/files.md`**: Moved the "Configuration Files" section from `CONTRIBUTING.md`.
  - **`docs/configuration/release.md`**: Moved the release pipeline config policy from `docs/architecture.md`.
- **`CONTRIBUTING.md`**: Removed misplaced "Configuration Files" section and added the "Local execution" command (`just run <args>`) to the "Verify Commands" section.
- **`docs/architecture.md`**: Removed the "Development" section as its contents were relocated to their proper canonical surfaces.

All edits ensure declarative styling and strictly avoid bold emphasis (`**`) per documentation rules.

---
*PR created automatically by Jules for task [6539973647247805874](https://jules.google.com/task/6539973647247805874) started by @akitorahayashi*