### PR TITLE
docs: emit cov event files for missing test coverage

### DIFF
--- a/.jules/exchange/events/ansible_executor_uncovered_cov.md
+++ b/.jules/exchange/events/ansible_executor_uncovered_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2026-03-14"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The Ansible executor adapter in `src/adapters/ansible/executor.rs` has low coverage (32/129 lines covered, ~24.8%).
+
+## Goal
+
+Improve test coverage for `AnsibleExecutor` to detect regressions in external process orchestration, error handling, and playbook argument formation.
+
+## Context
+
+The `executor.rs` file interfaces with the system's `ansible-playbook` binary, which is a highly failure-prone external dependency. The untested lines include the bulk of the command generation, argument formatting, and execution error-handling logic. Regressions here could cause deployment commands to fail or apply configurations incorrectly without being caught by the test suite, representing a significant false safety risk for system administration tasks.
+
+## Evidence
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "1-129"
+  note: "Line coverage is at 32/129 lines. Uncovered areas include the actual subprocess invocation and argument formatting logic within the `AnsiblePort` implementation."
+
+## Change Scope
+
+- `src/adapters/ansible/executor.rs`

--- a/.jules/exchange/events/backup_command_missing_coverage_cov.md
+++ b/.jules/exchange/events/backup_command_missing_coverage_cov.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2026-03-14"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The `backup` command logic in `src/app/commands/backup/mod.rs` has extremely low coverage (13/153 lines, 8.5%).
+
+## Goal
+
+Increase coverage for the `backup` command to control the risk of regressions in backup generation, file writing, and system settings resolution.
+
+## Context
+
+The `backup` command is responsible for reading macOS system defaults and VSCode extensions, processing them, and writing configuration YAML/JSON files safely to disk. Since this involves interacting with external ports (`FsPort`, `MacosDefaultsPort`, `VscodePort`) and manipulating user data, regressions could lead to silent data loss or corrupted backup files. Currently, the test suite only covers the CLI contract and argument parsing for `backup`, not the actual orchestration and logic.
+
+## Evidence
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "44-310"
+  note: "Line coverage is at 13/153 lines (8.5%). The untested lines encompass the entire logic for `execute_system` and `execute_vscode`, which dictate how backups are processed and saved."
+
+## Change Scope
+
+- `src/app/commands/backup/mod.rs`
+- `tests/cli/backup.rs`

--- a/.jules/exchange/events/repository_ref_parsing_uncovered_cov.md
+++ b/.jules/exchange/events/repository_ref_parsing_uncovered_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2026-03-14"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The GitHub repository reference domain model in `crates/mev-internal/src/domain/repository_ref.rs` has 0/48 lines covered during the workspace coverage run.
+
+## Goal
+
+Ensure the core domain parsing logic for repository references is fully covered by tests and properly executed in the CI coverage gate.
+
+## Context
+
+`RepositoryRef` handles critical domain logic: parsing SSH, HTTPS, and SCP-like Git remotes. Invariants in parsing must be robust to ensure correct repository operations downstream. A regression in parsing would silently break internal Git and GitHub adapter flows. Although there is a `#[cfg(test)]` module in the file, it is not being detected or executed by `cargo-tarpaulin` (0% coverage), indicating a gap in either test structure, coverage tool configuration for the workspace, or missing integration test execution.
+
+## Evidence
+
+- path: "crates/mev-internal/src/domain/repository_ref.rs"
+  loc: "3-83"
+  note: "Line coverage is at 0/48 lines. The unexecuted code includes core invariant checks like `parse_scp_like_remote` and `parse_ssh_remote` which process external state."
+
+## Change Scope
+
+- `crates/mev-internal/src/domain/repository_ref.rs`


### PR DESCRIPTION
Emitted 3 event files indicating missing test coverage in critical areas of the repository, per the `cov` observer role layer contract.

- `ansible_executor_uncovered_cov.md` for `src/adapters/ansible/executor.rs` (32/129 lines covered)
- `backup_command_missing_coverage_cov.md` for `src/app/commands/backup/mod.rs` (13/153 lines covered)
- `repository_ref_parsing_uncovered_cov.md` for `crates/mev-internal/src/domain/repository_ref.rs` (0/48 lines covered)

Also reverted changes to `mise.lock` caused by `cargo-tarpaulin`.

---
*PR created automatically by Jules for task [11775562541553315587](https://jules.google.com/task/11775562541553315587) started by @akitorahayashi*