### PR TITLE
docs(observer): emit rustacean events for error handling and fallbacks

### DIFF
--- a/.jules/exchange/events/silent_fallbacks_rustacean.md
+++ b/.jules/exchange/events/silent_fallbacks_rustacean.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2024-05-24"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Multiple usage of `.unwrap_or_default()` when parsing configurations or standard paths, masking failure and providing silent fallbacks.
+
+## Goal
+
+Ensure silent fallbacks are explicit, opt-in, or clearly logged. If an operation fails, it should propagate an error rather than silently defaulting, or the default should be justified.
+
+## Context
+
+Silent fallback behaviors drift configuration and mask failures. Falling back to default strings without surfacing a failure makes debugging difficult, violating the "No silent fallback" principle.
+
+## Evidence
+
+- path: "src/adapters/git/cli.rs"
+  loc: "read_config"
+  note: "`read_config` uses `.unwrap_or_default()` if `git config` fails, silently suppressing config fetch errors."
+
+- path: "src/adapters/ansible/locator.rs"
+  loc: "locate_ansible_dir"
+  note: "Locator logic defaults silently to returning an empty string/path when resolution fails."
+
+## Change Scope
+
+- `src/adapters/git/cli.rs`
+- `src/adapters/ansible/locator.rs`

--- a/.jules/exchange/events/untyped_errors_domain_rustacean.md
+++ b/.jules/exchange/events/untyped_errors_domain_rustacean.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2024-05-24"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Widespread use of `Box<dyn std::error::Error>` in domain logic (e.g., `RepositoryRef`) and application boundaries, losing typed error semantics and classification.
+
+## Goal
+
+Replace dynamic error trait objects with typed domain errors (like `AppError` or a specialized enum) to preserve domain meaning and context after propagation.
+
+## Context
+
+Using `Box<dyn Error>` collapses typed errors, preventing downstream callers from meaningfully matching on failure variants or adding context based on the operation. This violates the "Errors are part of the contract" principle.
+
+## Evidence
+
+- path: "crates/mev-internal/src/domain/repository_ref.rs"
+  loc: "from_repo_arg, from_remote_url"
+  note: "`from_repo_arg` and `from_remote_url` return `Result<Self, Box<dyn std::error::Error>>`, erasing the distinction between parsing and IO failures."
+
+- path: "src/app/container.rs"
+  loc: "new, for_identity"
+  note: "`Container::new` and `Container::for_identity` return dynamic errors instead of `AppError`."
+
+## Change Scope
+
+- `crates/mev-internal/src/domain/repository_ref.rs`
+- `src/app/container.rs`


### PR DESCRIPTION
Adds observer events targeting Rust ownership and boundary invariants, explicitly documenting `Box<dyn Error>` domain leakage and silent fallbacks inside config adapters.

---
*PR created automatically by Jules for task [7342318438015691694](https://jules.google.com/task/7342318438015691694) started by @akitorahayashi*