### PR TITLE
docs: emit cli sentinel observer events

### DIFF
--- a/.jules/exchange/events/backup_list_option_cli_sentinel.md
+++ b/.jules/exchange/events/backup_list_option_cli_sentinel.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+The `backup` command uses a `--list` (or `-l`) option to alter the primary execution verb (from "backup" to "list"), breaking the structural consistency of the CLI commands.
+
+## Goal
+
+Ensure the CLI commands adhere to the strict 'verb [object] arguments' structure and options do not substitute a required object or alter the primary execution verb.
+
+## Context
+
+Using an option to perform a distinct action (like listing available targets instead of performing a backup) violates the CLI Command Structure design rule. Options should only be used for additive behavior, limited-use edge cases, modifying existing behavior, output/safety control, or explicit override of auto-resolved context. A separate subcommand (e.g., `mev backup list` or integrating into `mev list`) should be used for this distinct action.
+
+## Evidence
+
+- path: "src/app/cli/backup.rs"
+  loc: "BackupArgs"
+  note: "The `list` boolean flag is defined as an option that alters the command's primary behavior."
+- path: "src/app/cli/backup.rs"
+  loc: "run"
+  note: "The `run` function branches its execution based on the `list` flag, either calling `commands::backup::list_targets()` or `commands::backup::execute()`, demonstrating that the option changes the primary execution verb."
+
+## Change Scope
+
+- `src/app/cli/backup.rs`
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/io_separation_violation_cli_sentinel.md
+++ b/.jules/exchange/events/io_separation_violation_cli_sentinel.md
@@ -1,0 +1,43 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+Multiple commands (`create`, `make`, `backup`, `update`, `config`, `switch`, `identity`) write human-readable diagnostics, progress indicators, and logs to `stdout` (`println!`), violating the CLI I/O separation contract.
+
+## Goal
+
+Ensure that CLI tools strictly output only structured, script-parseable result data to `stdout`, and write all human-readable diagnostics, progress indicators, logs, and errors to `stderr` (`eprintln!`).
+
+## Context
+
+The Domain I/O Decoupling and CLI I/O Separation rules mandate that `stdout` must carry result data and `stderr` must carry warnings, logs, and errors. Mixed streams break automation pipelines (e.g., piping results to `jq` fails if logs pollute `stdout`).
+
+## Evidence
+
+- path: "src/app/commands/create/mod.rs"
+  loc: "execute"
+  note: "Writes progress indicators (e.g., `println!(\"mev: Creating {} environment\", plan.profile);`, `println!(\"[{step}/{total}] Running: {tag}\");`) to stdout."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "execute"
+  note: "Writes progress messages (e.g., `println!(\"Running backup: {}\", target.description());`, `println!(\"✓ Backup completed successfully!\");`) to stdout."
+- path: "src/app/commands/update/mod.rs"
+  loc: "execute"
+  note: "Writes log messages to stdout (e.g., `println!(\"Running upgrade...\");`)."
+- path: "src/app/commands/switch/mod.rs"
+  loc: "execute"
+  note: "Writes log messages to stdout (e.g., `println!(\"Switching to {} identity...\", identity);`)."
+
+## Change Scope
+
+- `src/app/commands/backup/mod.rs`
+- `src/app/commands/config/mod.rs`
+- `src/app/commands/create/mod.rs`
+- `src/app/commands/identity/mod.rs`
+- `src/app/commands/make/mod.rs`
+- `src/app/commands/switch/mod.rs`
+- `src/app/commands/update/mod.rs`


### PR DESCRIPTION
Emitted two `cli_sentinel` observer events targeting structural drift and I/O separation violations in the CLI design:
- `.jules/exchange/events/backup_list_option_cli_sentinel.md`: Flags the use of the `--list` option on the `backup` command as an improper modifier of the primary execution verb.
- `.jules/exchange/events/io_separation_violation_cli_sentinel.md`: Flags violations of the CLI I/O separation contract across multiple commands where human-readable logs and progress are printed to `stdout` instead of `stderr`.

---
*PR created automatically by Jules for task [12658104707334857669](https://jules.google.com/task/12658104707334857669) started by @akitorahayashi*