### PR TITLE
Emit cli_sentinel events for backup and config commands

### DIFF
--- a/.jules/exchange/events/backup_command_structure_drift_cli_sentinel.md
+++ b/.jules/exchange/events/backup_command_structure_drift_cli_sentinel.md
@@ -1,0 +1,31 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+The `backup` command uses a `--list` option toggle to change its primary behavior from performing a backup to listing available targets, making the positional `target` argument conditionally mandatory.
+
+## Goal
+
+Align the `backup` command with standard structure by removing the `--list` toggle and using standard subcommands (e.g., `mev backup list`), or by making `target` a mandatory positional argument that outputs valid options upon missing argument errors.
+
+## Context
+
+A command should consistently read as `verb [object] arguments`. The `--list` toggle acts as a subcommand masquerading as an option, violating the structural contract and option classification rules. It creates an exception condition where the positional argument becomes required only if the option is absent.
+
+## Evidence
+
+- path: "src/app/cli/backup.rs"
+  loc: "BackupArgs"
+  note: "Defines the `--list` toggle and models the `target` argument as an `Option<String>`."
+- path: "src/app/cli/backup.rs"
+  loc: "run"
+  note: "Branching logic uses `args.list` to bypass the missing target error, confirming `--list` is used as a subcommand rather than a modifier."
+
+## Change Scope
+
+- `src/app/cli/backup.rs`

--- a/.jules/exchange/events/backup_io_separation_warning_cli_sentinel.md
+++ b/.jules/exchange/events/backup_io_separation_warning_cli_sentinel.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "cli_sentinel"
+confidence: "high"
+---
+
+## Problem
+
+The `backup` command emits a diagnostic warning about missing local definitions directly to `stdout` instead of `stderr`.
+
+## Goal
+
+Route the missing local definitions fallback warning to `stderr` to preserve strict I/O separation.
+
+## Context
+
+The `cli_sentinel` contract dictates strict I/O separation: "stdout carries result data; stderr carries warnings, logs, and errors. Mixed streams break automation." The fallback to package defaults is a warning state and should not pollute standard output streams.
+
+## Evidence
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "57-61"
+  note: "Uses `println!` to emit 'Local definitions not found at ... Using package defaults.' instead of `eprintln!`."
+
+## Change Scope
+
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/config_create_naming_drift_cli_sentinel.md
+++ b/.jules/exchange/events/config_create_naming_drift_cli_sentinel.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2026-03-14"
+author_role: "cli_sentinel"
+confidence: "medium"
+---
+
+## Problem
+
+The `mev config create` command uses the verb `create` for an action that copies/deploys existing configuration files, introducing a naming synonym conflict with the top-level `mev create` command which provisions a full environment.
+
+## Goal
+
+Rename the subcommand to accurately reflect its deployment action without overlapping with top-level environment creation verbs (e.g., `mev config deploy`).
+
+## Context
+
+CLI naming consistency rules require that "verb and object vocabulary follows established conventions without synonyms". The internal module is named `deploy_configs.rs` and the help text states "Deploy role configs...", confirming that the action is a deployment, not a creation from scratch.
+
+## Evidence
+
+- path: "src/app/cli/config.rs"
+  loc: "ConfigCommand::Create"
+  note: "The enum variant and CLI command are named 'Create', but the docstring states 'Deploy role configs'."
+
+## Change Scope
+
+- `src/app/cli/config.rs`


### PR DESCRIPTION
Emits 3 event files based on the `cli_sentinel` observer role analysis.

The following issues were identified and documented:
1.  **Structural Drift**: The `backup` command uses a `--list` option toggle as a de-facto subcommand, making the positional argument conditionally required and breaking standard command structure (`verb [object] arguments`).
2.  **I/O Separation Violation**: The `backup` command emits a warning ("Using package defaults") directly to `stdout` instead of `stderr`, mixing diagnostic logs with potential output streams.
3.  **Naming Consistency Drift**: The `config create` command deploys existing configuration rather than creating new environments, conflicting with the top-level `create` command's provisioning semantics.

---
*PR created automatically by Jules for task [12336399488082218617](https://jules.google.com/task/12336399488082218617) started by @akitorahayashi*