### PR TITLE
Emit rustacean events

### DIFF
--- a/.jules/exchange/events/path_invariants_rustacean.md
+++ b/.jules/exchange/events/path_invariants_rustacean.md
@@ -1,0 +1,30 @@
+---
+label: "refacts"
+created_at: "2024-05-24"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+The `ResolvedAnsibleDir` invariant is discarded immediately in `DependencyContainer::new`, converting to a raw `PathBuf` and losing the guarantee of structural validity for the Ansible directory.
+
+## Goal
+Preserve the `ResolvedAnsibleDir` type through the system, particularly into `AnsibleAdapter`, to ensure that invalid paths cannot be represented or passed around.
+
+## Context
+`ResolvedAnsibleDir` provides proof that the directory exists and contains necessary components (or cleans up a temp dir). However, `DependencyContainer::new` destructs it into a `PathBuf` (`into_parts()`) and hands it to `AnsibleAdapter::new(PathBuf, ...)`. This forces the adapter to re-verify the directory state or assume it's valid, violating the principle of making invalid states unrepresentable.
+
+## Evidence
+- path: "src/app/container.rs"
+  loc: "43"
+  note: "The ResolvedAnsibleDir is destructed into its parts."
+- path: "src/app/container.rs"
+  loc: "45"
+  note: "A raw PathBuf is cloned and passed to AnsibleAdapter::new."
+- path: "src/adapters/ansible/executor.rs"
+  loc: "67"
+  note: "AnsibleAdapter::new accepts a raw PathBuf."
+
+## Change Scope
+- `src/app/container.rs`
+- `src/adapters/ansible/executor.rs`

--- a/.jules/exchange/events/stringly_typed_errors_rustacean.md
+++ b/.jules/exchange/events/stringly_typed_errors_rustacean.md
@@ -1,0 +1,31 @@
+---
+label: "refacts"
+created_at: "2024-05-24"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+The application relies heavily on `String` variants in `AppError` and returns `Box<dyn std::error::Error>` from container initializers instead of preserving error domain context and type safety.
+
+## Goal
+Refactor error handling to avoid stringly-typed errors, provide strongly typed variants, and remove `Box<dyn std::error::Error>` from application boundary methods.
+
+## Context
+Error handling should preserve domain meaning after propagation. `AppError::Config(String)`, `AppError::Backup(String)`, and others collapse distinct errors into opaque strings, making matching or programmatic recovery impossible. Additionally, using `Box<dyn std::error::Error>` erases type information entirely at the container initialization boundary.
+
+## Evidence
+- path: "src/domain/error.rs"
+  loc: "17-25"
+  note: "AppError variants like Config, Update, and Backup encapsulate String payloads instead of distinct inner types or enums."
+- path: "src/app/container.rs"
+  loc: "40, 60"
+  note: "DependencyContainer::new and for_identity return Result<Self, Box<dyn std::error::Error>> instead of a specific domain error type."
+- path: "src/adapters/ansible/executor.rs"
+  loc: "69, 208"
+  note: "AnsibleAdapter::new and load_catalog return Result<..., Box<dyn std::error::Error>>."
+
+## Change Scope
+- `src/domain/error.rs`
+- `src/app/container.rs`
+- `src/adapters/ansible/executor.rs`


### PR DESCRIPTION
Emitted two observer events detailing Rust architectural improvements concerning boundary types and error handling, fulfilling the \`rustacean\` layer contract requirements.

---
*PR created automatically by Jules for task [11645199028050384379](https://jules.google.com/task/11645199028050384379) started by @akitorahayashi*