### PR TITLE
Emit taxonomy events for naming consistency

### DIFF
--- a/.jules/exchange/events/ambiguous_rust_names_taxonomy.md
+++ b/.jules/exchange/events/ambiguous_rust_names_taxonomy.md
@@ -1,0 +1,44 @@
+---
+label: "refacts"
+created_at: "2026-03-13"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+Ambiguous terms like `base`, `helpers`, and `common` are used as file, module, and struct names or concepts, violating the rule: "Class and file must not have ambiguous names or responsibilities such as base, common, core, utils, or helpers."
+
+## Goal
+
+Rename ambiguous variables, functions, structs, and modules to specific domain terms. E.g., `Profile::Common`, `config_base()`.
+
+## Context
+
+Ambiguous names hide responsibilities and make discovering functionality harder. They should be replaced with names defining specific single responsibilities.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "Profile::Common"
+  note: "Common is an ambiguous profile name; it should reflect its actual responsibility (e.g. Default or Shared)."
+- path: "src/domain/backup_target.rs"
+  loc: "\"common\""
+  note: "Subpath uses the term 'common'."
+- path: "src/adapters/identity_store/paths.rs"
+  loc: "config_base"
+  note: "Function named config_base() uses ambiguous term 'base'."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "// Shared helpers"
+  note: "Comments use the prohibited term 'helpers'."
+- path: "src/app/cli/mod.rs"
+  loc: "/// Git helpers."
+  note: "Comments use the prohibited term 'helpers'."
+
+## Change Scope
+
+- `src/domain/profile.rs`
+- `src/domain/backup_target.rs`
+- `src/adapters/identity_store/paths.rs`
+- `src/app/commands/backup/mod.rs`
+- `src/app/cli/mod.rs`

--- a/.jules/exchange/events/ansible_role_common_directory_taxonomy.md
+++ b/.jules/exchange/events/ansible_role_common_directory_taxonomy.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2026-03-13"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The `common` directory name is extensively used within `src/assets/ansible/roles/*/config/common`, violating the naming rule prohibiting ambiguous names like `common`.
+
+## Goal
+
+Rename the `common` directories to a specific domain term reflecting their single responsibility, such as `default` or `shared_config`.
+
+## Context
+
+Ambiguous names like `common` are prohibited as they restate package/directory scope and hide true responsibilities.
+
+## Evidence
+
+- path: "src/assets/ansible/roles/"
+  loc: "config/common"
+  note: "Multiple roles use 'common' as the subdirectory for configuration (e.g. system, shell, nodejs, etc)."
+
+## Change Scope
+
+- `src/assets/ansible/roles/*/config/common`


### PR DESCRIPTION
This submission creates two event files in `.jules/exchange/events/` based on findings by the `taxonomy` observer role.

1.  **ambiguous_rust_names_taxonomy.md**: Identifies the use of ambiguous terms (`base`, `helpers`, `common`) across several Rust files (`src/domain/profile.rs`, `src/adapters/identity_store/paths.rs`, `src/app/commands/backup/mod.rs`, etc.), violating the explicit repository naming rules.
2.  **ansible_role_common_directory_taxonomy.md**: Identifies the persistent use of `common` as a directory name within `src/assets/ansible/roles/*/config/common`, which also violates the naming rules and obscures the specific responsibility of those directories.

Both events are properly formatted according to `.jules/schemas/observers/event.md`, use the `refacts` label, and include concrete `loc` and `note` evidence. I verified that the changes don't introduce any test failures.

---
*PR created automatically by Jules for task [15353834998940861717](https://jules.google.com/task/15353834998940861717) started by @akitorahayashi*