### PR TITLE
Emit taxonomy events for ambiguous naming

### DIFF
--- a/.jules/exchange/events/remove_ambiguous_common_profile_taxonomy.md
+++ b/.jules/exchange/events/remove_ambiguous_common_profile_taxonomy.md
@@ -1,0 +1,34 @@
+---
+label: "refacts"
+created_at: "2024-03-19"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The term `common` is used extensively in the domain (e.g., `Profile::Common`, `src/domain/profile.rs`, config directories, CLI parameters). This violates the core design principle that prohibits ambiguous names such as `common`.
+
+## Goal
+
+Refactor the taxonomy to replace `common` with a precise, domain-aligned term (e.g., `baseline`, `shared`, or `default`). This includes updating the profile definitions, domain logic, command parameters, test cases, and configuration folder structures.
+
+## Context
+
+Using `common` is explicitly discouraged by the system architecture as an ambiguous classification that obscures a module or concept's precise responsibility. For `mev` profiles, a term like `baseline` defines the explicit role of configurations that apply universally before machine-specific overrides.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "line 12, 21, 56"
+  note: "Defines the `Profile::Common` variant and its canonical mapping to `common`."
+- path: "src/app/cli/make.rs"
+  loc: "line 14, 15"
+  note: "Defines the profile argument with the default value `common`."
+
+## Change Scope
+
+- `src/domain/profile.rs`
+- `src/domain/backup_target.rs`
+- `src/app/cli/make.rs`
+- Config directory layouts under `src/assets/ansible/roles/**/config/common`

--- a/.jules/exchange/events/remove_ambiguous_helpers_cli_taxonomy.md
+++ b/.jules/exchange/events/remove_ambiguous_helpers_cli_taxonomy.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-19"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The CLI descriptions for internal tools use the term `helpers` (`Git helpers.`, `GitHub CLI helpers.`). This violates the core design principle that prohibits the use of ambiguous taxonomy terms like `helpers`.
+
+## Goal
+
+Refactor the CLI command descriptions to avoid the term `helpers`, replacing it with descriptive, domain-aligned language (e.g., `Git integration commands.`, `GitHub CLI integration commands.`).
+
+## Context
+
+Using `helpers` for subcommands obfuscates the explicit functional boundaries they represent. A clear domain vocabulary is prioritized to optimize for comprehension and refactor safety.
+
+## Evidence
+
+- path: "src/app/cli/mod.rs"
+  loc: "line 67, 71"
+  note: "Uses `Git helpers.` and `GitHub CLI helpers.` for the `Git` and `Gh` internal subcommands respectively."
+- path: "crates/mev-internal/src/app/cli/mod.rs"
+  loc: "line 19, 23"
+  note: "Uses `Git helpers.` and `GitHub CLI helpers.` for the `Git` and `Gh` subcommands respectively."
+
+## Change Scope
+
+- `src/app/cli/mod.rs`
+- `crates/mev-internal/src/app/cli/mod.rs`

--- a/.jules/exchange/events/remove_ambiguous_helpers_taxonomy.md
+++ b/.jules/exchange/events/remove_ambiguous_helpers_taxonomy.md
@@ -1,0 +1,28 @@
+---
+label: "refacts"
+created_at: "2024-03-19"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The internal documentation comment `// Shared helpers` in `src/app/commands/backup/mod.rs` uses the forbidden term `helpers`, which violates the architectural constraint: "Class and file must not have ambiguous names or responsibilities such as base, common, core, utils, or helpers."
+
+## Goal
+
+Remove the ambiguous taxonomy (`Shared helpers`) from the codebase, replacing it with a precise, domain-aligned term that reflects the function's responsibility (e.g., `Resolution logic`).
+
+## Context
+
+The `AGENTS.md` and repository guidelines strictly prohibit ambiguous taxonomy like `base`, `common`, `core`, `utils`, or `helpers`. The presence of `Shared helpers` as a section comment within a module violates these constraints. Renaming it to clarify the exact purpose improves comprehensibility and adherence to the guidelines.
+
+## Evidence
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "line 275"
+  note: "The comment reads `// Shared helpers` which explicitly uses the forbidden term `helpers`."
+
+## Change Scope
+
+- `src/app/commands/backup/mod.rs`


### PR DESCRIPTION
Emits three event files tracking naming anti-patterns according to the taxonomy observer role:

- Identifies `helpers` usage in `src/app/commands/backup/mod.rs`
- Identifies `helpers` usage in CLI descriptions (`src/app/cli/mod.rs` and `crates/mev-internal/src/app/cli/mod.rs`)
- Identifies `common` usage in profile logic (`src/domain/profile.rs`, etc.)

---
*PR created automatically by Jules for task [16264969919173924727](https://jules.google.com/task/16264969919173924727) started by @akitorahayashi*