### PR TITLE
chore: bootstrap runtime workspace

### DIFF
--- a/crates/mev-internal/src/domain/repository_ref.rs
+++ b/crates/mev-internal/src/domain/repository_ref.rs
@@ -121,4 +121,43 @@ mod tests {
             .expect("ssh remote should parse");
         assert_eq!(repo.as_gh_repo_arg(), "github.com/owner/repo");
     }
+
+    #[test]
+    fn from_remote_url_parses_scp_like_ssh() {
+        let repo = RepositoryRef::from_remote_url("git@github.com:owner/repo.git")
+            .expect("scp-like ssh remote should parse");
+        assert_eq!(repo.host.as_deref(), Some("github.com"));
+        assert_eq!(repo.owner, "owner");
+        assert_eq!(repo.name, "repo");
+    }
+
+    #[test]
+    fn from_remote_url_parses_standard_ssh() {
+        let repo = RepositoryRef::from_remote_url("ssh://git@github.com/owner/repo.git")
+            .expect("standard ssh remote should parse");
+        assert_eq!(repo.host.as_deref(), Some("github.com"));
+        assert_eq!(repo.owner, "owner");
+        assert_eq!(repo.name, "repo");
+    }
+
+    #[test]
+    fn from_remote_url_parses_http() {
+        let repo = RepositoryRef::from_remote_url("http://github.com/owner/repo.git")
+            .expect("http remote should parse");
+        assert_eq!(repo.host.as_deref(), Some("github.com"));
+        assert_eq!(repo.owner, "owner");
+        assert_eq!(repo.name, "repo");
+    }
+
+    #[test]
+    fn from_remote_url_fails_on_unsupported_url() {
+        let result = RepositoryRef::from_remote_url("ftp://github.com/owner/repo.git");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn from_repo_arg_fails_on_invalid_format() {
+        assert!(RepositoryRef::from_repo_arg("just-one-part").is_err());
+        assert!(RepositoryRef::from_repo_arg("host/owner/repo/extra").is_err());
+    }
 }

--- a/src/domain/execution_plan.rs
+++ b/src/domain/execution_plan.rs
@@ -22,3 +22,28 @@ impl ExecutionPlan {
         Self { profile, tags, verbose }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::tag::FULL_SETUP_TAGS;
+
+    #[test]
+    fn full_setup_contains_all_tags() {
+        let plan = ExecutionPlan::full_setup(Profile::Macbook, true);
+        assert_eq!(plan.profile, Profile::Macbook);
+        assert!(plan.verbose);
+
+        assert_eq!(plan.tags.as_slice(), FULL_SETUP_TAGS);
+    }
+
+    #[test]
+    fn make_contains_provided_tags() {
+        let tags = vec!["tag1".to_string(), "tag2".to_string()];
+        let plan = ExecutionPlan::make(Profile::MacMini, tags.clone(), false);
+
+        assert_eq!(plan.profile, Profile::MacMini);
+        assert!(!plan.verbose);
+        assert_eq!(plan.tags, tags);
+    }
+}


### PR DESCRIPTION
Automated bootstrap update for the runtime workspace.

- synchronize main into jules via `jlo workflow bootstrap worker-branch`
- bootstrap managed files via `jlo workflow bootstrap managed-files`
- reset exchange state via `jlo workflow bootstrap clean-exchange`