### PR TITLE
Add data_arch events for domain model validation and boundary issues

### DIFF
--- a/.jules/exchange/events/cli_aliases_in_domain_data_arch.md
+++ b/.jules/exchange/events/cli_aliases_in_domain_data_arch.md
@@ -1,0 +1,43 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Core domain models contain CLI-specific string input parsing logic and aliases, violating Boundary Sovereignty and I/O decoupling rules.
+
+## Goal
+
+Move CLI input mapping, alias resolution, and string parsing to the adapter or application CLI layer, keeping domain models pure and independent of transport concerns.
+
+## Context
+
+The architecture rules mandate that domain pure logic ports abstract file system concepts and I/O away. Specifically, domain input parsing must not contain CLI-specific string input aliases. Validation and UI mapping should exclusively be handled by the adapter or application CLI layer. Currently, domain models like `SwitchIdentity`, `Profile`, and `BackupTarget` directly handle string resolution and CLI aliases.
+
+## Evidence
+
+- path: "src/domain/vcs_identity.rs"
+  loc: "SWITCH_IDENTITY_ALIASES"
+  note: "Defines CLI aliases for identity resolution directly in the domain model."
+- path: "src/domain/vcs_identity.rs"
+  loc: "resolve_switch_identity"
+  note: "Implements string-to-enum resolution using CLI aliases."
+- path: "src/domain/profile.rs"
+  loc: "PROFILE_ALIASES"
+  note: "Defines CLI aliases for profile resolution in the domain layer."
+- path: "src/domain/backup_target.rs"
+  loc: "BackupTarget::from_input"
+  note: "Implements CLI input parsing directly within the domain model."
+
+## Change Scope
+
+- `src/domain/vcs_identity.rs`
+- `src/domain/profile.rs`
+- `src/domain/backup_target.rs`
+- `src/app/cli/switch.rs`
+- `src/app/cli/make.rs`
+- `src/app/cli/create.rs`
+- `src/app/cli/backup.rs`

--- a/.jules/exchange/events/hardcoded_enumerables_data_arch.md
+++ b/.jules/exchange/events/hardcoded_enumerables_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Enumerable values like Ansible tags and profiles are hardcoded in the domain layer rather than being dynamically generated from authoritative sources.
+
+## Goal
+
+Generate enumerable values dynamically from authoritative sources (like Ansible role definitions, catalogs, or registries) to ensure extensibility and eliminate maintenance burden.
+
+## Context
+
+According to the design rules, enumerable values must be generated dynamically from authoritative sources rather than hardcoded. In the codebase, tags required for full setup and profiles are explicitly listed as static slices in the domain models, creating a maintenance burden whenever a new tag or profile is added in the configuration or Ansible roles.
+
+## Evidence
+
+- path: "src/domain/tag.rs"
+  loc: "FULL_SETUP_TAGS"
+  note: "Hardcodes the list of tags for a full environment setup."
+- path: "src/domain/tag.rs"
+  loc: "tag_groups"
+  note: "Hardcodes the mappings of tag groups to specific tags."
+- path: "src/domain/profile.rs"
+  loc: "all_profiles"
+  note: "Hardcodes the available profiles instead of discovering them dynamically."
+
+## Change Scope
+
+- `src/domain/tag.rs`
+- `src/domain/profile.rs`
+- `src/adapters/ansible/locator.rs`

--- a/.jules/exchange/events/scattered_identity_validation_data_arch.md
+++ b/.jules/exchange/events/scattered_identity_validation_data_arch.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+The `VcsIdentity` model allows invalid empty states, causing validation logic to be scattered to application layer call sites.
+
+## Goal
+
+Enforce invariants at the boundary by using appropriate types (e.g., a non-empty string type or a constructor that returns an error) so invalid states cannot be represented.
+
+## Context
+
+The First Principles of data architecture require representing valid states only, encoding invariants so invalid states are hard to express. The current `VcsIdentity` uses raw `String` types for name and email, allowing empty strings. This leads to missing validation in the domain, forcing the application layer to manually check for empty strings before use.
+
+## Evidence
+
+- path: "src/domain/vcs_identity.rs"
+  loc: "VcsIdentity"
+  note: "Defines name and email as raw strings without validation."
+- path: "src/app/commands/switch/mod.rs"
+  loc: "execute"
+  note: "Call site manually validates that vcs_identity.name and vcs_identity.email are not empty, proving invariants are not enforced by the type."
+
+## Change Scope
+
+- `src/domain/vcs_identity.rs`
+- `src/app/commands/switch/mod.rs`
+- `src/app/commands/identity/mod.rs`


### PR DESCRIPTION
Adds three high-signal data_arch observer event files documenting:
- CLI aliases and input parsing logic incorrectly placed in domain models.
- Hardcoded enumerable tags and profiles that should be dynamically generated.
- Missing boundary validation for VcsIdentity that allows invalid empty states.

---
*PR created automatically by Jules for task [9384563913487713737](https://jules.google.com/task/9384563913487713737) started by @akitorahayashi*