### PR TITLE
docs: correct config create deployment path

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,7 +38,7 @@ Configuration deploys via:
 ```sh
 mev identity set          # Configure VCS identities interactively
 mev identity show         # Show current configuration
-mev config create         # Deploy all role configs to ~/.config/mev/
+mev config create         # Deploy all role configs to ~/.config/mev/roles/
 mev config create rust    # Deploy only rust role config
 ```
 


### PR DESCRIPTION
Updates the `mev config create` command documentation in `docs/usage.md` to accurately reflect its deployment path (`~/.config/mev/roles/`), resolving the discrepancy with the CLI's actual behavior.

---
*PR created automatically by Jules for task [9053131320595658496](https://jules.google.com/task/9053131320595658496) started by @akitorahayashi*