### PR TITLE
Emit `cov` observer findings

### DIFF
--- a/.jules/exchange/events/command_orchestration_uncovered_cov.md
+++ b/.jules/exchange/events/command_orchestration_uncovered_cov.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2026-03-14"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Critical CLI command orchestration logic in `src/app/commands/config/mod.rs` and `src/app/commands/create/mod.rs` is completely uncovered (0% line coverage).
+
+## Goal
+
+Add tests to cover the most failure-expensive decisions and state transitions within the application's command orchestration layer.
+
+## Context
+
+The application layer handles command orchestration. High coverage without strong assertions is a liability, but 0% coverage on complex commands like `config` and `create` means that orchestration flow (success/error handling) has zero regression detection. These commands perform critical state transitions by invoking domain rules and ports. Without test coverage using injected test doubles, these uncovered regions are vulnerable to silent regressions.
+
+## Evidence
+
+- path: "src/app/commands/config/mod.rs"
+  loc: "create"
+  note: "Cargo tarpaulin reports 0/40 lines covered. This module is responsible for orchestrating role configuration deployments."
+- path: "src/app/commands/create/mod.rs"
+  loc: "execute"
+  note: "Cargo tarpaulin reports 0/36 lines covered. This module orchestrates the complete development environment creation."
+
+## Change Scope
+
+- `src/app/commands/config/mod.rs`
+- `src/app/commands/create/mod.rs`

--- a/.jules/exchange/events/execution_plan_coverage_gap_cov.md
+++ b/.jules/exchange/events/execution_plan_coverage_gap_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2026-03-14"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The pure domain logic `ExecutionPlan` (`src/domain/execution_plan.rs`) has 0% line coverage (0/3 lines).
+
+## Goal
+
+Ensure critical domain rules governing the sequence of tag execution are covered by tests.
+
+## Context
+
+Coverage is a signal for regression risk, and prefer critical-path floors over global averages. `ExecutionPlan` constructs the tag sequence for Ansible provisioning. As a pure domain module, it contains rules that are highly testable (no side-effects) and failure-expensive, since a misordered or missing tag sequence breaks the environment setup. The 0% coverage indicates that this domain decision is silently neglected.
+
+## Evidence
+
+- path: "src/domain/execution_plan.rs"
+  loc: "ExecutionPlan"
+  note: "Cargo tarpaulin reports 0/3 lines covered. The module construction of execution sequences is entirely unverified."
+
+## Change Scope
+
+- `src/domain/execution_plan.rs`


### PR DESCRIPTION
Emits two `cov` observer events based on `cargo tarpaulin` findings:
1. `command_orchestration_uncovered_cov.md`: Identifies 0% coverage on complex command orchestration logic (e.g., `src/app/commands/config/mod.rs` and `src/app/commands/create/mod.rs`), representing regression risk for critical state transitions.
2. `execution_plan_coverage_gap_cov.md`: Identifies 0% coverage in `src/domain/execution_plan.rs`, highlighting a gap in testing pure domain rules that govern tag execution order.

---
*PR created automatically by Jules for task [11378577083784167977](https://jules.google.com/task/11378577083784167977) started by @akitorahayashi*