### PR TITLE
docs: emit taxonomy observation events for ambiguous naming conventions

### DIFF
--- a/.jules/exchange/events/ambiguous_common_paths_taxonomy.md
+++ b/.jules/exchange/events/ambiguous_common_paths_taxonomy.md
@@ -1,0 +1,27 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+The term `common` is used extensively as a generic fallback or shared directory in Ansible role paths (e.g., `roles/*/config/common`), violating the design rule against using ambiguous names like "common" for scope/organization.
+
+## Goal
+Rename the generic `common` directory to a specific, domain-relevant term that describes its purpose (e.g., `global`, `shared`, `default`, or simply flattened into `config/` if no other variants exist).
+
+## Context
+Directories named `common` hide their actual responsibility and create a dumping ground for unrelated configurations. First principles dictate that names should encode the correct boundary or domain concept rather than restating package scope.
+
+## Evidence
+- path: "src/domain/backup_target.rs"
+  loc: "pub fn subpath"
+  note: "Hardcodes `common` as the subdirectory within the role config directory."
+- path: "src/assets/ansible/roles/system/config/common/system.yml"
+  loc: "com.apple.WindowManager"
+  note: "Example of a `common` directory used to store system definitions."
+
+## Change Scope
+- `src/domain/backup_target.rs`
+- `src/assets/ansible/roles/*/config/*`

--- a/.jules/exchange/events/ambiguous_profile_common_taxonomy.md
+++ b/.jules/exchange/events/ambiguous_profile_common_taxonomy.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+The domain model uses `Profile::Common` as a variant alongside machine-specific profiles (`Macbook`, `MacMini`), confusing a foundational configuration layer with an actual target machine profile.
+
+## Goal
+Establish a distinct domain concept (e.g., `BaseLayer` or `WorkspaceConfig`) to replace `Common` so that target profiles and foundational configurations are not conflated in the same enum.
+
+## Context
+"Common" is an ambiguous term that violates repository naming conventions. By placing `Common` inside the `Profile` enum, it implies a user could "provision a common machine," which is semantically incorrect. This also forces awkward logic like `profile.is_machine_profile()` to separate real targets from shared layers.
+
+## Evidence
+- path: "src/domain/profile.rs"
+  loc: "Profile::Common"
+  note: "`Common` is defined as a `Profile` variant alongside `Macbook` and `MacMini`."
+- path: "src/domain/profile.rs"
+  loc: "validate_machine_profile_rejects_common"
+  note: "`validate_machine_profile_rejects_common()` test explicitly acknowledges `common` is not a real machine profile."
+
+## Change Scope
+- `src/domain/profile.rs`
+- `src/app/commands/list/mod.rs`
+- `src/app/commands/make/mod.rs`

--- a/.jules/exchange/events/generic_helpers_nomenclature_taxonomy.md
+++ b/.jules/exchange/events/generic_helpers_nomenclature_taxonomy.md
@@ -1,0 +1,27 @@
+---
+label: "docs"
+created_at: "2026-03-14"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+The term `helpers` is used generically in module documentation and comments without specifying the domain noun or responsibility, violating the anti-pattern against vague names.
+
+## Goal
+Replace occurrences of the generic term "helpers" with precise, domain-oriented descriptions that specify the logic's responsibility (e.g., "Backup definitions resolution" or "Git CLI commands").
+
+## Context
+Generic names like "helpers" or "utils" obscure the true purpose of the code. Code should describe what it does and why, not that it "helps".
+
+## Evidence
+- path: "src/app/commands/backup/mod.rs"
+  loc: "// Shared helpers"
+  note: "Contains the generic comment `// Shared helpers` instead of describing the domain logic (e.g., definitions resolution)."
+- path: "src/app/cli/mod.rs"
+  loc: "/// Git helpers."
+  note: "Describes internal git commands generically as `/// Git helpers.`"
+
+## Change Scope
+- `src/app/commands/backup/mod.rs`
+- `src/app/cli/mod.rs`


### PR DESCRIPTION
This PR introduces three new event files detailing taxonomy and naming inconsistencies within the repository based on our naming conventions.

- Event: `ambiguous_profile_common_taxonomy.md` points out the issue of conflating `Profile::Common` with actual machine profiles in `src/domain/profile.rs`.
- Event: `ambiguous_common_paths_taxonomy.md` identifies the generic and widely-used `common` directory fallback in Ansible role paths as an anti-pattern.
- Event: `generic_helpers_nomenclature_taxonomy.md` captures occurrences of the generic and vague term `helpers` used in `src/app/commands/backup/mod.rs` and `src/app/cli/mod.rs`.

---
*PR created automatically by Jules for task [9728995998504425029](https://jules.google.com/task/9728995998504425029) started by @akitorahayashi*