### PR TITLE
Emit data_arch events for hardcoded enumerables

### DIFF
--- a/.jules/exchange/events/duplicate_tag_definitions_data_arch.md
+++ b/.jules/exchange/events/duplicate_tag_definitions_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-03-23"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Ansible execution tags (e.g., `python-platform`, `nodejs-tools`) are hardcoded in the Rust domain layer (`src/domain/tag.rs`) while the single source of truth for tag definitions is the Ansible playbook itself (`src/assets/ansible/playbook.yml`).
+
+## Goal
+
+Generate tag groups and lists dynamically from the authoritative source (the Ansible playbook) instead of hardcoding them in the Rust domain layer to eliminate maintenance burden and ensure extensibility.
+
+## Context
+
+The `AnsibleAdapter` already implements logic to parse the `playbook.yml` file and resolve the mapping of tags to roles. However, `src/domain/tag.rs` maintains an independent, hardcoded copy of full setup tags (`FULL_SETUP_TAGS`) and tag groups (`tag_groups()`). This violates the Single Source of Truth principle. If a tag is added or modified in the playbook, it must be manually updated in the Rust code to be available for the `create` or `make` commands. It is also error-prone and violates the design rule: "Never hardcode enumerable values. Generate them dynamically from authoritative sources (catalog, registry, schema) to ensure extensibility and eliminate maintenance burden."
+
+## Evidence
+
+- path: "src/domain/tag.rs"
+  loc: "tag_groups"
+  note: "Defines hardcoded `tag_groups()` that duplicate information natively present in or derived from the playbook."
+- path: "src/domain/tag.rs"
+  loc: "FULL_SETUP_TAGS"
+  note: "Defines hardcoded `FULL_SETUP_TAGS` that duplicate information natively present in or derived from the playbook."
+- path: "src/adapters/ansible/executor.rs"
+  loc: "AnsibleAdapter::new"
+  note: "The `AnsibleAdapter::new` function uses logic to parse `playbook.yml` to extract roles and tags, showing that the playbook is already read and parsed at runtime."
+
+## Change Scope
+
+- `src/domain/tag.rs`
+- `src/adapters/ansible/executor.rs`
+- `src/app/commands/create/mod.rs`

--- a/.jules/exchange/events/hardcoded_enumerables_data_arch.md
+++ b/.jules/exchange/events/hardcoded_enumerables_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-03-23"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Backup targets (`system`, `vscode`) and profiles (`macbook`, `mac-mini`, `common`) are hardcoded in the Rust domain layer, requiring manual updates to the Rust code whenever a new backup role or configuration profile is added to the Ansible assets.
+
+## Goal
+
+Eliminate hardcoded enumerable values for Profiles and Backup Targets by generating them dynamically from the Ansible assets.
+
+## Context
+
+`src/domain/profile.rs` and `src/domain/backup_target.rs` contain hardcoded enum variants (`Profile::Macbook`, `BackupTarget::System`, etc.). This violates the Single Source of Truth principle and the design rule against hardcoded enumerable values. The set of available profiles should be derived from the available configurations (e.g., from the authoritative Ansible assets), and the set of backup targets should be derived from the Ansible roles that support backups.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "Profile"
+  note: "Hardcoded enum `Profile` with `Macbook`, `MacMini`, `Common` variants, and hardcoded aliases."
+- path: "src/domain/backup_target.rs"
+  loc: "BackupTarget"
+  note: "Hardcoded enum `BackupTarget` with `System`, `Vscode` variants."
+
+## Change Scope
+
+- `src/domain/profile.rs`
+- `src/domain/backup_target.rs`


### PR DESCRIPTION
Emitted data_arch events highlighting hardcoded enumerable values in the domain layer that should be generated dynamically from authoritative Ansible assets.

---
*PR created automatically by Jules for task [1696376419162252821](https://jules.google.com/task/1696376419162252821) started by @akitorahayashi*