### PR TITLE
Emit coverage observer events for untracked risk areas

### DIFF
--- a/.jules/exchange/events/untested_backup_operations_cov.md
+++ b/.jules/exchange/events/untested_backup_operations_cov.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2024-03-23"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The system and VSCode settings backup orchestration (`src/app/commands/backup/mod.rs`) suffers from extremely low coverage (9 out of 149 lines covered), failing to validate crucial fallback values and file writes.
+
+## Goal
+
+Ensure that the fallback and normalization logic for system default backups and VSCode extension list parsing are robustly tested to avoid silent failures or data loss when configurations shift.
+
+## Context
+
+According to `cargo tarpaulin` coverage reports, the logic inside `src/app/commands/backup/mod.rs` is responsible for parsing configuration definitions, querying macOS defaults, validating settings, and generating YAML/JSON artifacts. This represents a complex and highly failure-prone data translation boundary. Without significant test coverage, new features or refactorings risk breaking user backup states.
+
+## Evidence
+
+- path: "src/app/commands/backup/mod.rs"
+  loc: "59-247"
+  note: "Only 9/149 lines covered. Critical methods like `execute_system`, `format_value`, and `execute_vscode` lack line-level tests, risking regressions when data formats change."
+
+## Change Scope
+
+- `src/app/commands/backup/mod.rs`
+- `tests/cli_contracts/backup.rs` (to be created or modified)

--- a/.jules/exchange/events/untested_gh_label_reset_cov.md
+++ b/.jules/exchange/events/untested_gh_label_reset_cov.md
@@ -1,0 +1,33 @@
+---
+label: "tests"
+created_at: "2024-03-23"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The GitHub label reset and deploy commands (`crates/mev-internal/src/app/commands/gh/labels_reset.rs` and `labels_deploy.rs`) have 0% line coverage.
+
+## Goal
+
+Provide integration tests for the GitHub label management commands, ensuring that destructive operations behave correctly and handle their error conditions properly without affecting unmanaged remote state.
+
+## Context
+
+According to `cargo tarpaulin` coverage reports, the `labels_reset` and `labels_deploy` orchestrations lack test execution. These orchestrations represent destructive commands modifying external state (GitHub issues configuration). Unmonitored changes in this flow present a risk of unintentional data loss or incorrect label deployments.
+
+## Evidence
+
+- path: "crates/mev-internal/src/app/commands/gh/labels_reset.rs"
+  loc: "16-32"
+  note: "0/12 lines covered in a command that explicitly deletes all labels from a given GitHub repository."
+- path: "crates/mev-internal/src/app/commands/gh/labels_deploy.rs"
+  loc: "17-38"
+  note: "0/13 lines covered in a command that manipulates repository labels by replacing or creating them based on a bundled catalog."
+
+## Change Scope
+
+- `crates/mev-internal/src/app/commands/gh/labels_reset.rs`
+- `crates/mev-internal/src/app/commands/gh/labels_deploy.rs`
+- `crates/mev-internal/tests/gh_contracts.rs` (to be created or modified)

--- a/.jules/exchange/events/untested_vcs_identity_switch_cov.md
+++ b/.jules/exchange/events/untested_vcs_identity_switch_cov.md
@@ -1,0 +1,29 @@
+---
+label: "tests"
+created_at: "2024-03-23"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The VCS identity switching orchestration logic in `src/app/commands/switch/mod.rs` has 0% line coverage. This represents an unmonitored risk to a critical authentication/state transition path.
+
+## Goal
+
+Ensure that identity switching behavior is covered by integration tests at the application boundary to catch regressions in setting proper global Git and Jujutsu configuration states.
+
+## Context
+
+Coverage metrics (via `cargo tarpaulin`) indicate that the entirety of the `switch` command orchestration—including loading identities from the store, validating the identity configuration, and writing values to the VCS ports—is uncovered. As this modifies global tool configurations on the developer's system, a silent failure here could lead to commits being authored with incorrect personal or work identities.
+
+## Evidence
+
+- path: "src/app/commands/switch/mod.rs"
+  loc: "14-43"
+  note: "0/23 lines covered. The `execute` function performs a critical auth/state transition but lacks integration tests validating the success or failure paths."
+
+## Change Scope
+
+- `src/app/commands/switch/mod.rs`
+- `tests/cli_contracts/switch.rs` (to be created or modified)


### PR DESCRIPTION
Emit event files based on test coverage gaps in the mev project. These findings focus on destructive and mutating functions like github label reset, identity context switching, and configurations deployment backup.

---
*PR created automatically by Jules for task [6635395481775348347](https://jules.google.com/task/6635395481775348347) started by @akitorahayashi*