### PR TITLE
chore: triage requirements for implementation readiness

### DIFF
--- a/.jules/exchange/requirements/cli_naming_drift.md
+++ b/.jules/exchange/requirements/cli_naming_drift.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/documentation_consistency_updates.md
+++ b/.jules/exchange/requirements/documentation_consistency_updates.md
@@ -1,6 +1,6 @@
 ---
 label: "docs"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/vague_security_assertions.md
+++ b/.jules/exchange/requirements/vague_security_assertions.md
@@ -1,6 +1,6 @@
 ---
 label: "tests"
-implementation_ready: false
+implementation_ready: true
 ---
 
 ## Goal


### PR DESCRIPTION
Triage requirement files in `.jules/exchange/requirements` and modify the `implementation_ready` attribute based on change scope and architectural impact.

---
*PR created automatically by Jules for task [14336805768305916394](https://jules.google.com/task/14336805768305916394) started by @akitorahayashi*