### PR TITLE
docs(README): clarify external ansible execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 macOS development environment provisioning CLI.
 
-Rust-first architecture with embedded Ansible assets.
+Rust-first architecture with embedded Ansible assets (playbooks and roles), orchestrating an external `ansible-playbook` binary installed on the host via `pipx`.
 
 ## Canonical Model
 


### PR DESCRIPTION
Update README.md to clearly state that the `ansible-playbook` binary must be installed on the host system via `pipx`. This resolves the contradiction where the README previously claimed "embedded Ansible assets" without clarifying the execution engine.

---
*PR created automatically by Jules for task [17737692103107602124](https://jules.google.com/task/17737692103107602124) started by @akitorahayashi*