### PR TITLE
Generate QA observer events

### DIFF
--- a/.jules/exchange/events/fs_abstraction_bypass_qa.md
+++ b/.jules/exchange/events/fs_abstraction_bypass_qa.md
@@ -1,0 +1,39 @@
+---
+label: "refacts"
+created_at: "2024-05-15"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Multiple pure logic parts and adapters bypass the `FsPort` abstraction to interact directly with the standard filesystem via `std::fs` and `std::path::PathBuf`. For example, `IdentityFileStore` contains direct calls to `std::fs::read_to_string`, `std::fs::create_dir_all`, and `std::fs::write`. Similar issues exist within `src/app/commands/config/mod.rs` and `src/app/commands/deploy_configs.rs`.
+
+## Goal
+
+Ensure that pure domain logic layers and infrastructure boundaries rely entirely on injected port abstractions rather than the direct usage of side-effect-producing components like `std::fs`. Adhere to the `FsPort` interface where filesystem concepts are concerned.
+
+## Context
+
+Bypassing filesystem port abstractions makes unit testing domain logic complex, slow, and non-deterministic because it relies on the real host filesystem state. This breaks the isolation-by-design testing principle and violates domain I/O decoupling rules since internal implementations shouldn't possess knowledge of hardcoded IO operations. Abstracting these I/O operations strictly through the boundary interfaces ensures side-effect-free test doubles can be correctly injected.
+
+## Evidence
+
+- path: "src/adapters/identity_store/local_json.rs"
+  loc: "IdentityStore::load"
+  note: "Directly uses `std::fs::read_to_string` to read from the identity config path."
+- path: "src/adapters/identity_store/local_json.rs"
+  loc: "IdentityStore::save"
+  note: "Directly uses `std::fs::create_dir_all`, `std::fs::write`, and `std::fs::rename` to manipulate the JSON configuration state."
+- path: "src/app/commands/config/mod.rs"
+  loc: "execute"
+  note: "Uses `std::fs::remove_dir_all` and `std::fs::rename` directly to configure the staging target configs instead of port abstractions."
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "execute"
+  note: "Uses `std::fs::remove_dir_all` to clean target deployments before recreating."
+
+## Change Scope
+
+- `src/adapters/identity_store/local_json.rs`
+- `src/app/commands/config/mod.rs`
+- `src/app/commands/deploy_configs.rs`

--- a/.jules/exchange/events/std_env_bypass_qa.md
+++ b/.jules/exchange/events/std_env_bypass_qa.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2024-05-15"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Application domain orchestration logic uses direct operating system environment access `std::env::var` (like `std::env::var("HOME")` inside `src/app/commands/backup/mod.rs`), which bypasses environment abstractions and prevents reliable sandboxing or injecting alternate environment variables during tests.
+
+## Goal
+
+Remove direct reads from `std::env` inside domain commands to prevent logic from coupling tightly to the host execution environment state. State should be captured implicitly by dependency injection paths (like `local_config_root` resolving HOME previously) or provided explicitly as injected variables through a defined port boundary context.
+
+## Context
+
+Relying on direct `std::env` polling in internal business logic violates dependency injection architectural rules and the principle of determinism. This results in global state that tests cannot control safely across thread executions (like the concurrent Rust runner) without producing race conditions. By ensuring all context resolves via pure logic parameters passed down from the top-level application boundaries, testability and determinism are enforced.
+
+## Evidence
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "format_string"
+  note: "Directly calls `std::env::var(\"HOME\")` to format string values, binding the application logic to the host machine's state without dependency inversion."
+
+## Change Scope
+
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/test_isolation_flakiness_qa.md
+++ b/.jules/exchange/events/test_isolation_flakiness_qa.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2024-05-15"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The CLI contract tests instantiate multiple `TestContext` structs implicitly via `TestContext::new()`. During cargo's parallel test execution, multiple `TestContext::new()` calls map to parallel operations that set environment variables (like `HOME`). The Rust testing harness for modifying global environment variables without serial execution leads to race conditions, flakiness, or test failures across independent test runs.
+
+## Goal
+
+Ensure all integration tests that rely on shared environmental context state overrides are isolated explicitly and run serially using the `serial_test` crate.
+
+## Context
+
+Running integration and cli contract tests concurrently through Rust's default test harness means multiple processes/threads can interfere with each other if they are sharing mutable states such as test working directories and overriding standard environment variables `HOME`. This is an anti-pattern as described in the testing principles regarding isolating tests by design and preventing flakes at the source.
+
+## Evidence
+
+- path: "tests/harness/test_context.rs"
+  loc: "TestContext::cli"
+  note: "This sets the HOME environment variable for the testing command, which affects integration tests that depend on checking global env configurations."
+- path: "tests/cli/switch.rs"
+  loc: "switch_help_shows_identity_argument"
+  note: "Like many other CLI tests, it instantiates `TestContext::new()` and runs concurrently with other tests."
+
+## Change Scope
+
+- `tests/cli/*.rs`
+- `tests/harness/test_context.rs`


### PR DESCRIPTION
Emitted QA observer event files for:
1. Test isolation flakiness due to concurrent tests mutating `HOME`.
2. FS abstraction bypass by directly using `std::fs` inside domain/adapters.
3. Standard environment bypass by calling `std::env::var` inside application domain logic.

---
*PR created automatically by Jules for task [4362999325548311836](https://jules.google.com/task/4362999325548311836) started by @akitorahayashi*