### PR TITLE
docs: emit taxonomy observer events for ambiguous vocabulary

### DIFF
--- a/.jules/exchange/events/ambiguous_base_term_usage_taxonomy.md
+++ b/.jules/exchange/events/ambiguous_base_term_usage_taxonomy.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2026-03-12"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The term "base" is used in an ambiguous context for paths/URLs instead of precise domain-specific terms.
+
+## Goal
+
+Replace occurrences of "base" with more descriptive terms indicating their specific role, such as "root".
+
+## Context
+
+Using terms like "base path" or "release base URL" lacks specificity and can lead to confusion about what exactly the variable represents. "Base" is restricted by `AGENTS.md`.
+
+## Evidence
+
+- path: "src/adapters/identity_store/paths.rs"
+  loc: "line 3"
+  note: "Uses 'base path' instead of a more specific term like 'configuration root'."
+- path: "src/assets/ansible/roles/rust/config/common/tools.yml"
+  loc: "line 6"
+  note: "Uses 'release base URL' instead of 'release root URL'."
+
+## Change Scope
+
+- `src/adapters/identity_store/paths.rs`
+- `src/assets/ansible/roles/rust/config/common/tools.yml`

--- a/.jules/exchange/events/ambiguous_core_term_usage_taxonomy.md
+++ b/.jules/exchange/events/ambiguous_core_term_usage_taxonomy.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2026-03-12"
+author_role: "taxonomy"
+confidence: "medium"
+---
+
+## Problem
+
+The term "core" is used in the `svo-cli-design` skill document which violates the anti-pattern rule prohibiting "core" as a vague identifier.
+
+## Goal
+
+Replace occurrences of "core" with precise terms when not referring to specific packages or configuration parameters.
+
+## Context
+
+The rule is primarily for code, but using "core" loosely in prompt guidelines like `SKILL.md` creates an inconsistency with the repository-wide vocabulary guidelines.
+
+## Evidence
+
+- path: "src/assets/ansible/roles/nodejs/config/common/coder/skills/svo-cli-design/SKILL.md"
+  loc: "line 8, 10"
+  note: "Uses 'Core Objective' and 'core required inputs'. These can be replaced with 'Primary Objective' and 'fundamental required inputs'."
+- path: "src/assets/ansible/roles/nodejs/config/common/coder/skills/effective-prompting/SKILL.md"
+  loc: "line 8"
+  note: "Uses 'Core Objective' as a section header."
+
+## Change Scope
+
+- `src/assets/ansible/roles/nodejs/config/common/coder/skills/svo-cli-design/SKILL.md`
+- `src/assets/ansible/roles/nodejs/config/common/coder/skills/effective-prompting/SKILL.md`

--- a/.jules/exchange/events/ambiguous_helper_term_usage_taxonomy.md
+++ b/.jules/exchange/events/ambiguous_helper_term_usage_taxonomy.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2026-03-12"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The term "helpers" is used inconsistently across the codebase. In some places it indicates internal modules/functions, and in others it indicates CLI commands delegated to other tools.
+
+## Goal
+
+Remove ambiguous occurrences of "helpers" or "utils" and establish clear domain vocabulary.
+
+## Context
+
+The repository's AGENTS.md explicitly states: "Class and file must not have ambiguous names or responsibilities such as base, common, core, utils, or helpers." The current use of "helpers" in `mod.rs` files obscures the actual responsibility of the code.
+
+## Evidence
+
+- path: "src/app/cli/mod.rs"
+  loc: "line 67, 71"
+  note: "Uses 'helpers' to describe subcommands delegating to `git` and `gh` CLIs. A more precise term like 'commands' or 'integrations' would be better."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 274"
+  note: "Uses '// Shared helpers' as a section comment for a function resolving paths."
+- path: "crates/mev-internal/src/app/cli/mod.rs"
+  loc: "line 19, 23"
+  note: "Repeats the same use of 'helpers' for git and gh CLI commands as the main crate."
+
+## Change Scope
+
+- `src/app/cli/mod.rs`
+- `src/app/commands/backup/mod.rs`
+- `crates/mev-internal/src/app/cli/mod.rs`


### PR DESCRIPTION
Emitted 3 taxonomy event files highlighting the usage of ambiguous and non-domain terminology across the repository.

- `ambiguous_helper_term_usage_taxonomy.md`: Flags occurrences of `helpers` in `mod.rs` files for CLI delegations, and backup paths, confusing true boundaries.
- `ambiguous_base_term_usage_taxonomy.md`: Flags occurrences of `base` being used as prefixes/suffixes for generic identifiers.
- `ambiguous_core_term_usage_taxonomy.md`: Flags uses of `core` in nodejs coder skills which violates rules to avoid using it outside specific contexts.

---
*PR created automatically by Jules for task [18099599002526628472](https://jules.google.com/task/18099599002526628472) started by @akitorahayashi*