### PR TITLE
Emit consistency events for documentation and CI drift

### DIFF
--- a/.jules/exchange/events/build_provenance_consistency.md
+++ b/.jules/exchange/events/build_provenance_consistency.md
@@ -1,0 +1,28 @@
+---
+label: "bugs"
+created_at: "2024-03-26"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The CI environment documentation specifies that release build artifacts use `actions/attest-build-provenance@v2` for code signing and build provenance, which requires adding `id-token: write` and `attestations: write` permissions to the relevant workflow job. However, `.github/workflows/build.yml` does not implement `actions/attest-build-provenance@v2` and lacks the necessary permissions.
+
+## Goal
+
+Add `actions/attest-build-provenance@v2` to `.github/workflows/build.yml` when uploading release assets, along with the required `id-token: write` and `attestations: write` permissions.
+
+## Context
+
+According to the provided architecture rule for CI Environment Setup (Provenance), release build artifacts must use `actions/attest-build-provenance@v2` for code signing and build provenance, which requires adding `id-token: write` and `attestations: write` permissions to the relevant workflow job. The actual `build.yml` currently builds and uploads the artifact with its sha256 checksum but skips the provenance attestation step.
+
+## Evidence
+
+- path: ".github/workflows/build.yml"
+  loc: "7-42"
+  note: "The `build-darwin-aarch64` job has `permissions: contents: read` only and does not call `actions/attest-build-provenance@v2` after building the release artifact."
+
+## Change Scope
+
+- `.github/workflows/build.yml`

--- a/.jules/exchange/events/cli_aliases_consistency.md
+++ b/.jules/exchange/events/cli_aliases_consistency.md
@@ -1,0 +1,40 @@
+---
+label: "docs"
+created_at: "2024-03-26"
+author_role: "consistency"
+confidence: "high"
+---
+
+## Problem
+
+The CLI documentation in `docs/usage.md` is missing examples for the `config` (`cf`) and `identity` (`id`) shorthands, resulting in drift between the implemented CLI behavior and the usage manual. Furthermore, `mev backup --list` fails to mention the implemented `-l` short flag.
+
+## Goal
+
+Ensure that `docs/usage.md` fully documents the available shorthands for all core subcommands, explicitly adding `cf` for `config`, `id` for `identity`, and `-l` for `backup --list`.
+
+## Context
+
+The `mev` CLI provides consistent aliases for all subcommands (e.g., `cr`, `mk`, `ls`, `cf`, `id`, `sw`, `bk`, `u`) to improve developer experience. However, `docs/usage.md` fails to document `cf`, `id`, and `-l`, causing an incomplete reference.
+
+## Evidence
+
+- path: "docs/usage.md"
+  loc: "39-42"
+  note: "Usage examples for `identity` and `config` omit the `id` and `cf` shorthands entirely."
+
+- path: "src/app/cli/mod.rs"
+  loc: "48-52"
+  note: "The `config` command uses alias `cf` and `identity` uses `id`."
+
+- path: "docs/usage.md"
+  loc: "59"
+  note: "`mev backup --list` is listed, but missing the shorthand `-l`."
+
+- path: "src/app/cli/backup.rs"
+  loc: "15"
+  note: "The `--list` flag implements a short option `-l`."
+
+## Change Scope
+
+- `docs/usage.md`


### PR DESCRIPTION
Emitted consistency events to flag undocumented subcommands (`cf` and `id`) in usage docs and lacking `actions/attest-build-provenance` workflow setup.

---
*PR created automatically by Jules for task [12792363345667806654](https://jules.google.com/task/12792363345667806654) started by @akitorahayashi*