### PR TITLE
Emit Rustacean Observer Events

### DIFF
--- a/.jules/exchange/events/application_io_side_effects_structural_arch.md
+++ b/.jules/exchange/events/application_io_side_effects_structural_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+The application layer performs side-effecting I/O directly via `std::fs` operations, bypassing the port/adapter boundary (`FsPort`).
+
+## Goal
+
+Delegate all local file system mutations to `FsPort` to ensure I/O constraints are decoupled from the application logic orchestration and to permit injecting test doubles for unit-testing.
+
+## Context
+
+Per the "Architecture Rule (Application I/O Side Effects)", application orchestration commands must not bypass the port/adapter boundary. Direct usage of `std::fs` and `std::path` creates a hidden coupling and prevents proper dependency injection in test suites.
+
+## Evidence
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "42-74"
+  note: "Directly uses `std::fs::remove_dir_all`, `std::fs::create_dir_all`, `std::fs::read_dir`, and `std::fs::copy`."
+- path: "src/app/commands/config/mod.rs"
+  loc: "43-71"
+  note: "Directly uses `std::fs::remove_dir_all`, `std::fs::rename`, `std::fs::create_dir_all`, `std::fs::read_dir`, and `std::fs::copy`."
+
+## Change Scope
+
+- `src/app/commands/deploy_configs.rs`
+- `src/app/commands/config/mod.rs`

--- a/.jules/exchange/events/backup_list_option_cli_sentinel.md
+++ b/.jules/exchange/events/backup_list_option_cli_sentinel.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+The `backup` command uses a `--list` (or `-l`) option to alter the primary execution verb (from "backup" to "list"), breaking the structural consistency of the CLI commands.
+
+## Goal
+
+Ensure the CLI commands adhere to the strict 'verb [object] arguments' structure and options do not substitute a required object or alter the primary execution verb.
+
+## Context
+
+Using an option to perform a distinct action (like listing available targets instead of performing a backup) violates the CLI Command Structure design rule. Options should only be used for additive behavior, limited-use edge cases, modifying existing behavior, output/safety control, or explicit override of auto-resolved context. A separate subcommand (e.g., `mev backup list` or integrating into `mev list`) should be used for this distinct action.
+
+## Evidence
+
+- path: "src/app/cli/backup.rs"
+  loc: "BackupArgs"
+  note: "The `list` boolean flag is defined as an option that alters the command's primary behavior."
+- path: "src/app/cli/backup.rs"
+  loc: "run"
+  note: "The `run` function branches its execution based on the `list` flag, either calling `commands::backup::list_targets()` or `commands::backup::execute()`, demonstrating that the option changes the primary execution verb."
+
+## Change Scope
+
+- `src/app/cli/backup.rs`
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/cli_aliases_in_domain_data_arch.md
+++ b/.jules/exchange/events/cli_aliases_in_domain_data_arch.md
@@ -1,0 +1,43 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Core domain models contain CLI-specific string input parsing logic and aliases, violating Boundary Sovereignty and I/O decoupling rules.
+
+## Goal
+
+Move CLI input mapping, alias resolution, and string parsing to the adapter or application CLI layer, keeping domain models pure and independent of transport concerns.
+
+## Context
+
+The architecture rules mandate that domain pure logic ports abstract file system concepts and I/O away. Specifically, domain input parsing must not contain CLI-specific string input aliases. Validation and UI mapping should exclusively be handled by the adapter or application CLI layer. Currently, domain models like `SwitchIdentity`, `Profile`, and `BackupTarget` directly handle string resolution and CLI aliases.
+
+## Evidence
+
+- path: "src/domain/vcs_identity.rs"
+  loc: "SWITCH_IDENTITY_ALIASES"
+  note: "Defines CLI aliases for identity resolution directly in the domain model."
+- path: "src/domain/vcs_identity.rs"
+  loc: "resolve_switch_identity"
+  note: "Implements string-to-enum resolution using CLI aliases."
+- path: "src/domain/profile.rs"
+  loc: "PROFILE_ALIASES"
+  note: "Defines CLI aliases for profile resolution in the domain layer."
+- path: "src/domain/backup_target.rs"
+  loc: "BackupTarget::from_input"
+  note: "Implements CLI input parsing directly within the domain model."
+
+## Change Scope
+
+- `src/domain/vcs_identity.rs`
+- `src/domain/profile.rs`
+- `src/domain/backup_target.rs`
+- `src/app/cli/switch.rs`
+- `src/app/cli/make.rs`
+- `src/app/cli/create.rs`
+- `src/app/cli/backup.rs`

