### PR TITLE
Refine backup command structure and implement integration tests

### DIFF
--- a/src/app/cli/backup.rs
+++ b/src/app/cli/backup.rs
@@ -6,27 +6,16 @@ use crate::app::api;
 use crate::domain::error::AppError;
 
 #[derive(Args)]
-#[command(group(
-    clap::ArgGroup::new("action")
-        .required(true)
-        .args(["list", "target"]),
-))]
 pub struct BackupArgs {
-    #[arg(short = 'l', long = "list", aliases = ["ls"], action = clap::ArgAction::SetTrue, help = "List available backup targets")]
-    pub list: bool,
-
-    /// Backup target (system, vscode).
-    pub target: Option<String>,
+    /// Backup target (system, vscode, or 'list' to show available targets).
+    pub target: String,
 }
 
 pub fn run(args: BackupArgs) -> Result<(), AppError> {
-    if args.list {
+    if args.target == "list" {
         api::backup_list();
         Ok(())
-    } else if let Some(target) = args.target {
-        api::backup(target.as_str())
     } else {
-        // Controlled by ArgGroup(required=true)
-        unreachable!("clap ensures either list or target is present")
+        api::backup(args.target.as_str())
     }
 }

--- a/src/app/commands/backup/mod.rs
+++ b/src/app/commands/backup/mod.rs
@@ -55,7 +55,7 @@ pub fn execute(ctx: &DependencyContainer, target_input: &str) -> Result<(), AppE
             let definitions_dir = match resolve_definitions_dir(&local_config_dir, ctx, &target) {
                 DefinitionsDirResolution::Local(path) => path,
                 DefinitionsDirResolution::PackageDefault { resolved_dir, missing_local_dir } => {
-                    println!(
+                    eprintln!(
                         "Local definitions not found at {}. Using package defaults.",
                         missing_local_dir.display()
                     );

--- a/tests/cli/backup.rs
+++ b/tests/cli/backup.rs
@@ -22,38 +22,21 @@ fn backup_alias_bk_is_accepted() {
     let ctx = TestContext::new();
 
     ctx.cli()
-        .args(["bk", "--list"])
+        .args(["bk", "list"])
         .assert()
         .success()
         .stdout(predicate::str::contains("Available backup targets"));
 }
 
 #[test]
-fn backup_list_shows_targets() {
+fn backup_positional_list_shows_targets() {
     let ctx = TestContext::new();
 
-    ctx.cli().args(["backup", "--list"]).assert().success().stdout(
+    ctx.cli().args(["backup", "list"]).assert().success().stdout(
         predicate::str::contains("system")
             .and(predicate::str::contains("vscode"))
             .and(predicate::str::contains("Available backup targets")),
     );
-}
-
-#[test]
-fn backup_short_list_flag_shows_targets() {
-    let ctx = TestContext::new();
-
-    ctx.cli()
-        .args(["backup", "-l"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("Available backup targets"));
-
-    ctx.cli()
-        .args(["backup", "--ls"])
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("Available backup targets"));
 }
 
 #[test]
@@ -72,4 +55,114 @@ fn backup_help_visible_in_main_help() {
     let ctx = TestContext::new();
 
     ctx.cli().arg("--help").assert().success().stdout(predicate::str::contains("backup"));
+}
+
+#[test]
+fn backup_system_generates_yaml() {
+    let ctx = TestContext::new();
+
+    let def_dir = ctx.work_dir().join(".config/mev/roles/system/common/definitions");
+    std::fs::create_dir_all(&def_dir).unwrap();
+
+    let def_file = def_dir.join("test.yml");
+    std::fs::write(
+        &def_file,
+        r#"
+- key: "test_key"
+  type: "string"
+  default: "test_value"
+"#,
+    )
+    .unwrap();
+
+    // Create a fake defaults executable that just prints a known value so we don't rely on the real defaults tool
+    let bin_dir = ctx.work_dir().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let fake_defaults = bin_dir.join("defaults");
+    std::fs::write(&fake_defaults, "#!/bin/sh\necho 'fake_value'\n").unwrap();
+
+    // Make executable
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&fake_defaults).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_defaults, perms).unwrap();
+    }
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), original_path);
+
+    ctx.cli()
+        .args(["backup", "system"])
+        .env("PATH", new_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Backup completed successfully"));
+
+    let out_file = ctx.work_dir().join(".config/mev/roles/system/common/system.yml");
+    assert!(out_file.exists());
+    let content = std::fs::read_to_string(&out_file).unwrap();
+    assert!(content.contains("test_key"));
+    assert!(content.contains("fake_value"));
+}
+
+#[test]
+fn backup_system_emits_fallback_warning_to_stderr() {
+    let ctx = TestContext::new();
+
+    // Do not create local definitions to trigger the fallback logic
+
+    // We still need `defaults` to pass if it checks real defaults, but without definitions it will just use package defaults,
+    // which in TestContext will not exist either, so it will fail with "definitions directory not found".
+    // Wait, the fallback resolves to `ansible_dir/roles/system/config/common/definitions`.
+    // Let's see what happens without injecting definitions. It will use package defaults.
+    // If the test context doesn't map to real ansible_dir, it will fail, BUT it will have emitted the stderr first.
+    let result = ctx.cli().args(["backup", "system"]).assert();
+
+    result.stderr(predicate::str::contains("Local definitions not found at"));
+}
+
+#[test]
+fn backup_vscode_generates_json() {
+    let ctx = TestContext::new();
+
+    let bin_dir = ctx.work_dir().join("bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    let fake_code = bin_dir.join("code");
+    std::fs::write(
+        &fake_code,
+        r#"#!/bin/sh
+if [ "$1" = "--list-extensions" ]; then
+    echo 'ms-python.python'
+    echo 'rust-lang.rust-analyzer'
+fi
+"#,
+    )
+    .unwrap();
+
+    // Make executable
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&fake_code).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&fake_code, perms).unwrap();
+    }
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    let new_path = format!("{}:{}", bin_dir.display(), original_path);
+
+    ctx.cli()
+        .args(["backup", "vscode"])
+        .env("PATH", new_path)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Backup completed successfully"));
+
+    let out_file = ctx.work_dir().join(".config/mev/roles/editor/common/vscode-extensions.json");
+    assert!(out_file.exists());
+    let content = std::fs::read_to_string(&out_file).unwrap();
+    assert!(content.contains("ms-python.python"));
+    assert!(content.contains("rust-lang.rust-analyzer"));
 }


### PR DESCRIPTION
This pull request addresses the `backup` command refinements described in the execution plan.

Key changes:
1. Removed the `--list` flag and its aliases in favor of handling `"list"` natively via the `target` argument in `src/app/cli/backup.rs`.
2. Changed `println!` to `eprintln!` for the fallback "Local definitions not found..." warning in `src/app/commands/backup/mod.rs` to enforce correct stream separation.
3. Overhauled `tests/cli/backup.rs`:
   - Replaced old flag tests with tests checking positional `list`.
   - Added `backup_system_generates_yaml` utilizing a mocked `defaults` script and isolated `.config` paths to assert integration execution.
   - Added `backup_system_emits_fallback_warning_to_stderr`.
   - Added `backup_vscode_generates_json` by mocking the `code` CLI executable in a temporary `bin` directory, effectively testing the observable behaviors without mocking internal orchestrator state.

All testing passes cleanly locally using `cargo test` and `just test`.

---
*PR created automatically by Jules for task [15859865069004875488](https://jules.google.com/task/15859865069004875488) started by @akitorahayashi*