### PR TITLE
Emit events identifying global test state leaks and untestable application boundaries

### DIFF
--- a/.jules/exchange/events/global_state_leak_integration_tests_qa.md
+++ b/.jules/exchange/events/global_state_leak_integration_tests_qa.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2025-01-14"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The integration testing harness (`TestContext`) isolates the current working directory but fails to isolate global user state (the `HOME` environment variable). This allows CLI tests to inadvertently read from or write to the host developer's actual configuration (`~/.config/mev/identity.json`).
+
+## Goal
+
+Ensure complete environment isolation for CLI integration tests by overriding `HOME` to a temporary directory within the test harness, preventing accidental host state mutation and guaranteeing deterministic test runs regardless of the developer's local setup.
+
+## Context
+
+Tests are developer tooling that must be deterministically safe. Because `TestContext::cli()` does not overwrite `HOME`, commands like `mev identity set` or `mev switch` executed during a test run will reach out to `dirs::home_dir()` (the actual host machine's home directory) via the `IdentityFileStore`. This violates the "Isolation By Design" principle by introducing shared mutable state between the host machine and the test runner.
+
+## Evidence
+
+- path: "tests/harness/test_context.rs"
+  loc: "line 29-34"
+  note: "`TestContext::cli()` sets the current working directory via `cmd.current_dir(&self.work_dir)`, but does not override `HOME` using `cmd.env(\"HOME\", &self.work_dir)`."
+
+## Change Scope
+
+- `tests/harness/test_context.rs`

--- a/.jules/exchange/events/untestable_app_layer_qa.md
+++ b/.jules/exchange/events/untestable_app_layer_qa.md
@@ -1,0 +1,29 @@
+---
+label: "refacts"
+created_at: "2025-01-14"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The application layer (`DependencyContainer`) wires concrete adapter implementations (e.g., `GitCli`, `JjCli`, `IdentityFileStore`) directly to the application context instead of using domain port abstractions (e.g., `Box<dyn GitPort>`). This prevents injecting test doubles to unit-test the command orchestration logic.
+
+## Goal
+
+Refactor `DependencyContainer` to hold trait objects (or use generics) for its port dependencies, enabling the injection of in-memory test doubles (from `src/testing/mod.rs`) so that the command orchestration logic in `src/app/commands/` can be unit tested without side effects.
+
+## Context
+
+The core value of the ports-and-adapters architecture is the ability to test pure logic without side effects. Currently, `src/app/commands/` handles command orchestration (e.g., switching identities, backing up files). However, because `DependencyContainer` relies on concrete types, this logic cannot be unit tested in isolation. We are forced to rely entirely on slow, integration-level tests (`tests/cli/`) that execute real I/O. Testing pure orchestration logic via slow integration tests is an anti-pattern that impacts the feedback-speed design.
+
+## Evidence
+
+- path: "src/app/container.rs"
+  loc: "line 17-26"
+  note: "`DependencyContainer` struct fields are typed to concrete adapters (`pub git: GitCli`) instead of traits (`pub git: Box<dyn GitPort>`)."
+
+## Change Scope
+
+- `src/app/container.rs`
+- `src/app/api.rs`


### PR DESCRIPTION
This PR addresses test isolation and dependency injection flaws found during the QA observer codebase evaluation.

- Emits `global_state_leak_integration_tests_qa.md` documenting the failure to override the `HOME` environment variable in the integration test harness, which allows tests to accidentally read from or mutate the host developer's actual state.
- Emits `untestable_app_layer_qa.md` documenting that the `DependencyContainer` relies on concrete adapter implementations rather than domain port abstractions, preventing the injection of in-memory test doubles to verify the command orchestration logic.

---
*PR created automatically by Jules for task [5344903166780868470](https://jules.google.com/task/5344903166780868470) started by @akitorahayashi*