--- a/.jules/exchange/events/config_path_drift_consistency.md
+++ b/.jules/exchange/events/config_path_drift_consistency.md
@@ -1,0 +1,31 @@
+---
+label: "docs"
+created_at: "2026-03-14"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation for the `config create` command in `docs/usage.md` incorrectly states that it deploys all role configs to `~/.config/mev/`, whereas the CLI `--help` and underlying implementation (`src/adapters/identity_store/paths.rs`) show it deploys to `~/.config/mev/roles/`.
+
+## Goal
+
+Update `docs/usage.md` to accurately reflect the correct deployment path (`~/.config/mev/roles/`).
+
+## Context
+
+Consistency between the documentation and the implementation is critical. When users run `mev config create`, they expect the configs to be deposited exactly where the documentation indicates. The current documentation provides an inaccurate path, creating confusion about the config directory structure.
+
+## Evidence
+
+- path: "docs/usage.md"
+  loc: "line 41"
+  note: "The documentation states `mev config create         # Deploy all role configs to ~/.config/mev/`."
+- path: "src/app/cli/config.rs"
+  loc: "line 12"
+  note: "The CLI documentation explicitly defines `Deploy role configs to ~/.config/mev/roles/.`."
+
+## Change Scope
+
+- `docs/usage.md`

--- a/.jules/exchange/events/domain_io_entanglement_structural_arch.md
+++ b/.jules/exchange/events/domain_io_entanglement_structural_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+Domain logic ports (`FsPort` and `IdentityStore`) are tightly coupled to standard library filesystem concepts (`std::path::Path` and `std::path::PathBuf`).
+
+## Goal
+
+Decouple the domain interface from filesystem implementations by replacing `Path` and `PathBuf` types with domain-appropriate generic or primitive types like `&str` and `String`.
+
+## Context
+
+Per the "Architecture Rule (Domain I/O Decoupling)", domain pure logic ports must abstract file system concepts away. Currently, they embed `std::path` structures which violate boundary enforcement, leaking infrastructure concerns into the domain boundary.
+
+## Evidence
+
+- path: "src/domain/ports/fs.rs"
+  loc: "FsPort"
+  note: "FsPort relies on `std::path::{Path, PathBuf}` for path parameters and returns, coupling the interface strictly to local disk assumptions."
+- path: "src/domain/ports/identity_store.rs"
+  loc: "IdentityStore"
+  note: "IdentityStore returns a `std::path::PathBuf` from `identity_path`, tying the abstraction to the file system instead of a generic identifier."
+- path: "crates/mev-internal/src/domain/submodule_path.rs"
+  loc: "validate_submodule_path"
+  note: "Uses `std::path::Path` to validate submodule paths, even though submodules are inherently Git-specific strings, bleeding OS-level filesystem normalization logic into the domain."
+
+## Change Scope
+
+- `src/domain/ports/fs.rs`
+- `src/domain/ports/identity_store.rs`
+- `crates/mev-internal/src/domain/submodule_path.rs`

--- a/.jules/exchange/events/hardcoded_enumerables_data_arch.md
+++ b/.jules/exchange/events/hardcoded_enumerables_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Enumerable values like Ansible tags and profiles are hardcoded in the domain layer rather than being dynamically generated from authoritative sources.
+
+## Goal
+
+Generate enumerable values dynamically from authoritative sources (like Ansible role definitions, catalogs, or registries) to ensure extensibility and eliminate maintenance burden.
+
+## Context
+
+According to the design rules, enumerable values must be generated dynamically from authoritative sources rather than hardcoded. In the codebase, tags required for full setup and profiles are explicitly listed as static slices in the domain models, creating a maintenance burden whenever a new tag or profile is added in the configuration or Ansible roles.
+
+## Evidence
+
+- path: "src/domain/tag.rs"
+  loc: "FULL_SETUP_TAGS"
+  note: "Hardcodes the list of tags for a full environment setup."
+- path: "src/domain/tag.rs"
+  loc: "tag_groups"
+  note: "Hardcodes the mappings of tag groups to specific tags."
+- path: "src/domain/profile.rs"
+  loc: "all_profiles"
+  note: "Hardcodes the available profiles instead of discovering them dynamically."
+
+## Change Scope
+
+- `src/domain/tag.rs`
+- `src/domain/profile.rs`
+- `src/adapters/ansible/locator.rs`

