### PR TITLE
Emit structural arch events for I/O boundary violations

### DIFF
--- a/.jules/exchange/events/app_fs_violation_structural_arch.md
+++ b/.jules/exchange/events/app_fs_violation_structural_arch.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2024-03-12"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+The `app/commands` layer (specifically `deploy_configs.rs` and `config/mod.rs`) directly imports and uses `std::fs` and `std::path` to perform filesystem mutations, rather than delegating I/O operations through the `FsPort`.
+
+## Goal
+
+Enforce the dependency boundary by routing all filesystem interactions in the application logic layer through the `FsPort`, abstracting away direct host system dependencies and improving testability.
+
+## Context
+
+The application orchestration commands should not bypass the port/adapter boundary to perform I/O side effects directly. By using standard library filesystem routines, the code tightly couples to the host filesystem, preventing simple dependency injection for testing and breaking the designed abstraction.
+
+## Evidence
+
+- path: "src/app/commands/config/mod.rs"
+  loc: "Lines 42-73"
+  note: "Directly calls `std::fs::remove_dir_all`, `std::fs::rename`, `std::fs::create_dir_all`, `std::fs::read_dir`, and `std::fs::copy`."
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "Lines 41-76"
+  note: "Directly calls `std::fs::remove_dir_all`, `std::fs::create_dir_all`, `std::fs::read_dir`, and `std::fs::copy`."
+
+## Change Scope
+
+- `src/app/commands/config/mod.rs`
+- `src/app/commands/deploy_configs.rs`
+- `src/domain/ports/fs.rs`
+- `src/adapters/fs/std_fs.rs`

--- a/.jules/exchange/events/domain_path_violation_structural_arch.md
+++ b/.jules/exchange/events/domain_path_violation_structural_arch.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2024-03-12"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+Domain pure logic ports (`FsPort` and `IdentityStore`) depend on `std::path::Path` and `std::path::PathBuf` structs, entangling the domain layer with host filesystem concepts.
+
+## Goal
+
+Decouple I/O concerns from the domain layer by replacing `std::path` types in domain ports with primitive types like `&str` or `String`.
+
+## Context
+
+The Architecture Rule dictates that domain pure logic ports must abstract file system concepts away and avoid `std::path` types. Depending on `std::path` couples the port contracts to a specific implementation detail (filesystem paths) when they should be strictly abstract string/primitive representations.
+
+## Evidence
+
+- path: "src/domain/ports/fs.rs"
+  loc: "Lines 3, 10-20"
+  note: "Imports `std::path::{Path, PathBuf}` and uses them in all port method signatures (`exists`, `read_to_string`, `read_dir`, `write`, `create_dir_all`)."
+- path: "src/domain/ports/identity_store.rs"
+  loc: "Lines 3, 21"
+  note: "Imports `std::path::PathBuf` and uses it as the return type for the `identity_path` method."
+
+## Change Scope
+
+- `src/domain/ports/fs.rs`
+- `src/domain/ports/identity_store.rs`
+- `src/adapters/fs/std_fs.rs`
+- `src/adapters/identity_store/local_json.rs`
+- `src/app/commands/*`


### PR DESCRIPTION
Emitted two high-signal observer events representing structural arch violations. The application orchestration layer currently uses `std::fs` heavily instead of relying completely on `FsPort`, and the domain layer currently depends heavily on `std::path::Path` and `std::path::PathBuf` structs, entangling it with host filesystem concepts.

---
*PR created automatically by Jules for task [6787419237229054323](https://jules.google.com/task/6787419237229054323) started by @akitorahayashi*