### PR TITLE
docs: Document config deployment path drift in docs/usage.md

### DIFF
--- a/.jules/exchange/events/config_path_drift_consistency.md
+++ b/.jules/exchange/events/config_path_drift_consistency.md
@@ -1,0 +1,31 @@
+---
+label: "docs"
+created_at: "2026-03-14"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation for the `config create` command in `docs/usage.md` incorrectly states that it deploys all role configs to `~/.config/mev/`, whereas the CLI `--help` and underlying implementation (`src/adapters/identity_store/paths.rs`) show it deploys to `~/.config/mev/roles/`.
+
+## Goal
+
+Update `docs/usage.md` to accurately reflect the correct deployment path (`~/.config/mev/roles/`).
+
+## Context
+
+Consistency between the documentation and the implementation is critical. When users run `mev config create`, they expect the configs to be deposited exactly where the documentation indicates. The current documentation provides an inaccurate path, creating confusion about the config directory structure.
+
+## Evidence
+
+- path: "docs/usage.md"
+  loc: "line 41"
+  note: "The documentation states `mev config create         # Deploy all role configs to ~/.config/mev/`."
+- path: "src/app/cli/config.rs"
+  loc: "line 12"
+  note: "The CLI documentation explicitly defines `Deploy role configs to ~/.config/mev/roles/.`."
+
+## Change Scope
+
+- `docs/usage.md`


### PR DESCRIPTION
Creates an event file for documentation drift in `docs/usage.md` concerning the `config create` deployment path. `docs/usage.md` erroneously states `~/.config/mev/`, while the CLI and source (`src/adapters/identity_store/paths.rs`) specify `~/.config/mev/roles/`.

---
*PR created automatically by Jules for task [14907547230048914707](https://jules.google.com/task/14907547230048914707) started by @akitorahayashi*