--- a/.jules/exchange/events/invariants_boundaries_rustacean.md
+++ b/.jules/exchange/events/invariants_boundaries_rustacean.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-created_at: "YYYY-MM-DD"
+created_at: "2024-05-23"
 author_role: "rustacean"
 confidence: "high"
 ---

--- a/.jules/exchange/events/io_separation_violation_cli_sentinel.md
+++ b/.jules/exchange/events/io_separation_violation_cli_sentinel.md
@@ -1,0 +1,43 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+Multiple commands (`create`, `make`, `backup`, `update`, `config`, `switch`, `identity`) write human-readable diagnostics, progress indicators, and logs to `stdout` (`println!`), violating the CLI I/O separation contract.
+
+## Goal
+
+Ensure that CLI tools strictly output only structured, script-parseable result data to `stdout`, and write all human-readable diagnostics, progress indicators, logs, and errors to `stderr` (`eprintln!`).
+
+## Context
+
+The Domain I/O Decoupling and CLI I/O Separation rules mandate that `stdout` must carry result data and `stderr` must carry warnings, logs, and errors. Mixed streams break automation pipelines (e.g., piping results to `jq` fails if logs pollute `stdout`).
+
+## Evidence
+
+- path: "src/app/commands/create/mod.rs"
+  loc: "execute"
+  note: "Writes progress indicators (e.g., `println!(\"mev: Creating {} environment\", plan.profile);`, `println!(\"[{step}/{total}] Running: {tag}\");`) to stdout."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "execute"
+  note: "Writes progress messages (e.g., `println!(\"Running backup: {}\", target.description());`, `println!(\"✓ Backup completed successfully!\");`) to stdout."
+- path: "src/app/commands/update/mod.rs"
+  loc: "execute"
+  note: "Writes log messages to stdout (e.g., `println!(\"Running upgrade...\");`)."
+- path: "src/app/commands/switch/mod.rs"
+  loc: "execute"
+  note: "Writes log messages to stdout (e.g., `println!(\"Switching to {} identity...\", identity);`)."
+
+## Change Scope
+
+- `src/app/commands/backup/mod.rs`
+- `src/app/commands/config/mod.rs`
+- `src/app/commands/create/mod.rs`
+- `src/app/commands/identity/mod.rs`
+- `src/app/commands/make/mod.rs`
+- `src/app/commands/switch/mod.rs`
+- `src/app/commands/update/mod.rs`

--- a/.jules/exchange/events/masked_coverage_failures_devops.md
+++ b/.jules/exchange/events/masked_coverage_failures_devops.md
@@ -1,0 +1,28 @@
+---
+label: "bugs"
+created_at: "2025-03-14"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+The test coverage generation step is configured to unconditionally succeed even if the underlying command fails, masking deterministic failures and hiding test signal quality.
+
+## Goal
+
+Remove `continue-on-error: true` from the coverage generation step to ensure failures during coverage collection are explicitly surfaced and block the pipeline.
+
+## Context
+
+Verification gates must produce fast and trustworthy signals for merge decisions. Using `continue-on-error: true` represents a silent fallback pattern that masks underlying execution failures, making it impossible to trust whether the test coverage metric represents a successful execution of the test suite or a failed command that was silently ignored.
+
+## Evidence
+
+- path: ".github/workflows/collect-coverage.yml"
+  loc: "Generate coverage"
+  note: "The step includes `continue-on-error: true` when running `just coverage`, masking any potential failures in coverage tool execution."
+
+## Change Scope
+
+- `.github/workflows/collect-coverage.yml`

--- a/.jules/exchange/events/ownership_allocations_rustacean.md
+++ b/.jules/exchange/events/ownership_allocations_rustacean.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-created_at: "YYYY-MM-DD"
+created_at: "2024-05-23"
 author_role: "rustacean"
 confidence: "high"
 ---

--- a/.jules/exchange/events/scattered_identity_validation_data_arch.md
+++ b/.jules/exchange/events/scattered_identity_validation_data_arch.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The `VcsIdentity` model allows invalid empty states, causing validation logic to be scattered to application layer call sites.
+
+## Goal
+
+Enforce invariants at the boundary by using appropriate types (e.g., a non-empty string type or a constructor that returns an error) so invalid states cannot be represented.
+
+## Context
+
+The First Principles of data architecture require representing valid states only, encoding invariants so invalid states are hard to express. The current `VcsIdentity` uses raw `String` types for name and email, allowing empty strings. This leads to missing validation in the domain, forcing the application layer to manually check for empty strings before use.
+
+## Evidence
+
+- path: "src/domain/vcs_identity.rs"
+  loc: "VcsIdentity"
+  note: "Defines name and email as raw strings without validation."
+- path: "src/app/commands/switch/mod.rs"
+  loc: "execute"
+  note: "Call site manually validates that vcs_identity.name and vcs_identity.email are not empty, proving invariants are not enforced by the type."
+
+## Change Scope
+
+- `src/domain/vcs_identity.rs`
+- `src/app/commands/switch/mod.rs`
+- `src/app/commands/identity/mod.rs`

