### PR TITLE
Emit structural architecture events

### DIFF
--- a/.jules/exchange/events/adapter_fs_abstraction_structural_arch.md
+++ b/.jules/exchange/events/adapter_fs_abstraction_structural_arch.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "structural_arch"
+confidence: "medium"
+---
+
+## Problem
+
+Some files interact with `std::fs` explicitly in the app/command layer, rather than utilizing the `FsPort`. This bypasses testing seams and couples orchestration logic directly to the filesystem adapter.
+
+## Goal
+
+Consistent abstraction over I/O. All application and command orchestration logic must use `ctx.fs` (`FsPort`) rather than relying on `std::fs`, ensuring proper decoupling and testability via dependency injection.
+
+## Context
+
+While `FsPort` exists and is wired up in `DependencyContainer`, there are instances where `std::fs` is used directly in commands, which creates a testing blast radius and bypasses the defined boundary.
+
+## Evidence
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "42"
+  note: "Uses `std::fs::remove_dir_all(&target)` instead of abstracting through the `FsPort`."
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "66-74"
+  note: "`copy_dir_recursive` uses `std::fs::create_dir_all`, `std::fs::read_dir`, and `std::fs::copy` instead of port abstractions."
+
+- path: "src/app/commands/config/mod.rs"
+  loc: "63-71"
+  note: "`copy_dir_recursive` uses `std::fs::create_dir_all`, `std::fs::read_dir`, and `std::fs::copy` instead of port abstractions."
+
+## Change Scope
+
+- `src/app/commands/config/mod.rs`
+- `src/app/commands/deploy_configs.rs`
+- `src/domain/ports/fs.rs`

--- a/.jules/exchange/events/ansible_port_dependency_structural_arch.md
+++ b/.jules/exchange/events/ansible_port_dependency_structural_arch.md
@@ -1,0 +1,39 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+The Application command orchestration (`src/app/commands/deploy_configs.rs` and `src/app/commands/config/mod.rs`) depend directly on Ansible internals or the filesystem layout of the Ansible directory rather than abstracting this via Ports or pure data mapping.
+
+## Goal
+
+Ensure core application logic interacts with abstract Ports, removing direct references to Ansible file layouts (e.g. `roles/{role}/config`) inside command execution paths. The boundary between "Ansible as an implementation detail" and the pure application logic should be strictly enforced.
+
+## Context
+
+Commands like `config` and `deploy_configs` are manually reconstructing Ansible role config paths instead of asking the `AnsiblePort` or a dedicated configuration adapter for the resolved paths. This breaks boundary sovereignty by bleeding the Ansible internal folder structure into the command layer. Furthermore, `DependencyContainer::new` exposes `ansible_dir` publicly which encourages other components to bypass adapters.
+
+## Evidence
+
+- path: "src/app/commands/config/mod.rs"
+  loc: "34"
+  note: "Directly constructs paths like `ctx.ansible_dir.join(\"roles\").join(role_name).join(\"config\")`, leaking adapter structure into command layer."
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "47"
+  note: "Directly accesses `ansible_dir.join(\"roles\").join(&role).join(\"config\")`, bypassing any port-level abstraction."
+
+- path: "src/app/container.rs"
+  loc: "24"
+  note: "The `DependencyContainer` struct leaves `pub ansible_dir: PathBuf` exposed, enabling unchecked adapter-internal access."
+
+## Change Scope
+
+- `src/app/commands/config/mod.rs`
+- `src/app/commands/deploy_configs.rs`
+- `src/app/container.rs`
+- `src/domain/ports/ansible.rs`

--- a/.jules/exchange/events/pub_use_flow_structural_arch.md
+++ b/.jules/exchange/events/pub_use_flow_structural_arch.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "structural_arch"
+confidence: "high"
+---
+
+## Problem
+
+The application layer and domain layer are entangled via `pub use` statements and implicit backflow. `src/app/api.rs` exports domain models (`BackupTarget`, `Profile`, `ExecutionPlan`, etc.), and `src/lib.rs` exports both `api` and `cli`. This creates a situation where the application layer is acting as the public facade for domain constructs, which violates boundary sovereignty and directionality.
+
+## Goal
+
+Minimize public surface and enforce unidirectional dependency flow. The domain layer should not be re-exported by the application layer. Instead, entry points (CLI and programmatic API) should reside at the true edge, and the domain should be consumed directly or via deliberate adapter mappings, preventing "export everything" anti-patterns.
+
+## Context
+
+The current `pub use` re-exports in `src/app/api.rs` and `src/lib.rs` mean the internal architecture (Domain -> Ports -> Adapters -> App) is exposed to programmatic consumers via the `app` module. The application layer's responsibility is orchestration, not serving as a domain catalog. This makes refactoring the domain harder because its types are part of the `app::api` contract.
+
+## Evidence
+
+- path: "src/app/api.rs"
+  loc: "14-19"
+  note: "Re-exports domain models (`BackupTarget`, `AppError`, `ExecutionPlan`, `IdentityState`, `Profile`, `VcsIdentity`) via `pub use crate::domain::...`."
+
+- path: "src/lib.rs"
+  loc: "15-18"
+  note: "Exports `app::cli::run as cli` and `app::api`. This makes `app` the public interface of the crate."
+
+## Change Scope
+
+- `src/app/api.rs`
+- `src/lib.rs`


### PR DESCRIPTION
This PR emits three event files detailing findings according to the `structural_arch` observer role. The findings focus on unidirectional flow violations, leaked adapter details, and filesystem abstraction bypasses.

---
*PR created automatically by Jules for task [10162696519613151368](https://jules.google.com/task/10162696519613151368) started by @akitorahayashi*