### PR TITLE
docs(observer): emit rustacean events for unsafe and cloning

### DIFF
--- a/.jules/exchange/events/mutex_shared_state_testing_rustacean.md
+++ b/.jules/exchange/events/mutex_shared_state_testing_rustacean.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2024-05-23"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+`FakeAnsiblePort` and other fakes in `src/testing/fakes.rs` utilize `std::sync::Mutex` to wrap mock internal state (like `files`, `dirs`, `events`).
+
+## Goal
+
+Replace coarse-grained `Mutex` shared mutable state with more isolated or single-owner structures. If tests are synchronous, `RefCell` is more appropriate. Alternatively, tests should be structured so that the `App` or the `Adapter` can run without needing heavily synchronized shared state.
+
+## Context
+
+Defaulting to `Arc<Mutex<T>>` as a universal escape hatch is an anti-pattern. Test fakes shouldn't need thread-safe locking unless they are actively being used across multiple threads, which shouldn't be the case for simple component tests. If the adapter tests are indeed multithreaded, the lock scope and state management should be explicit and bounded.
+
+## Evidence
+
+- path: "src/testing/fakes.rs"
+  loc: "11, 13, 15, 21-23"
+  note: "`pub files: Mutex<HashMap<PathBuf, String>>` and other state wrapped in Mutex inside `FakeAnsiblePort`."
+
+## Change Scope
+
+- `src/testing/fakes.rs`

--- a/.jules/exchange/events/unjustified_clone_usage_rustacean.md
+++ b/.jules/exchange/events/unjustified_clone_usage_rustacean.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-05-23"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Unjustified use of `.clone()` on `PathBuf` when passing directories within `AnsibleAdapter`. The adapter copies the paths via `clone()` instead of utilizing references (`&Path`) when traversing or returning values, leading to unnecessary allocations. Also in `src/app/commands/backup/mod.rs` strings are explicitly cloned when processing YAML sequences.
+
+## Goal
+
+Eliminate unjustified reflexive `.clone()` usages by aligning ownership structures to utilize borrowed values (`&str`, `&Path`) where appropriate, reducing unnecessary allocations and keeping references tighter to their data owners.
+
+## Context
+
+Clone/RC must pay rent: copies and shared ownership exist only with a named boundary rationale. Cloning strings or paths simply to appease the borrow checker or to avoid lifetime annotations when the data outlives the required scope goes against ownership principles.
+
+## Evidence
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "419"
+  note: "`ansible_dir: ansible_dir.clone(),` is an unnecessary clone as `AnsibleAdapter` could take ownership or the test can be restructured to avoid cloning the tempdir path."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "152, 216"
+  note: "`serde_yaml::Value::String(s) => s.clone()` unnecessary cloning of string values out of the YAML tree."
+
+## Change Scope
+
+- `src/adapters/ansible/executor.rs`
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/unsafe_env_var_mutation_rustacean.md
+++ b/.jules/exchange/events/unsafe_env_var_mutation_rustacean.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2024-05-23"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+The `EnvGuard` struct in `src/adapters/ansible/executor.rs` uses `unsafe { env::set_var(...) }` and `unsafe { env::remove_var(...) }` to mutate process-wide environment variables during unit tests.
+
+## Goal
+
+Remove `unsafe` environment variable mutations from the test suite to prevent undefined behavior and data races. Use `serial_test` with a safer approach or redesign the test to avoid process-global state changes, potentially by passing environment variables explicitly through a context or using `std::process::Command::env()` and testing the command builder instead of relying on global env state for binary resolution tests.
+
+## Context
+
+Modifying process environment variables (`env::set_var`, `env::remove_var`) is inherently unsafe in Rust when multiple threads are running, as it can cause data races with any other code reading the environment. While the tests are marked with `#[serial]`, using `unsafe` blocks for this is an anti-pattern and often masks a design issue where global state is used instead of explicit dependency injection or configuration objects.
+
+## Evidence
+
+- path: "src/adapters/ansible/executor.rs"
+  loc: "304, 311, 319, 321"
+  note: "`EnvGuard` uses `unsafe { env::set_var(...) }` and `unsafe { env::remove_var(...) }`."
+
+## Change Scope
+
+- `src/adapters/ansible/executor.rs`


### PR DESCRIPTION
Emits 3 events covering unsafe env var mutations, unjustified `clone()` usage on PathBuf and Strings, and `Mutex` usage in test fakes. All findings are backed by file paths and evidence.

---
*PR created automatically by Jules for task [6052989587389273265](https://jules.google.com/task/6052989587389273265) started by @akitorahayashi*