--- a/.jules/exchange/events/typed_errors_rustacean.md
+++ b/.jules/exchange/events/typed_errors_rustacean.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-created_at: "YYYY-MM-DD"
+created_at: "2024-05-23"
 author_role: "rustacean"
 confidence: "high"
 ---

--- a/.jules/exchange/events/unpinned_tool_dependencies_devops.md
+++ b/.jules/exchange/events/unpinned_tool_dependencies_devops.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2025-03-14"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+External tool dependencies (e.g., pipx, Ansible, and Homebrew packages) are installed without explicit version pinning across multiple CI workflows, violating dependency pinning requirements and introducing supply-chain risks.
+
+## Goal
+
+Pin all external tool dependencies to specific versions to guarantee deterministic execution, eliminate environmental drift, and mitigate supply chain risks.
+
+## Context
+
+According to the DevOps Rule (Dependency Pinning), external tool dependencies (e.g., Homebrew packages, pipx packages) must be explicitly pinned to specific versions in execution paths and GitHub workflows. Unpinned dependencies can lead to non-deterministic failures, silent behavioral changes in CI pipelines, and potential security vulnerabilities if an upstream package is compromised.
+
+## Evidence
+
+- path: ".github/actions/setup-base/action.yml"
+  loc: "Install ansible with pipx and export binary path"
+  note: "pipx and ansible are installed without version pinning."
+
+- path: ".github/workflows/run-linters.yml"
+  loc: "Install shell tools"
+  note: "Homebrew packages shellcheck and shfmt are installed without version constraints."
+
+- path: ".github/workflows/collect-coverage.yml"
+  loc: "Ensure mise is available"
+  note: "Homebrew package mise is installed without version constraints."
+
+## Change Scope
+
+- `.github/actions/setup-base/action.yml`
+- `.github/workflows/run-linters.yml`
+- `.github/workflows/collect-coverage.yml`

--- a/.jules/exchange/events/vague_naming_anti_patterns_taxonomy.md
+++ b/.jules/exchange/events/vague_naming_anti_patterns_taxonomy.md
@@ -1,0 +1,44 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The codebase uses vague and overly generic names such as `helpers` and `common` which hide responsibility and create ambiguous boundaries. The role and rule constraints explicitly prohibit naming structures `base`, `common`, `core`, `utils`, or `helpers`.
+
+## Goal
+
+Remove anti-pattern naming (`common`, `helpers`) from the codebase, replacing them with precise terms that reflect their domain responsibility.
+
+## Context
+
+Using vague module and profile names like `common` or describing commands as `helpers` makes it difficult to understand the actual function of the code without inspecting it. `helpers` should be defined by the domain action they perform. The profile `common` should be referred to by a canonical term representing the global or default environment setting.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "Common,"
+  note: "Defines a profile variant named `Common`, which maps to the string 'common'."
+- path: "src/domain/backup_target.rs"
+  loc: "common"
+  note: "Returns a subpath 'common'."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "// Shared helpers"
+  note: "Uses 'helpers' to group functions in backup execution."
+- path: "src/app/cli/mod.rs"
+  loc: "/// Git helpers."
+  note: "CLI help text uses the vague term 'helpers'."
+- path: "crates/mev-internal/src/app/cli/mod.rs"
+  loc: "/// GitHub CLI helpers."
+  note: "CLI help text uses the vague term 'helpers'."
+
+## Change Scope
+
+- `src/domain/profile.rs`
+- `src/domain/backup_target.rs`
+- `src/app/commands/backup/mod.rs`
+- `src/app/cli/mod.rs`
+- `crates/mev-internal/src/app/cli/mod.rs`


### PR DESCRIPTION
Emitted 3 event files in `.jules/exchange/events/` observing Rust ownership and error handling issues in `mev`. Highlighted the overreliance on stringly-typed/dynamic errors, silent fallbacks via `unwrap_or`, and unjustified reflexive `.clone()` usages.

---
*PR created automatically by Jules for task [9548790012374840620](https://jules.google.com/task/9548790012374840620) started by @akitorahayashi*