### PR TITLE
docs: update architecture references to match implementation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,14 +20,15 @@ src/
 │   ├── cli/               # clap argument contracts (1 file per command)
 │   │   └── mod.rs         # Single owner of clap parser and command dispatch
 │   ├── commands/           # Orchestration units per command domain
-│   ├── context.rs          # Dependency wiring (ports → adapters)
+│   ├── container.rs        # Dependency wiring (ports → adapters)
 │   └── api.rs              # Stable library entrypoints
 ├── domain/
 │   ├── error.rs            # Typed domain errors
 │   ├── ports/              # Trait interfaces
 │   ├── profile.rs          # Profile identifiers and mapping
 │   ├── tag.rs              # Tag resolution from catalogs
-│   ├── config.rs           # VCS identity configuration model
+│   ├── vcs_identity.rs     # VCS identity configuration model
+│   ├── backup_target.rs    # Backup target resolution and metadata
 │   └── execution_plan.rs   # Deterministic ansible plan construction
 ├── adapters/
 │   ├── ansible/            # Playbook execution, locator, runtime asset materialization
@@ -41,7 +42,7 @@ src/
 └── testing/                # In-process test doubles
 
 crates/
-└── mev-internal/          # Internal command implementations (shell, vcs)
+└── mev-internal/          # Internal command implementations (vcs)
 
 tests/
 ├── harness/                # Shared fixtures (TestContext)


### PR DESCRIPTION
Update architecture documentation to accurately reflect current codebase structure and dependencies by fixing incorrect filenames, removing non-existent module references, and adding missing files.

---
*PR created automatically by Jules for task [2959136171368859658](https://jules.google.com/task/2959136171368859658) started by @akitorahayashi*