### PR TITLE
Add Rustacean observer events

### DIFF
--- a/.jules/exchange/events/error_handling_rustacean.md
+++ b/.jules/exchange/events/error_handling_rustacean.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2025-03-14"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Heavy usage of `Box<dyn std::error::Error>` across the `crates/mev-internal` library boundary collapses typed errors, preventing consumers from correctly classifying failures or reacting to domain-specific conditions (like a missing Git section vs an I/O error).
+
+## Goal
+
+Define explicit error types (e.g. via `thiserror`) for internal modules (`gh`, `git`, `process`) to preserve classification and attach boundary context, removing `Box<dyn Error>` from function signatures.
+
+## Context
+
+The `mev-internal` crate provides CLI boundaries for `git` and `gh`. Returning type-erased errors forces callers into string-matching or generic failure handling, violating the Rust design rule that errors must preserve domain meaning and classification.
+
+## Evidence
+
+- path: "crates/mev-internal/src/adapters/process.rs"
+  loc: "run_status and run_output"
+  note: "Returns `Result<..., Box<dyn std::error::Error>>` for process execution failures, hiding the underlying IO or exit status error types."
+- path: "crates/mev-internal/src/domain/repository_ref.rs"
+  loc: "RepositoryRef::from_remote_url and parsing functions"
+  note: "Fails with a string converted to `Box<dyn Error>`, dropping the distinction between parse failures and domain logic errors."
+
+## Change Scope
+
+- `crates/mev-internal/src/adapters/process.rs`
+- `crates/mev-internal/src/adapters/git.rs`
+- `crates/mev-internal/src/adapters/gh.rs`
+- `crates/mev-internal/src/domain/repository_ref.rs`

--- a/.jules/exchange/events/ownership_rustacean.md
+++ b/.jules/exchange/events/ownership_rustacean.md
@@ -1,0 +1,37 @@
+---
+label: "refacts"
+created_at: "2025-03-14"
+author_role: "rustacean"
+confidence: "medium"
+---
+
+## Problem
+
+Reflexive `.clone()` usage for string and path allocation across adapters and commands bypasses proper lifetime and ownership design, increasing allocation overhead without a justified threading or caching boundary.
+
+## Goal
+
+Align ownership structures by leveraging borrowed values (`&str`, `&Path`) for ephemeral operations or transferring ownership properly, rather than sprinkling `.clone()` to appease the borrow checker.
+
+## Context
+
+Cloning values without a documented boundary rationale (such as long-lived storage, threads, or complex ergonomics) violates ownership architecture. It obscures the single source of truth and adds unnecessary runtime allocations.
+
+## Evidence
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "192"
+  note: "The entire `tags_by_role` HashMap is cloned when returning it from `AnsiblePort::tags_by_role()`, which could be avoided if the trait returned an iterator or reference."
+- path: "src/app/container.rs"
+  loc: "45"
+  note: "`ansible_dir.clone()` and `local_config_root.clone()` are passed to `AnsibleAdapter::new`, suggesting the container might be needlessly cloning paths instead of passing references or taking ownership."
+- path: "src/adapters/identity_store/local_json.rs"
+  loc: "81"
+  note: "Clones the path `self.identity_path` just to return it from a getter, which could return a `&Path`."
+
+## Change Scope
+
+- `src/adapters/ansible/executor.rs`
+- `src/app/container.rs`
+- `src/adapters/identity_store/local_json.rs`
+- `src/domain/ports/ansible.rs`

--- a/.jules/exchange/events/silent_failure_rustacean.md
+++ b/.jules/exchange/events/silent_failure_rustacean.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2025-03-14"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Use of `.unwrap_or()` for plausible runtime failures or parsing masks the actual failure, causing silent fallback behaviors instead of surfacing explicit errors.
+
+## Goal
+
+Replace silent fallbacks with explicit error propagation or typed boundary validation to prevent masking critical application or execution failures.
+
+## Context
+
+The Rustacean design rules prohibit silent fallbacks (`unwrap_or`) on production paths where failure is plausible. Masking failures makes debugging difficult and allows configuration or state to drift without user awareness.
+
+## Evidence
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "204, 208"
+  note: "Parsing floats and formatting strings falls back to the original string or original value using `.unwrap_or()`, silently masking parse errors."
+- path: "src/adapters/ansible/executor.rs"
+  loc: "152"
+  note: "The `ansible-playbook` exit code is fetched using `.unwrap_or(-1)` if `code()` is None (e.g., killed by signal). This masks signal termination as an arbitrary exit code."
+- path: "crates/mev-internal/src/adapters/process.rs"
+  loc: "run_status"
+  note: "Process exit code is silently defaulted to 1 via `unwrap_or(1)` if terminated by a signal."
+
+## Change Scope
+
+- `src/app/commands/backup/mod.rs`
+- `src/adapters/ansible/executor.rs`
+- `crates/mev-internal/src/adapters/process.rs`


### PR DESCRIPTION
This PR adds 3 event files in `.jules/exchange/events/` identifying high-signal findings matching the Rustacean anti-patterns.
- `error_handling_rustacean.md`: Identifies heavy usage of `Box<dyn std::error::Error>` across the `crates/mev-internal` library boundary that collapses typed errors.
- `silent_failure_rustacean.md`: Identifies the use of `.unwrap_or()` for plausible runtime failures or parsing that masks actual failures.
- `ownership_rustacean.md`: Identifies reflexive `.clone()` usage for string and path allocation across adapters and commands that bypasses proper lifetime and ownership design.

---
*PR created automatically by Jules for task [17960852697200402387](https://jules.google.com/task/17960852697200402387) started by @akitorahayashi*