### PR TITLE
Add `data_arch` observer event findings for domain boundaries

### DIFF
--- a/.jules/exchange/events/domain_cli_parsing_leak_data_arch.md
+++ b/.jules/exchange/events/domain_cli_parsing_leak_data_arch.md
@@ -1,0 +1,45 @@
+---
+label: "refacts"
+created_at: "2026-03-13"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Domain models contain CLI-specific string input parsing logic and aliases.
+
+## Goal
+
+Move input alias definition and resolution logic out of domain models and into the CLI adapter layer where it belongs.
+
+## Context
+
+Boundary Sovereignty dictates that domain models must not handle transport/UI concerns. Currently, `Profile`, `SwitchIdentity`, and `tag` models define CLI string aliases (e.g., "mbk", "p", "rust" expanding to "rust-platform") and the logic to parse user strings into domain types. This validation and mapping should be handled by the adapter/CLI boundary.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "Profile::aliases"
+  note: "Defines CLI aliases like 'mbk' for 'macbook'."
+- path: "src/domain/profile.rs"
+  loc: "resolve_profile"
+  note: "Parses CLI input strings into Profile types."
+- path: "src/domain/vcs_identity.rs"
+  loc: "resolve_switch_identity"
+  note: "Parses CLI input strings into SwitchIdentity types."
+- path: "src/domain/tag.rs"
+  loc: "tag_groups"
+  note: "Defines CLI tag expansion groups."
+- path: "src/domain/tag.rs"
+  loc: "resolve_tags"
+  note: "Expands CLI input strings into concrete tags."
+
+## Change Scope
+
+- `src/domain/profile.rs`
+- `src/domain/vcs_identity.rs`
+- `src/domain/tag.rs`
+- `src/app/cli/make.rs`
+- `src/app/cli/switch.rs`
+- `src/app/cli/create.rs`

--- a/.jules/exchange/events/domain_io_coupling_data_arch.md
+++ b/.jules/exchange/events/domain_io_coupling_data_arch.md
@@ -1,0 +1,29 @@
+---
+label: "refacts"
+created_at: "2026-03-13"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Domain pure logic ports are coupled to `std::path::PathBuf`.
+
+## Goal
+
+Decouple the `IdentityStore` port from standard library file system paths, using stringly or domain-specific identifiers instead if needed.
+
+## Context
+
+Domain pure logic ports must abstract file system concepts away. The `IdentityStore` trait currently exposes `identity_path() -> PathBuf`, forcing the domain layer to understand that identities are stored on a file system using paths.
+
+## Evidence
+
+- path: "src/domain/ports/identity_store.rs"
+  loc: "IdentityStore::identity_path"
+  note: "Returns a `std::path::PathBuf`, coupling the port to the file system."
+
+## Change Scope
+
+- `src/domain/ports/identity_store.rs`
+- `src/adapters/identity_store/local_json.rs`

--- a/.jules/exchange/events/domain_persistence_leak_data_arch.md
+++ b/.jules/exchange/events/domain_persistence_leak_data_arch.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2026-03-13"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Domain models are directly coupled to persistence serialization frameworks.
+
+## Goal
+
+Decouple domain models from persistence concerns by removing `serde` derivations and separating transport/storage types from core facts.
+
+## Context
+
+First Principles demand Boundary Sovereignty: keeping domain models independent of transport or runtime concerns. Currently, `VcsIdentity` and `IdentityState` derive `serde::Serialize` and `serde::Deserialize`, which couples core business rules to the JSON persistence format used by the local adapter.
+
+## Evidence
+
+- path: "src/domain/vcs_identity.rs"
+  loc: "VcsIdentity"
+  note: "Derives `serde::Serialize` and `serde::Deserialize`."
+- path: "src/domain/ports/identity_store.rs"
+  loc: "IdentityState"
+  note: "A top-level model stored on disk deriving serde traits."
+
+## Change Scope
+
+- `src/domain/vcs_identity.rs`
+- `src/domain/ports/identity_store.rs`
+- `src/adapters/identity_store/local_json.rs`


### PR DESCRIPTION
This PR introduces three new event artifacts under `.jules/exchange/events` generated by the `data_arch` observer role.

These findings analyze the data model boundaries across the repository and outline necessary refactoring goals to:
1. Stop `VcsIdentity` and `IdentityState` from deriving direct JSON persistence traits (`serde`).
2. Move CLI transport logic (like `Profile`, `SwitchIdentity`, and `tag` string alias mappings) out of the pure domain and into the adapter/CLI boundary.
3. Remove the standard library's filesystem types (`PathBuf`) from domain pure logic ports (`IdentityStore`).

---
*PR created automatically by Jules for task [8679614768904976346](https://jules.google.com/task/8679614768904976346) started by @akitorahayashi*