### PR TITLE
docs: emit QA observer findings for test structure

### DIFF
--- a/.jules/exchange/events/adapter_tests_rely_on_host_state_qa.md
+++ b/.jules/exchange/events/adapter_tests_rely_on_host_state_qa.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2024-05-30"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Adapter contract tests rely on unconstrained host global state. Tests like `tests/adapters/git.rs` and `tests/adapters/jj.rs` verify whether `git` or `jj` is available on the machine running the tests (`is_available`). If the test environment doesn't have these installed, `which::which("git")` or `which::which("jj")` fails, leading to differences in test execution. For `jj_cli_is_available_returns_bool`, it only checks that it doesn't panic. For `git_cli_reports_available`, it strictly asserts `assert!(git.is_available());`, causing an actual test failure if `git` is missing.
+
+## Goal
+
+Ensure adapter contract tests use mock tools, fakes, dependency injection, or properly configured local repositories rather than unconstrained global host state so they run deterministically and correctly on all environments.
+
+## Context
+
+Testing against host environments is an anti-pattern. Adapter contract tests should rely on test fakes or properly constructed mock directories where tools like `git` and `jj` are isolated from the host environment to guarantee reproducibility across all developer and CI machines. Relying on `git` or `jj` binaries in the system's `$PATH` directly violates the testing rule regarding unconstrained host global state.
+
+## Evidence
+
+- path: "tests/adapters/git.rs"
+  loc: "10-12"
+  note: "Asserts `git.is_available()` returns true, which fails on environments where git is missing."
+- path: "tests/adapters/jj.rs"
+  loc: "10-13"
+  note: "Test ignores the `is_available()` result because it acknowledges `jj` might be missing in CI. Relies on host state."
+
+## Change Scope
+
+- `tests/adapters/git.rs`
+- `tests/adapters/jj.rs`

--- a/.jules/exchange/events/duplicate_help_and_shape_tests_qa.md
+++ b/.jules/exchange/events/duplicate_help_and_shape_tests_qa.md
@@ -1,0 +1,44 @@
+---
+label: "tests"
+created_at: "2024-05-30"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Duplicate boundary test coverage for CLI argument checks. Each subcommand test file verifies `--help` output attributes, instead of concentrating global argument and general shape tests in a single place.
+
+## Goal
+
+Consolidate basic CLI shape checks (like validating `--help` outputs, presence of standard flags, handling of unrecognised commands) into a central boundary test file (e.g., `tests/cli/help_and_version.rs`) to prevent test duplication and reduce redundant maintenance across many files.
+
+## Context
+
+Running similar shape tests repeatedly across `tests/cli/list.rs`, `tests/cli/make.rs`, `tests/cli/create.rs`, and others adds to the total execution time, makes modifying help text difficult, and fails to follow the strategy of testing behavior rather than internals or redundant properties across multiple modules. The testing rules explicitly dictate consolidating CLI shape checks into a single boundary test.
+
+## Evidence
+
+- path: "tests/cli/make.rs"
+  loc: "6-24"
+  note: "Verifies make help shows overwrite flag, verbose flag, and profile flag."
+- path: "tests/cli/create.rs"
+  loc: "7-25"
+  note: "Verifies create help shows overwrite flag, verbose flag."
+- path: "tests/cli/list.rs"
+  loc: "6-17"
+  note: "Verifies list help shows description and alias."
+- path: "tests/cli/backup.rs"
+  loc: "6-14"
+  note: "Verifies backup help shows target argument."
+
+## Change Scope
+
+- `tests/cli/help_and_version.rs`
+- `tests/cli/create.rs`
+- `tests/cli/make.rs`
+- `tests/cli/list.rs`
+- `tests/cli/backup.rs`
+- `tests/cli/switch.rs`
+- `tests/cli/config.rs`
+- `tests/cli/identity.rs`

--- a/.jules/exchange/events/global_state_modification_flakiness_qa.md
+++ b/.jules/exchange/events/global_state_modification_flakiness_qa.md
@@ -1,0 +1,35 @@
+---
+label: "tests"
+created_at: "2024-05-30"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Some tests implicitly configure global process state, leading to non-determinism, undefined behaviors, or test data races. In `tests/harness/test_context.rs`, the code configures paths directly instead of leveraging `serial_test` (`#[serial]`) when it has no option but to modify state, but there isn't actually global state modification using `unsafe { env::set_var }` directly. But if a developer were to introduce one based on `cmd.env()`, it is fine. However, a deeper issue lies within the architecture of `test_tmp_dir` inside `TestContext::new()`. Multiple parallel tests use `tempfile::TempDir::new_in(&test_tmp_dir)` which is relatively safe, but multiple `TestContext::new()` runs concurrently could cause resource exhaustion or interference if not careful. The main problem is `TestContext` doesn't enforce serialization for parallel tests doing heavy operations.
+Wait, let's look at `crates/mev-internal/src/testing/env_mock.rs` that explicitly warns:
+"Note: Tests using this should be marked with `#[serial]` to avoid environment variable races."
+And `env::set_current_dir(target_dir).unwrap();` is used globally by `DirGuard`. This modifies global process state, affecting all tests running concurrently.
+
+## Goal
+
+Ensure tests using `DirGuard` or `PathGuard` in `crates/mev-internal/src/testing/env_mock.rs` or any logic modifying global state (`env::set_current_dir`, `env::set_var`) use the `serial_test` crate (`#[serial]`) to avoid test flakiness, or refactor the code to avoid modifying global state entirely.
+
+## Context
+
+Modifying global state in Rust tests is inherently unsafe and leads to race conditions since `cargo test` runs tests in parallel by default on multiple threads. If one test changes the current working directory while another test executes, the second test may fail unpredictably (flakiness). This breaks the core principle of isolation and determinism over retries.
+
+## Evidence
+
+- path: "crates/mev-internal/src/testing/env_mock.rs"
+  loc: "15-16"
+  note: "`DirGuard::new` calls `env::set_current_dir(target_dir).unwrap();`. If any test uses `DirGuard` without `#[serial]`, it causes global state data races."
+- path: "crates/mev-internal/src/testing/env_mock.rs"
+  loc: "44-46"
+  note: "`PathGuard::new` calls `unsafe { env::set_var(\"PATH\", new_path); }`. It expects tests to use `#[serial]`, but if they forget, undefined behavior occurs."
+
+## Change Scope
+
+- `crates/mev-internal/src/testing/env_mock.rs`
+- `crates/mev-internal/tests/gh_contracts.rs` (needs to verify all tests use #[serial] properly or refactor them to use DI)


### PR DESCRIPTION
Emitted 3 event files into `.jules/exchange/events/` evaluating test structure and quality based on the QA observer contract.

The emitted events identify:
1. Adapter tests relying on host global state (e.g., git/jj presence in $PATH).
2. Duplicate CLI shape/help tests scattered across multiple files that should be consolidated.
3. Flakiness risks from modifying global process state (e.g., current directory or $PATH) without using `serial_test`.

---
*PR created automatically by Jules for task [6097183217888079476](https://jules.google.com/task/6097183217888079476) started by @akitorahayashi*