### PR TITLE
docs: generate rustacean observer event files

### DIFF
--- a/.jules/exchange/events/application_io_side_effects_rustacean.md
+++ b/.jules/exchange/events/application_io_side_effects_rustacean.md
@@ -1,0 +1,49 @@
+---
+label: "refacts"
+created_at: "2024-05-16"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Application orchestration commands bypass the port/adapter boundary and perform I/O side effects directly. `src/app/commands/deploy_configs.rs` manipulates the file system via `std::fs` and `src/app/commands/backup/mod.rs` accesses the `HOME` environment variable via `std::env::var`.
+
+## Goal
+
+All file system manipulations and system interactions in the application layer must be delegated to the abstract `FsPort` or other relevant ports. The application layer must not import `std::fs` or `std::path` directly or use `std::env::var`.
+
+## Context
+
+According to the Architecture Rule (Application I/O Side Effects), application orchestration commands must not bypass the port/adapter boundary to perform I/O side effects directly. All file system manipulations must be delegated to the abstract `FsPort`. Similarly, system environment variables should be accessed via a port or provided via dependency injection rather than accessed globally.
+
+## Evidence
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "use std::path::Path;"
+  note: "Imports std::path directly."
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "std::fs::remove_dir_all(&target)"
+  note: "Bypasses FsPort to manipulate the filesystem."
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "std::fs::create_dir_all(dst)?;"
+  note: "Bypasses FsPort to manipulate the filesystem."
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "std::fs::read_dir(src)?;"
+  note: "Bypasses FsPort to manipulate the filesystem."
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "std::fs::copy(&src_path, &dst_path)?;"
+  note: "Bypasses FsPort to manipulate the filesystem."
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "std::env::var(\"HOME\")"
+  note: "Bypasses the port boundary to access the environment directly."
+
+## Change Scope
+
+- `src/app/commands/deploy_configs.rs`
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/domain_io_decoupling_rustacean.md
+++ b/.jules/exchange/events/domain_io_decoupling_rustacean.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2024-05-16"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Domain pure logic ports (`FsPort` and `IdentityStore`) leak file system concepts by exposing `std::path::{Path, PathBuf}` directly in their trait signatures.
+
+## Goal
+
+Abstract file system concepts away and avoid `std::path` types in domain ports. Primitive types like `&str` or `String` should be used instead to properly decouple I/O concerns from domain concepts.
+
+## Context
+
+According to the Architecture Rule (Domain I/O Decoupling), domain pure logic ports must abstract file system concepts away and avoid `std::path` types to properly decouple I/O concerns. Using `Path` or `PathBuf` binds the domain model directly to the host operating system's filesystem abstractions.
+
+## Evidence
+
+- path: "src/domain/ports/fs.rs"
+  loc: "use std::path::{Path, PathBuf};"
+  note: "FsPort leaks std::path::Path and std::path::PathBuf in trait method signatures."
+
+- path: "src/domain/ports/identity_store.rs"
+  loc: "use std::path::PathBuf;"
+  note: "IdentityStore leaks std::path::PathBuf in trait method signatures."
+
+## Change Scope
+
+- `src/domain/ports/fs.rs`
+- `src/domain/ports/identity_store.rs`


### PR DESCRIPTION
I have successfully investigated the codebase as a "rustacean" observer and generated event files mapping out the key invariant and boundaries violations found.

The generated event files fall into the scope constraint of exactly 2 event files containing file-level evidence:
1. `.jules/exchange/events/domain_io_decoupling_rustacean.md` - Addresses Domain I/O Decoupling architecture rule violations where domain pure logic ports leak file system concepts.
2. `.jules/exchange/events/application_io_side_effects_rustacean.md` - Addresses Application I/O Side Effects architecture rule violations where orchestration commands bypass the port boundary.

Tests run via `just check` and `just test` confirm no regressions were introduced.

---
*PR created automatically by Jules for task [322735406913763783](https://jules.google.com/task/322735406913763783) started by @akitorahayashi*