### PR TITLE
Emit CLI sentinel events

### DIFF
--- a/.jules/exchange/events/backup_list_option_cli_sentinel.md
+++ b/.jules/exchange/events/backup_list_option_cli_sentinel.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2023-10-25"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+The `backup` command relies on an option flag (`--list`) to completely change its primary execution action from performing a backup to listing available targets, creating a mutually exclusive relationship with the positional `target` argument. This violates option classification principles and command structure (verb + [object]).
+
+## Goal
+
+Restructure the `backup` command to eliminate the `--list` flag. Listing should be handled as a standard subcommand (e.g., `backup list`) or by displaying targets when `backup` is invoked without a target, strictly separating the primary command verb from its options.
+
+## Context
+
+Using an option to perform a primary verb action (like listing) adds help-text noise and breaks the predictability of the command structure. Options should modify behavior, not define the action itself. The current design introduces conditional mandatory arguments ("Target is required unless --list is used"), which indicates structural drift.
+
+## Evidence
+
+- path: "src/app/cli/backup.rs"
+  loc: "pub struct BackupArgs { ... pub list: bool ... pub target: Option<String> ... }"
+  note: "Defines a `--list` flag that mutually excludes the positional `target` argument."
+- path: "src/app/cli/backup.rs"
+  loc: "if args.list { ... } else if let Some(target) = args.target { ... }"
+  note: "Executes completely different code paths based on the presence of the `--list` option, replacing the command's primary verb."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "pub fn list_targets()"
+  note: "Implements the listing action that currently relies on the `--list` option rather than a structural command."
+
+## Change Scope
+
+- `src/app/cli/backup.rs`
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/destructive_ops_safety_contract_cli_sentinel.md
+++ b/.jules/exchange/events/destructive_ops_safety_contract_cli_sentinel.md
@@ -1,0 +1,39 @@
+---
+label: "feats"
+created_at: "2023-10-25"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+Destructive commands that mutate system configuration (`create`, `make`, `switch`) lack standardized safety contracts. While they offer flags like `--overwrite`, they proceed automatically without confirmation prompts, `--dry-run` modes, or protective warnings, increasing the risk of unintended system changes.
+
+## Goal
+
+Implement consistent safety contracts for all destructive operations. Add `--dry-run` to preview actions where feasible, or incorporate a unified confirmation prompt/warning strategy (with an explicit override like `--yes` or `--force`) before mutating configurations.
+
+## Context
+
+Running commands like `mev switch` modifies global user `.gitconfig` and JJ settings silently. The `create` and `make` commands similarly trigger broad Ansible state changes. Safety measures should be uniform for operations carrying similar risk levels to prevent operational accidents and user mistakes.
+
+## Evidence
+
+- path: "src/app/cli/create.rs"
+  loc: "pub struct CreateArgs { ... }"
+  note: "Defines no `--dry-run` or `--yes` option, but executes an Ansible plan that changes the system."
+- path: "src/app/cli/make.rs"
+  loc: "pub struct MakeArgs { ... }"
+  note: "Lacks `--dry-run` or safety confirmation before executing targeted Ansible changes."
+- path: "src/app/cli/switch.rs"
+  loc: "pub struct SwitchArgs { ... }"
+  note: "Silently switches identity profiles and modifies the Git system config without asking for user consent."
+
+## Change Scope
+
+- `src/app/cli/create.rs`
+- `src/app/cli/make.rs`
+- `src/app/cli/switch.rs`
+- `src/app/commands/create/mod.rs`
+- `src/app/commands/make/mod.rs`
+- `src/app/commands/switch/mod.rs`

--- a/.jules/exchange/events/io_separation_logs_stdout_cli_sentinel.md
+++ b/.jules/exchange/events/io_separation_logs_stdout_cli_sentinel.md
@@ -1,0 +1,41 @@
+---
+label: "refacts"
+created_at: "2023-10-25"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+Human-readable logs, progress indicators, and informative messages are emitted to `stdout` rather than `stderr` across several key CLI commands (`create`, `make`, `switch`, `backup`). This mixes diagnostic or informative output with actual result data, potentially breaking automation that relies on parsing `stdout` for results.
+
+## Goal
+
+Ensure all human-readable diagnostics, logs, and progress output use `stderr` (`eprintln!`), reserving `stdout` exclusively for structured, script-parseable result data (or keeping it completely empty).
+
+## Context
+
+Mixing logs and progress output in `stdout` prevents commands from being safely piped to other tools (like `jq` or `grep`). Automation requires a strict separation where `stdout` is the true payload, while `stderr` handles human feedback. Output streams must not be ambiguous.
+
+## Evidence
+
+- path: "src/app/commands/create/mod.rs"
+  loc: "println!(\"mev: Creating {} environment\", plan.profile);"
+  note: "Outputs raw log text to `stdout` during environment creation."
+- path: "src/app/commands/switch/mod.rs"
+  loc: "println!(\"Switching to {} identity...\", identity);"
+  note: "Outputs state changes and progress logs to `stdout`."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "println!(\"Running backup: {}\", target.description());"
+  note: "Informational message about running backups sent to `stdout`."
+- path: "src/app/commands/make/mod.rs"
+  loc: "println!(\"Running tags: {}\", plan.tags.join(\", \"));"
+  note: "Diagnostic progress information sent to `stdout`."
+
+## Change Scope
+
+- `src/app/commands/create/mod.rs`
+- `src/app/commands/make/mod.rs`
+- `src/app/commands/switch/mod.rs`
+- `src/app/commands/backup/mod.rs`
+- `src/app/commands/deploy_configs.rs`


### PR DESCRIPTION
Evaluated CLI command designs and emitted three event files for structural consistency, option discipline, and operational contract adherence, following the cli_sentinel observer role.

---
*PR created automatically by Jules for task [14433335402045014289](https://jules.google.com/task/14433335402045014289) started by @akitorahayashi*