### PR TITLE
Emit Consistency Drift Events

### DIFF
--- a/.jules/exchange/events/build_provenance_drift_consistency.md
+++ b/.jules/exchange/events/build_provenance_drift_consistency.md
@@ -1,0 +1,32 @@
+---
+label: "docs"
+created_at: "2026-03-23"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The CI environment setup for release build artifacts does not use `actions/attest-build-provenance@v2` for code signing and build provenance, despite this being a required CI environment setup rule. The documentation incorrectly describes the release process using manual SHA256 hashes instead of build provenance.
+
+## Goal
+
+Update the CI release workflow to use `actions/attest-build-provenance@v2` with the necessary permissions, and update `docs/configuration.md` to accurately reflect this process.
+
+## Context
+
+The repository rules require that release build artifacts use `actions/attest-build-provenance@v2` for code signing and build provenance. However, `.github/workflows/build.yml` uses a manual `shasum` command and does not use the provenance action, and `docs/configuration.md` documents this manual process.
+
+## Evidence
+
+- path: ".github/workflows/build.yml"
+  loc: "lines 25-30"
+  note: "Uses manual `shasum -a 256` instead of `actions/attest-build-provenance@v2`."
+- path: "docs/configuration.md"
+  loc: "line 15"
+  note: "Documents that 'the build job attaches mev-darwin-aarch64 plus its SHA256 file directly to GitHub Releases', ignoring build provenance requirements."
+
+## Change Scope
+
+- `.github/workflows/build.yml`
+- `docs/configuration.md`

--- a/.jules/exchange/events/naming_rule_drift_consistency.md
+++ b/.jules/exchange/events/naming_rule_drift_consistency.md
@@ -1,0 +1,32 @@
+---
+label: "docs"
+created_at: "2026-03-23"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation explicitly forbids ambiguous directory names such as `core/`, but a `core/` directory exists in the shell alias configurations.
+
+## Goal
+
+Ensure the directory naming rule in the architecture documentation is followed by renaming the `core/` directory, or clarify in the documentation if this rule applies only to Rust source code and not to Ansible configuration assets.
+
+## Context
+
+`docs/architecture.md` defines an Architecture Principle that "Ambiguous names such as `core/`, `utils/`, `helpers/` are forbidden". However, the directory `src/assets/ansible/roles/shell/config/common/alias/core/` exists.
+
+## Evidence
+
+- path: "docs/architecture.md"
+  loc: "line 67"
+  note: "Documentation states 'Ambiguous names such as `core/`, `utils/`, `helpers/` are forbidden'."
+- path: "src/assets/ansible/roles/shell/config/common/alias/core"
+  loc: "Directory exists"
+  note: "A directory named `core` exists in the codebase, violating the documented principle."
+
+## Change Scope
+
+- `docs/architecture.md`
+- `src/assets/ansible/roles/shell/config/common/alias/core/`

--- a/.jules/exchange/events/profile_config_drift_consistency.md
+++ b/.jules/exchange/events/profile_config_drift_consistency.md
@@ -1,0 +1,32 @@
+---
+label: "docs"
+created_at: "2026-03-23"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The documentation states that only the `brew` role uses profile-specific configurations, but the implementation shows that the `llm` role also uses profile-specific configurations.
+
+## Goal
+
+Update the documentation to reflect that both `brew` and `llm` roles use profile-specific configurations, or update the implementation to remove the profile-specific configuration for `llm` if it's not intended.
+
+## Context
+
+According to `docs/architecture.md`, the design rule for profile configs is that "Roles store configs in `config/common/` (all roles) and `config/profiles/` (brew only)". However, the directory `src/assets/ansible/roles/llm/config/profiles/mac-mini/` exists.
+
+## Evidence
+
+- path: "docs/architecture.md"
+  loc: "line 82"
+  note: "Documentation explicitly claims `config/profiles/ (brew only)`."
+- path: "src/assets/ansible/roles/llm/config/profiles/"
+  loc: "Directory exists"
+  note: "The `llm` role contains profile-specific configurations, contradicting the documentation."
+
+## Change Scope
+
+- `docs/architecture.md`
+- `src/assets/ansible/roles/llm/config/profiles/`


### PR DESCRIPTION
Emitted three high-signal event files to `exchange/events` documenting consistency drifts:

1. `profile_config_drift_consistency.md`: The architecture documentation claims only the `brew` role uses profile-specific configs, but the implementation shows the `llm` role doing so as well.
2. `naming_rule_drift_consistency.md`: The architecture documentation forbids ambiguous directory names like `core/`, but the `shell` role configuration clearly has a `core` directory.
3. `build_provenance_drift_consistency.md`: The repository's memory rules dictate the use of `actions/attest-build-provenance@v2` for code signing and build provenance, but the actual implementation in `.github/workflows/build.yml` uses a manual `shasum` action, and the configuration docs reflect this manual workaround.

Tests passed successfully across the workspace and `crates/mev-internal`.

---
*PR created automatically by Jules for task [17534672950542635738](https://jules.google.com/task/17534672950542635738) started by @akitorahayashi*