### PR TITLE
docs: emit consistency events for architecture drift

### DIFF
--- a/.jules/exchange/events/docs_architecture_container_consistency.md
+++ b/.jules/exchange/events/docs_architecture_container_consistency.md
@@ -1,0 +1,31 @@
+---
+label: "docs"
+created_at: "2024-03-14"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The architectural documentation references `src/app/context.rs` for dependency wiring, but the file is actually named `src/app/container.rs`.
+
+## Goal
+
+Update the architecture documentation to reflect the correct filename (`container.rs`) used for dependency wiring in the application layer.
+
+## Context
+
+The documentation serves as the canonical map for the package structure. When file paths in `docs/architecture.md` do not match the implementation, it creates confusion for contributors navigating the application layer boundaries and dependency injection setup.
+
+## Evidence
+
+- path: "docs/architecture.md"
+  loc: "19"
+  note: "Documents `├── context.rs          # Dependency wiring (ports → adapters)`"
+- path: "src/app/container.rs"
+  loc: "1"
+  note: "The actual implemented file is `container.rs`, which contains the `DependencyContainer` struct for dependency wiring."
+
+## Change Scope
+
+- `docs/architecture.md`

--- a/.jules/exchange/events/docs_architecture_crates_consistency.md
+++ b/.jules/exchange/events/docs_architecture_crates_consistency.md
@@ -1,0 +1,31 @@
+---
+label: "docs"
+created_at: "2024-03-14"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The architectural documentation (`docs/architecture.md`) claims that `crates/mev-internal/` contains internal command implementations for `(shell, vcs)`. However, there is no `shell` implementation inside `mev-internal`, only `git` and `gh` (which belong to VCS).
+
+## Goal
+
+Correct the `docs/architecture.md` file to reflect the actual implementations available inside `crates/mev-internal/`.
+
+## Context
+
+The architecture documentation map is important for discovering internal dependencies. Specifying non-existent modules leads to confusion when a developer searches for a `shell` internal command implementation that doesn't exist.
+
+## Evidence
+
+- path: "docs/architecture.md"
+  loc: "35"
+  note: "Documents `└── mev-internal/          # Internal command implementations (shell, vcs)`"
+- path: "crates/mev-internal/src/app/cli/"
+  loc: "N/A"
+  note: "Directory contains `gh.rs` and `git.rs`. There is no `shell` implementation."
+
+## Change Scope
+
+- `docs/architecture.md`

--- a/.jules/exchange/events/docs_architecture_missing_files_consistency.md
+++ b/.jules/exchange/events/docs_architecture_missing_files_consistency.md
@@ -1,0 +1,31 @@
+---
+label: "docs"
+created_at: "2024-03-14"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The architectural documentation (`docs/architecture.md`) has missing domain files in its tree structure, failing to document `src/domain/backup_target.rs`. Also `src/domain/config.rs` is documented but it doesn't exist (it should be `src/domain/vcs_identity.rs`).
+
+## Goal
+
+Ensure that the domain folder package structure inside `docs/architecture.md` accurately reflects the files in the codebase.
+
+## Context
+
+The documentation aims to act as a definitive map for developers interacting with the architecture. When files are present but undocumented (like `backup_target.rs`), developers may fail to see the established abstraction or understand its role within the domain logic.
+
+## Evidence
+
+- path: "docs/architecture.md"
+  loc: "23"
+  note: "Documents `├── config.rs           # VCS identity configuration model` but missing `backup_target.rs` and `vcs_identity.rs`"
+- path: "src/domain/"
+  loc: "N/A"
+  note: "Contains `backup_target.rs` and `vcs_identity.rs`, while `config.rs` does not exist."
+
+## Change Scope
+
+- `docs/architecture.md`


### PR DESCRIPTION
This PR adds three consistency event files indicating discrepancies between the implemented architecture and its documentation in `docs/architecture.md`. Discrepancies found include the `src/app/container.rs` (documented as `context.rs`), the inner crates in `crates/mev-internal/src/app/cli/` missing `shell` implementation but documenting it, and missing domain files `src/domain/vcs_identity.rs` and `src/domain/backup_target.rs` while incorrectly documenting `src/domain/config.rs`.

---
*PR created automatically by Jules for task [11306911725515026282](https://jules.google.com/task/11306911725515026282) started by @akitorahayashi*