### PR TITLE
docs: emit devops observer events

### DIFF
--- a/.jules/exchange/events/masked_coverage_failures_devops.md
+++ b/.jules/exchange/events/masked_coverage_failures_devops.md
@@ -1,0 +1,28 @@
+---
+label: "bugs"
+created_at: "2025-03-14"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+The test coverage generation step is configured to unconditionally succeed even if the underlying command fails, masking deterministic failures and hiding test signal quality.
+
+## Goal
+
+Remove `continue-on-error: true` from the coverage generation step to ensure failures during coverage collection are explicitly surfaced and block the pipeline.
+
+## Context
+
+Verification gates must produce fast and trustworthy signals for merge decisions. Using `continue-on-error: true` represents a silent fallback pattern that masks underlying execution failures, making it impossible to trust whether the test coverage metric represents a successful execution of the test suite or a failed command that was silently ignored.
+
+## Evidence
+
+- path: ".github/workflows/collect-coverage.yml"
+  loc: "Generate coverage"
+  note: "The step includes `continue-on-error: true` when running `just coverage`, masking any potential failures in coverage tool execution."
+
+## Change Scope
+
+- `.github/workflows/collect-coverage.yml`

--- a/.jules/exchange/events/unpinned_tool_dependencies_devops.md
+++ b/.jules/exchange/events/unpinned_tool_dependencies_devops.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2025-03-14"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+External tool dependencies (e.g., pipx, Ansible, and Homebrew packages) are installed without explicit version pinning across multiple CI workflows, violating dependency pinning requirements and introducing supply-chain risks.
+
+## Goal
+
+Pin all external tool dependencies to specific versions to guarantee deterministic execution, eliminate environmental drift, and mitigate supply chain risks.
+
+## Context
+
+According to the DevOps Rule (Dependency Pinning), external tool dependencies (e.g., Homebrew packages, pipx packages) must be explicitly pinned to specific versions in execution paths and GitHub workflows. Unpinned dependencies can lead to non-deterministic failures, silent behavioral changes in CI pipelines, and potential security vulnerabilities if an upstream package is compromised.
+
+## Evidence
+
+- path: ".github/actions/setup-base/action.yml"
+  loc: "Install ansible with pipx and export binary path"
+  note: "pipx and ansible are installed without version pinning."
+
+- path: ".github/workflows/run-linters.yml"
+  loc: "Install shell tools"
+  note: "Homebrew packages shellcheck and shfmt are installed without version constraints."
+
+- path: ".github/workflows/collect-coverage.yml"
+  loc: "Ensure mise is available"
+  note: "Homebrew package mise is installed without version constraints."
+
+## Change Scope
+
+- `.github/actions/setup-base/action.yml`
+- `.github/workflows/run-linters.yml`
+- `.github/workflows/collect-coverage.yml`


### PR DESCRIPTION
This PR contains the output of the devops observer role. It emits two event files detailing high-signal findings related to CI/CD automation safety and reliability.

Events emitted:
- `unpinned_tool_dependencies_devops.md` (label: refacts): Highlights the lack of version pinning for external tool dependencies like pipx, ansible, and Homebrew packages.
- `masked_coverage_failures_devops.md` (label: bugs): Details the use of `continue-on-error: true` during coverage generation, which masks underlying deterministic failures.

---
*PR created automatically by Jules for task [4509222493157614611](https://jules.google.com/task/4509222493157614611) started by @akitorahayashi*