### PR TITLE
Emit data_arch observer events for boundary and domain issues

### DIFF
--- a/.jules/exchange/events/api_domain_reexport_data_arch.md
+++ b/.jules/exchange/events/api_domain_reexport_data_arch.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2024-05-24"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The API layer (`src/app/api.rs`) directly re-exports domain types like `Profile`, `BackupTarget`, `ExecutionPlan`, `IdentityState`, and `VcsIdentity` instead of mapping them to API-specific structs/enums.
+
+## Goal
+
+Isolate boundary domains by ensuring the API layer provides its own specific structs and enums that map to/from internal domain types, fulfilling the strict boundary isolation architecture rule.
+
+## Context
+
+Directly exposing domain structs in the API layer violates Boundary Sovereignty. The API represents the transport/UI boundary and should not leak internal domain models. This coupling makes it difficult to evolve the internal domain without breaking external API contracts.
+
+## Evidence
+
+- path: "src/app/api.rs"
+  loc: "pub use crate::domain::*"
+  note: "Directly re-exports `BackupTarget`, `AppError`, `ExecutionPlan`, `IdentityState`, `Profile`, `SwitchIdentity`, and `VcsIdentity`."
+
+## Change Scope
+
+- `src/app/api.rs`

--- a/.jules/exchange/events/domain_cli_parsing_data_arch.md
+++ b/.jules/exchange/events/domain_cli_parsing_data_arch.md
@@ -1,0 +1,37 @@
+---
+label: "refacts"
+created_at: "2024-05-24"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Core domain models (`Profile`, `SwitchIdentity`, `BackupTarget`) contain CLI-specific string input parsing logic, aliases, and validation.
+
+## Goal
+
+Remove CLI parsing concerns from core domain models, moving validation and input resolution to the adapter or application CLI layer.
+
+## Context
+
+Domain models represent the pure, canonical state and rules of the application. By embedding CLI aliases (e.g., "mbk" for Macbook) and string parsing (`from_input`, `resolve_switch_identity`) directly into the domain types, UI/transport concerns are leaking into the core domain logic, violating Boundary Sovereignty.
+
+## Evidence
+
+- path: "src/domain/vcs_identity.rs"
+  loc: "resolve_switch_identity"
+  note: "`resolve_switch_identity` handle CLI input mapping in the domain."
+- path: "src/domain/profile.rs"
+  loc: "resolve_profile, validate_machine_profile, validate_profile"
+  note: "`resolve_profile` and `validate_machine_profile` embed CLI string mapping and validation logic."
+- path: "src/domain/backup_target.rs"
+  loc: "from_input"
+  note: "`from_input` parses user-provided strings, including an alias 'vscode-extensions'."
+
+## Change Scope
+
+- `src/domain/vcs_identity.rs`
+- `src/domain/profile.rs`
+- `src/domain/backup_target.rs`
+- `src/app/cli/`

--- a/.jules/exchange/events/hardcoded_tags_data_arch.md
+++ b/.jules/exchange/events/hardcoded_tags_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-05-24"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Ansible tags and groups (`tag_groups` and `FULL_SETUP_TAGS`) are hardcoded in `src/domain/tag.rs` rather than being generated dynamically from the authoritative Ansible playbook catalog.
+
+## Goal
+
+Eliminate redundant definitions by dynamically resolving tags and tag groups from the Ansible `playbook.yml` catalog.
+
+## Context
+
+Hardcoding enumerable values like tags creates a dual source of truth (the Rust codebase and the Ansible playbooks). This leads to a maintenance burden and the risk of divergence. The codebase should treat the Ansible catalog as the single source of truth for available tags and execution orders.
+
+## Evidence
+
+- path: "src/domain/tag.rs"
+  loc: "tag_groups, FULL_SETUP_TAGS"
+  note: "`tag_groups` and `FULL_SETUP_TAGS` define static lists of tags that duplicate information present in the Ansible playbook."
+- path: "src/domain/execution_plan.rs"
+  loc: "ExecutionPlan::full_setup"
+  note: "`ExecutionPlan::full_setup` relies on the hardcoded `FULL_SETUP_TAGS`."
+
+## Change Scope
+
+- `src/domain/tag.rs`
+- `src/domain/execution_plan.rs`


### PR DESCRIPTION
Created 3 observer event files in `.jules/exchange/events/` identifying structural/architectural issues according to the `data_arch` role:
1. API layer boundary leaks (re-exporting internal domain types).
2. Domain types containing CLI-specific input parsing and aliases.
3. Hardcoded Ansible tags violating the single-source-of-truth principle.

---
*PR created automatically by Jules for task [822676167434971796](https://jules.google.com/task/822676167434971796) started by @akitorahayashi*