### PR TITLE
chore: Emit devops observer events

### DIFF
--- a/.jules/exchange/events/missing_automation_topology_devops.md
+++ b/.jules/exchange/events/missing_automation_topology_devops.md
@@ -1,0 +1,38 @@
+---
+label: "docs"
+created_at: "2026-03-14"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+The repository lacks a centralized automation topology contract (`docs/automation_topology.md`), and execution surfaces do not reference it.
+
+## Goal
+
+Establish a single source of truth for automation policies and enforce its reference across all execution surfaces to ensure consistency and prevent source-of-truth drift.
+
+## Context
+
+According to the memory rules, the repository uses `docs/automation_topology.md` as the single source of truth for automation policies. Execution surfaces (like `justfile` and `.github/workflows/*.yml`) must include the inline header `# Automation Topology Source: docs/automation_topology.md`. Currently, the documentation file is missing, and the execution surfaces do not contain the required header.
+
+## Evidence
+
+- path: "docs/automation_topology.md"
+  loc: "file"
+  note: "File does not exist in the repository."
+
+- path: "justfile"
+  loc: "line 1"
+  note: "Missing `# Automation Topology Source: docs/automation_topology.md` header."
+
+- path: ".github/workflows/ci-workflows.yml"
+  loc: "line 1"
+  note: "Missing `# Automation Topology Source: docs/automation_topology.md` header."
+
+## Change Scope
+
+- `docs/automation_topology.md`
+- `justfile`
+- `.github/workflows/*.yml`

--- a/.jules/exchange/events/unpinned_system_dependencies_devops.md
+++ b/.jules/exchange/events/unpinned_system_dependencies_devops.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+External tool dependencies, specifically Homebrew packages (`shellcheck`, `shfmt`, `mise`) and Python pipx packages (`ansible`), are not pinned to specific versions in GitHub workflow and action definitions.
+
+## Goal
+
+Pin all external system dependencies in execution paths to guarantee determinism, isolate test signals from upstream supply chain mutations, and improve reproducibility.
+
+## Context
+
+Implicit trust of mutable external artifacts breaks deterministic execution. Unpinned tools like linters (`shellcheck`, `shfmt`) or runners (`mise`, `ansible`) can introduce breaking changes silently, creating CI flakiness and masking actual codebase errors. Trust boundaries must be explicit, and dependencies must be pinned to enforce operational integrity.
+
+## Evidence
+
+- path: ".github/workflows/run-linters.yml"
+  loc: "line 29"
+  note: "Unpinned Homebrew installation: `brew install shellcheck shfmt`."
+
+- path: ".github/workflows/collect-coverage.yml"
+  loc: "line 28"
+  note: "Unpinned Homebrew installation: `brew install mise`."
+
+- path: ".github/actions/setup-base/action.yml"
+  loc: "line 20"
+  note: "Unpinned pipx installation: `python -m pipx install --force ansible`."
+
+## Change Scope
+
+- `.github/workflows/run-linters.yml`
+- `.github/workflows/collect-coverage.yml`
+- `.github/actions/setup-base/action.yml`


### PR DESCRIPTION
Emitted two observer events from the devops perspective.
1. `missing_automation_topology_devops.md`: Flagged missing source of truth for automation policies (`docs/automation_topology.md`).
2. `unpinned_system_dependencies_devops.md`: Flagged unpinned CI toolchain dependencies (e.g. `shellcheck`, `shfmt`, `ansible`) breaking reproducibility.

---
*PR created automatically by Jules for task [14655591513909506459](https://jules.google.com/task/14655591513909506459) started by @akitorahayashi*