### PR TITLE
docs: emit devops event files for CI/CD issues

### DIFF
--- a/.jules/exchange/events/unpinned_dependencies_devops.md
+++ b/.jules/exchange/events/unpinned_dependencies_devops.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+External dependencies `pipx` and `ansible` are installed without explicit version pinning in the base setup action.
+
+## Goal
+
+Pin `pipx` and `ansible` to explicit versions to ensure deterministic execution, prevent unexpected regressions due to upstream updates, and mitigate supply chain risks.
+
+## Context
+
+The `setup-base` action currently installs `pipx` and `ansible` using `pip install --user pipx` and `pipx install --force ansible` respectively. This results in the latest available versions being installed, introducing a risk of breaking changes or supply chain attacks in upstream packages. Per DevOps rules, external dependencies must be pinned to specific versions to guarantee deterministic execution.
+
+## Evidence
+
+- path: ".github/actions/setup-base/action.yml"
+  loc: "23-24"
+  note: "`pipx` and `ansible` are installed via `pip` and `pipx` respectively without version specifiers, pulling the latest available versions."
+
+## Change Scope
+
+- `.github/actions/setup-base/action.yml`

--- a/.jules/exchange/events/unpinned_homebrew_dependencies_devops.md
+++ b/.jules/exchange/events/unpinned_homebrew_dependencies_devops.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "devops"
+confidence: "high"
+---
+
+## Problem
+
+Homebrew packages `shellcheck` and `shfmt` are installed without version pinning in the `Run Linters` workflow.
+
+## Goal
+
+Pin `shellcheck` and `shfmt` to explicit versions in the linter workflow to ensure reproducible builds and deterministic linting outcomes.
+
+## Context
+
+The `Run Linters` workflow uses `brew install shellcheck shfmt`, which installs the latest available versions of these tools. This violates the DevOps dependency pinning rule, potentially introducing subtle linting differences over time due to toolchain drift. To guarantee consistent linting, Homebrew installations should use specific versions or rely on the `mise.toml` configuration if available in the repository.
+
+## Evidence
+
+- path: ".github/workflows/run-linters.yml"
+  loc: "31"
+  note: "`brew install shellcheck shfmt` does not specify versions, resulting in dynamic tool resolution."
+
+## Change Scope
+
+- `.github/workflows/run-linters.yml`

--- a/.jules/exchange/events/unverified_artifact_provenance_devops.md
+++ b/.jules/exchange/events/unverified_artifact_provenance_devops.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "devops"
+confidence: "medium"
+---
+
+## Problem
+
+Release artifacts generated in the `Build` workflow do not have cryptographically verifiable provenance signatures (e.g. sigstore/cosign) linking the artifact back to the build run.
+
+## Goal
+
+Generate and attach verifiable provenance attestations to release artifacts to ensure end-to-end supply-chain integrity and artifact lineage traceability.
+
+## Context
+
+While the `Build` workflow produces an SHA256 checksum file alongside the `mev-darwin-aarch64` binary, there is no cryptographic signature generated to prove that the artifact was compiled by the specific GitHub Actions runner and workflow execution. Incorporating an attestation mechanism establishes strong artifact provenance and protects against compromised artifacts in the release path.
+
+## Evidence
+
+- path: ".github/workflows/build.yml"
+  loc: "23-35"
+  note: "The workflow creates binary and SHA256 hashes, but omits code signing or provenance generation."
+
+## Change Scope
+
+- `.github/workflows/build.yml`


### PR DESCRIPTION
This PR introduces three new event files based on an observer analysis using the `devops` role. The analysis surfaced the following findings regarding delivery automation reliability and security:

1. **Unpinned External Dependencies:** The base setup action uses `pip` and `pipx` to install Python dependencies and `ansible` without explicitly pinning versions, posing a potential supply chain risk and allowing non-deterministic execution.
2. **Unpinned Homebrew Dependencies:** The linter setup workflow uses `brew install shellcheck shfmt` to pull the latest versions. Lacking version pinning guarantees exposes the system to implicit linting drift.
3. **Unverified Artifact Provenance:** The release artifact creation in the build workflow relies solely on SHA256 hashes and lacks cryptographic provenance generation, rendering the release artifacts partially unverified.

---
*PR created automatically by Jules for task [8458472903957783324](https://jules.google.com/task/8458472903957783324) started by @akitorahayashi*