### PR TITLE
qa: emit test quality events

### DIFF
--- a/.jules/exchange/events/application_orchestration_test_doubles_qa.md
+++ b/.jules/exchange/events/application_orchestration_test_doubles_qa.md
@@ -1,0 +1,36 @@
+---
+label: "tests"
+created_at: "2026-03-14"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+The application orchestration layer (`src/app/commands/`) cannot be unit tested in isolation using test doubles because it depends on a concrete `DependencyContainer` rather than port interfaces. This forces integration tests to assert on partial failures (e.g., missing assets) rather than verifying pure command logic.
+
+## Goal
+
+Refactor command dependencies to use port interfaces (e.g., `&dyn AnsiblePort`) so that orchestration logic can be validated with fast, in-process test doubles instead of slow, brittle binary invocations.
+
+## Context
+
+Testing pure logic with slow integration/E2E tests that execute the full binary is an anti-pattern. This prevents testing application command boundaries without side effects. Currently, integration tests like `tests/cli/backup.rs` test partial success (subcommand parsing) followed by failure (missing assets), which is a brittle test structure that asserts error behavior instead of positive logic flow.
+
+## Evidence
+
+- path: "src/app/commands/create/mod.rs"
+  loc: "14"
+  note: "`pub fn execute(ctx: &DependencyContainer, ...)` tightly couples logic to concrete adapters."
+- path: "tests/cli/backup.rs"
+  loc: "12-14"
+  note: "`backup_alias_bk_is_accepted` explicitly expects failure due to missing ansible assets but tests alias resolution, demonstrating a lack of isolated environment testing."
+- path: "src/testing/mod.rs"
+  loc: "1"
+  note: "`//! In-process test doubles and builders.` module is empty, indicating missing testing infrastructure for this architectural boundary."
+
+## Change Scope
+
+- `src/app/commands/`
+- `src/testing/`
+- `tests/cli/`

--- a/.jules/exchange/events/missing_execution_plan_tests_qa.md
+++ b/.jules/exchange/events/missing_execution_plan_tests_qa.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2026-03-14"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Pure domain logic in `ExecutionPlan` lacks isolated unit tests, missing validation of its properties and boundaries.
+
+## Goal
+
+Add unit tests within `src/domain/execution_plan.rs` to verify plan construction, ensuring deterministic behavior independent of external side effects.
+
+## Context
+
+Domain models must enforce invariants at the boundary and be thoroughly tested for expected properties. The absence of tests for `ExecutionPlan` leaves a gap in verifying whether `full_setup` correctly includes `FULL_SETUP_TAGS` or `make` accurately handles user tags.
+
+## Evidence
+
+- path: "src/domain/execution_plan.rs"
+  loc: "12-22"
+  note: "`ExecutionPlan::full_setup` and `ExecutionPlan::make` contain pure plan construction logic but have no corresponding `#[cfg(test)]` module, unlike other domain modules (e.g., `profile.rs`, `tag.rs`)."
+
+## Change Scope
+
+- `src/domain/execution_plan.rs`

--- a/.jules/exchange/events/vague_security_assertions_qa.md
+++ b/.jules/exchange/events/vague_security_assertions_qa.md
@@ -1,0 +1,31 @@
+---
+label: "tests"
+created_at: "2026-03-14"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Security contract tests assert on broad stderr output ("error" or "Error") rather than specific diagnostic failure modes, severely reducing failure diagnosability.
+
+## Goal
+
+Update assertions to verify specific typed error messages or exit codes to ensure tests fail for the right reasons.
+
+## Context
+
+Broad string-matching assertions are anti-patterns because they can produce false positives. For example, if the CLI panics or fails for an unrelated configuration reason (like a missing dependency), it will also output "Error", and the test would mistakenly pass as having rejected the invalid profile.
+
+## Evidence
+
+- path: "tests/security/input_validation.rs"
+  loc: "13"
+  note: "`stderr(predicate::str::contains(\"error\").or(predicate::str::contains(\"Error\")));` is overly broad in `create_rejects_invalid_profile`."
+- path: "tests/security/input_validation.rs"
+  loc: "25"
+  note: "`stderr(predicate::str::contains(\"error\").or(predicate::str::contains(\"Error\")));` is overly broad in `switch_rejects_invalid_profile`."
+
+## Change Scope
+
+- `tests/security/input_validation.rs`


### PR DESCRIPTION
As a QA observer, I've analyzed the codebase test structure and quality based on the given guidelines.

I found three significant issues that need addressing:
1.  **Test Doubles & Application Boundaries**: The application orchestration layer (`src/app/commands/`) tightly couples to a concrete `DependencyContainer` instead of leveraging interfaces (like `AnsiblePort`). This prevents writing isolated unit tests for command logic, leading to reliance on slower, more brittle binary invocations (`tests/cli/backup.rs` relying on partial failures).
2.  **Missing Domain Tests**: The domain logic in `src/domain/execution_plan.rs` (which determines execution plans like `full_setup` and `make`) lacks its own unit tests (`#[cfg(test)]`). Pure logic should be tested in isolation.
3.  **Assertion Granularity**: In `tests/security/input_validation.rs`, error output assertions are too broad (`predicate::str::contains("error").or(predicate::str::contains("Error"))`), which could lead to false positives if a test fails for the wrong reason (e.g. panics or missing dependencies).

I've generated 3 event files in `.jules/exchange/events/` conforming to the `.jules/schemas/event.md` schema to capture these findings.

---
*PR created automatically by Jules for task [5325948493702174496](https://jules.google.com/task/5325948493702174496) started by @akitorahayashi*