### PR TITLE
test: Isolate HOME environment variable in test harness

### DIFF
--- a/tests/harness/test_context.rs
+++ b/tests/harness/test_context.rs
@@ -31,6 +31,7 @@ impl TestContext {
         let bin_path = assert_cmd::cargo::cargo_bin!("mev");
         let mut cmd = Command::new(bin_path);
         cmd.current_dir(&self.work_dir);
+        cmd.env("HOME", &self.work_dir);
         cmd
     }
 


### PR DESCRIPTION
Ensure complete environment isolation for CLI integration tests by overriding the `HOME` environment variable to a temporary directory in `tests/harness/test_context.rs`.

---
*PR created automatically by Jules for task [6168948560586731134](https://jules.google.com/task/6168948560586731134) started by @akitorahayashi*