### PR TITLE
refactor: emit structural arch events for I/O decoupling

### DIFF
--- a/.jules/exchange/events/application_io_side_effects_structural_arch.md
+++ b/.jules/exchange/events/application_io_side_effects_structural_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+The application layer performs side-effecting I/O directly via `std::fs` operations, bypassing the port/adapter boundary (`FsPort`).
+
+## Goal
+
+Delegate all local file system mutations to `FsPort` to ensure I/O constraints are decoupled from the application logic orchestration and to permit injecting test doubles for unit-testing.
+
+## Context
+
+Per the "Architecture Rule (Application I/O Side Effects)", application orchestration commands must not bypass the port/adapter boundary. Direct usage of `std::fs` and `std::path` creates a hidden coupling and prevents proper dependency injection in test suites.
+
+## Evidence
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "42-74"
+  note: "Directly uses `std::fs::remove_dir_all`, `std::fs::create_dir_all`, `std::fs::read_dir`, and `std::fs::copy`."
+- path: "src/app/commands/config/mod.rs"
+  loc: "43-71"
+  note: "Directly uses `std::fs::remove_dir_all`, `std::fs::rename`, `std::fs::create_dir_all`, `std::fs::read_dir`, and `std::fs::copy`."
+
+## Change Scope
+
+- `src/app/commands/deploy_configs.rs`
+- `src/app/commands/config/mod.rs`

--- a/.jules/exchange/events/domain_io_entanglement_structural_arch.md
+++ b/.jules/exchange/events/domain_io_entanglement_structural_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+Domain logic ports (`FsPort` and `IdentityStore`) are tightly coupled to standard library filesystem concepts (`std::path::Path` and `std::path::PathBuf`).
+
+## Goal
+
+Decouple the domain interface from filesystem implementations by replacing `Path` and `PathBuf` types with domain-appropriate generic or primitive types like `&str` and `String`.
+
+## Context
+
+Per the "Architecture Rule (Domain I/O Decoupling)", domain pure logic ports must abstract file system concepts away. Currently, they embed `std::path` structures which violate boundary enforcement, leaking infrastructure concerns into the domain boundary.
+
+## Evidence
+
+- path: "src/domain/ports/fs.rs"
+  loc: "FsPort"
+  note: "FsPort relies on `std::path::{Path, PathBuf}` for path parameters and returns, coupling the interface strictly to local disk assumptions."
+- path: "src/domain/ports/identity_store.rs"
+  loc: "IdentityStore"
+  note: "IdentityStore returns a `std::path::PathBuf` from `identity_path`, tying the abstraction to the file system instead of a generic identifier."
+- path: "crates/mev-internal/src/domain/submodule_path.rs"
+  loc: "validate_submodule_path"
+  note: "Uses `std::path::Path` to validate submodule paths, even though submodules are inherently Git-specific strings, bleeding OS-level filesystem normalization logic into the domain."
+
+## Change Scope
+
+- `src/domain/ports/fs.rs`
+- `src/domain/ports/identity_store.rs`
+- `crates/mev-internal/src/domain/submodule_path.rs`


### PR DESCRIPTION
Emitted two high-signal `structural_arch` events:
1. `domain_io_entanglement_structural_arch.md`: Highlights the leaking of filesystem concepts into the domain logic layer via `std::path` in `FsPort`, `IdentityStore`, and `submodule_path`.
2. `application_io_side_effects_structural_arch.md`: Highlights the application layer directly interacting with `std::fs` to perform side-effecting operations without using the `FsPort`.

---
*PR created automatically by Jules for task [1026826311077782665](https://jules.google.com/task/1026826311077782665) started by @akitorahayashi*