### PR TITLE
feat: add rustacean observer events for ownership and errors

### DIFF
--- a/.jules/exchange/events/explicit_typed_errors_rustacean.md
+++ b/.jules/exchange/events/explicit_typed_errors_rustacean.md
@@ -1,0 +1,48 @@
+---
+label: "refacts"
+created_at: "2024-05-15"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+The codebase frequently uses `Box<dyn std::error::Error>` across multiple layers, including application bounds, domain parsing, and adapter functions. This erases the semantic meaning of errors, making classification impossible and diagnosis less actionable, directly violating the architectural rule: "All domain and boundary errors must use explicit typed errors (e.g., `DomainError` in internal crates or `AppError` at the application layer) instead of generic `Box<dyn std::error::Error>`."
+
+## Goal
+
+Replace all instances of `Box<dyn std::error::Error>` with explicitly typed errors (e.g., `DomainError`, `AppError`, `AdapterError` or standard enum errors per boundary) to preserve error context and semantic classification.
+
+## Context
+
+Using `Box<dyn std::error::Error>` collapses all errors into a generic type, making it impossible for upstream callers to distinguish between different failure modes (e.g., IO vs network vs parsing). By using explicitly typed errors, the codebase adheres to the standard error handling practices where errors are part of the contract and context is attached.
+
+## Evidence
+
+- path: "src/app/container.rs"
+  loc: "40, 60"
+  note: "Uses Box<dyn std::error::Error> as the return type for new() and for_identity()."
+- path: "crates/mev-internal/src/app/commands/git/delete_submodule.rs"
+  loc: "14"
+  note: "Uses Box<dyn std::error::Error> as the return type for run()."
+- path: "crates/mev-internal/src/domain/repository_ref.rs"
+  loc: "11, 20, 51, 64, 71, 78, 85"
+  note: "Parsing functions return Box<dyn std::error::Error>."
+- path: "crates/mev-internal/src/app/cli/gh.rs"
+  loc: "12, 27"
+  note: "Uses Box<dyn std::error::Error>."
+- path: "crates/mev-internal/src/app/cli/git.rs"
+  loc: "11"
+  note: "Uses Box<dyn std::error::Error>."
+- path: "crates/mev-internal/src/adapters/process.rs"
+  loc: "8, 20"
+  note: "Uses Box<dyn std::error::Error>."
+
+## Change Scope
+
+- `src/app/container.rs`
+- `crates/mev-internal/src/app/commands/git/delete_submodule.rs`
+- `crates/mev-internal/src/domain/repository_ref.rs`
+- `crates/mev-internal/src/app/cli/gh.rs`
+- `crates/mev-internal/src/app/cli/git.rs`
+- `crates/mev-internal/src/adapters/process.rs`

--- a/.jules/exchange/events/remove_unwraps_rustacean.md
+++ b/.jules/exchange/events/remove_unwraps_rustacean.md
@@ -1,0 +1,40 @@
+---
+label: "refacts"
+created_at: "2024-05-15"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+The codebase uses `.unwrap()` or `.expect()` heavily in non-test paths (e.g., tests logic is mixed with production code, or commands unwrap directly without surfacing an error correctly to the user), such as parsing environment variables, setting permissions, or running commands. These usages present a risk of unhandled panics and silent failures.
+
+## Goal
+
+Ensure all production code uses explicit typed errors or safely falls back using established error mechanisms, rather than relying on `unwrap()` or `expect()`. Remove panics from critical execution paths (unless genuinely unreachable).
+
+## Context
+
+Using `unwrap()` and `expect()` obscures the source of errors and can crash the application abruptly. Instead of crashing, the application should handle failures gracefully or explicitly propagate them up the call stack to be diagnosed.
+
+## Evidence
+
+- path: "src/adapters/ansible/locator.rs"
+  loc: "98, 99"
+  note: "Locator functions use unwrap() to create directories or write files directly, bypassing error handling."
+- path: "src/adapters/ansible/executor.rs"
+  loc: "309, 311"
+  note: "Executor logic unwraps directory accesses."
+- path: "crates/mev-internal/src/adapters/gh.rs"
+  loc: "71"
+  note: "Unwrapping OS variables heavily or defaulting incorrectly."
+- path: "crates/mev-internal/src/adapters/git.rs"
+  loc: "36"
+  note: "git base dir unwrap_or_else() uses current_dir().unwrap() without dealing with failure gracefully."
+
+## Change Scope
+
+- `src/adapters/ansible/locator.rs`
+- `src/adapters/ansible/executor.rs`
+- `crates/mev-internal/src/adapters/gh.rs`
+- `crates/mev-internal/src/adapters/git.rs`

--- a/.jules/exchange/events/unnecessary_clones_rustacean.md
+++ b/.jules/exchange/events/unnecessary_clones_rustacean.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-05-15"
+author_role: "rustacean"
+confidence: "medium"
+---
+
+## Problem
+
+The `.clone()` usage is prolific throughout the codebase, often used reflexively to appease the borrow checker rather than to express a deliberate design intent. Several instances copy strings, vectors, and path buffers when borrowed values (`&str`, `&Path`, `Cow`) would suffice, leading to unnecessary allocations.
+
+## Goal
+
+Eliminate unjustified reflexive `.clone()` usages by aligning ownership structures to utilize borrowed values (`&str`, `&Path`, `Cow`) where appropriate, reducing unnecessary allocations and keeping references tighter to their data owners.
+
+## Context
+
+Excessive use of `.clone()` obscures the actual ownership flow and introduces unnecessary performance overhead through allocations. Aligning the architecture to favor references or explicit ownership transfers simplifies the mental model of the system.
+
+## Evidence
+
+- path: "src/domain/execution_plan.rs"
+  loc: "43"
+  note: "Clones the `tags` parameter instead of passing it explicitly or allowing an owned variant."
+- path: "src/adapters/ansible/locator.rs"
+  loc: "109, 110"
+  note: "Clones `manifest_dir` unnecessarily instead of passing an owned or referenced path."
+- path: "src/adapters/ansible/executor.rs"
+  loc: "274, 288"
+  note: "Unnecessary string clones when pushing tags to maps/vectors."
+
+## Change Scope
+
+- `src/domain/execution_plan.rs`
+- `src/adapters/ansible/locator.rs`
+- `src/adapters/ansible/executor.rs`


### PR DESCRIPTION
Added three high-signal observer events in `.jules/exchange/events/` identifying specific architectural and ownership issues across the codebase.
- `explicit_typed_errors_rustacean.md`: highlights the systemic use of `Box<dyn Error>` instead of strongly-typed boundary errors.
- `remove_unwraps_rustacean.md`: addresses the pervasive use of `.unwrap()` and `.expect()` in non-test paths.
- `unnecessary_clones_rustacean.md`: calls out the unjustified reflexive use of `.clone()` when references would suffice.

---
*PR created automatically by Jules for task [10306413578745225880](https://jules.google.com/task/10306413578745225880) started by @akitorahayashi*