### PR TITLE
docs: emit data arch observer events

### DIFF
--- a/.jules/exchange/events/cli_aliases_domain_data_arch.md
+++ b/.jules/exchange/events/cli_aliases_domain_data_arch.md
@@ -1,0 +1,37 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Core domain models contain CLI-specific string input parsing logic and hardcoded alias mappings.
+
+## Goal
+
+Relocate string input parsing and alias resolution to the adapter or application CLI layer, preserving the domain models' focus solely on business rules and valid internal states.
+
+## Context
+
+Architecture Rule (Domain Input Parsing) dictates that core domain models must not contain CLI-specific string input parsing logic or aliases. Validation, UI mapping, and string parsing must be exclusively handled by the adapter or application CLI layer to maintain Boundary Sovereignty.
+
+## Evidence
+
+- path: "src/domain/vcs_identity.rs"
+  loc: "SWITCH_IDENTITY_ALIASES"
+  note: "Defines hardcoded CLI aliases within the domain model."
+- path: "src/domain/profile.rs"
+  loc: "PROFILE_ALIASES"
+  note: "Contains CLI aliases and mapping rules for profile resolution."
+- path: "src/domain/backup_target.rs"
+  loc: "from_input"
+  note: "Implements string-based parsing and alias resolution directly on the domain type."
+
+## Change Scope
+
+- `src/domain/vcs_identity.rs`
+- `src/domain/profile.rs`
+- `src/domain/backup_target.rs`
+- `src/app/cli/`

--- a/.jules/exchange/events/persistence_leak_data_arch.md
+++ b/.jules/exchange/events/persistence_leak_data_arch.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Core domain entities derive `serde::Serialize` and `serde::Deserialize`, tightly coupling the domain model to serialization mechanisms and formats (e.g., JSON).
+
+## Goal
+
+Decouple domain entities from persistence concerns. Serialization and deserialization should be handled by DTOs in the adapter layer (e.g., in `src/adapters/identity_store/local_json.rs`), which are then mapped to the core domain types.
+
+## Context
+
+Boundary Sovereignty mandates that domain models must be independent of transport or persistence concerns. Deriving `serde` traits in the domain layer allows persistence details to leak into core logic, violating this principle.
+
+## Evidence
+
+- path: "src/domain/vcs_identity.rs"
+  loc: "VcsIdentity"
+  note: "Derives `serde::Serialize` and `serde::Deserialize` directly on the core domain model."
+- path: "src/domain/ports/identity_store.rs"
+  loc: "IdentityState"
+  note: "Derives `serde::Serialize` and `serde::Deserialize` directly on the domain port model."
+
+## Change Scope
+
+- `src/domain/vcs_identity.rs`
+- `src/domain/ports/identity_store.rs`
+- `src/adapters/identity_store/local_json.rs`

--- a/.jules/exchange/events/silent_fallbacks_data_arch.md
+++ b/.jules/exchange/events/silent_fallbacks_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-14"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Adapter implementations silently swallow external command failures by using `unwrap_or_default()`, masking errors instead of bubbling them up.
+
+## Goal
+
+Surface explicit errors to the caller using appropriate `Result` types instead of falling back to default values when external commands fail.
+
+## Context
+
+The design rules explicitly prohibit silent fallbacks; any fallback must be explicit, opt-in, and surfaced as a failure or logged. Additionally, the Rust Design Rule regarding error handling mandates that errors must preserve domain meaning without collapsing into defaults in production paths where failure is plausible.
+
+## Evidence
+
+- path: "src/adapters/git/cli.rs"
+  loc: "read_config"
+  note: "Uses `unwrap_or_default()` when the git command fails, silently returning an empty string instead of an error."
+- path: "src/adapters/jj/cli.rs"
+  loc: "read_config"
+  note: "Uses `unwrap_or_default()` when the jj command fails, silently returning an empty string instead of an error."
+
+## Change Scope
+
+- `src/adapters/git/cli.rs`
+- `src/adapters/jj/cli.rs`


### PR DESCRIPTION
Emitted three observer events for data architecture analysis:
- `persistence_leak_data_arch.md`: Documenting the leak of serde traits into core domain models like VcsIdentity.
- `cli_aliases_domain_data_arch.md`: Documenting the leak of CLI string parsing and alias mapping into core domain models.
- `silent_fallbacks_data_arch.md`: Documenting the use of silent fallbacks (`unwrap_or_default`) when external commands fail in adapters.

---
*PR created automatically by Jules for task [5132922419927908244](https://jules.google.com/task/5132922419927908244) started by @akitorahayashi*