### PR TITLE
tests: emit observer events for low coverage boundaries

### DIFF
--- a/.jules/exchange/events/uncovered_adapters_ansible_runtime_assets_cov.md
+++ b/.jules/exchange/events/uncovered_adapters_ansible_runtime_assets_cov.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The extraction logic in `src/adapters/ansible/runtime_assets.rs`, responsible for dumping embedded Ansible assets to disk, is significantly under-tested.
+
+## Goal
+
+Provide rigorous test coverage ensuring that `runtime_assets.rs` can extract embedded directories securely to temporary spaces, controlling risks around corrupt or missing files that could halt provisioning.
+
+## Context
+
+Tarpaulin shows only 2 out of 25 lines covered for `runtime_assets.rs`. This file is in the critical path for any ansible execution. If asset extraction fails or creates bad permissions, the entire tool chain will fail in production.
+
+## Evidence
+
+- path: "src/adapters/ansible/runtime_assets.rs"
+  loc: "2/25"
+  note: "Primary extraction logic and failure modes (e.g., IO errors, missing assets) are uncovered."
+- path: "src/adapters/ansible/locator.rs"
+  loc: "16/34"
+  note: "Resolution logic bridging embedded extraction and local overrides is only partially tested."
+
+## Change Scope
+
+- `src/adapters/ansible/runtime_assets.rs`
+- `tests/ansible/`

--- a/.jules/exchange/events/uncovered_commands_and_adapters_cov.md
+++ b/.jules/exchange/events/uncovered_commands_and_adapters_cov.md
@@ -1,0 +1,47 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+Several critical CLI commands, adapters, and domain modules completely lack test coverage, specifically in `crates/mev-internal`. The global line coverage metric is artificially boosted while these essential paths remain untested, creating a high risk of regression.
+
+## Goal
+
+Establish foundational test coverage for the untrusted/uncovered boundary interfaces and CLI logic to ensure failure-expensive decisions are verified. Focus first on writing tests for the `gh` and `git` internal CLI tools and their related domain logic.
+
+## Context
+
+The `cargo tarpaulin` output indicates 0% coverage across the following key areas:
+- `crates/mev-internal/src/app/commands/gh/`
+- `crates/mev-internal/src/app/commands/git/`
+- `crates/mev-internal/src/app/cli/`
+- `crates/mev-internal/src/adapters/`
+- `crates/mev-internal/src/domain/repo_target.rs`
+- `crates/mev-internal/src/domain/repository_ref.rs`
+
+Without test boundaries on these modules, any underlying adapter changes could silently break the `gh` and `git` integration.
+
+## Evidence
+
+- path: "crates/mev-internal/src/app/cli/gh.rs"
+  loc: "0/7"
+  note: "Only tests exist for subcommand shape but zero line coverage recorded in tarpaulin output."
+- path: "crates/mev-internal/src/app/cli/git.rs"
+  loc: "0/3"
+  note: "No coverage for CLI execution flow."
+- path: "crates/mev-internal/src/app/commands/gh/labels_deploy.rs"
+  loc: "0/15"
+  note: "Core command logic completely uncovered."
+- path: "crates/mev-internal/src/adapters/git.rs"
+  loc: "0/37"
+  note: "System boundary for git operations is completely untested."
+
+## Change Scope
+
+- `crates/mev-internal/tests/`
+- `crates/mev-internal/src/app/commands/`
+- `crates/mev-internal/src/adapters/`

--- a/.jules/exchange/events/unverified_cli_contracts_cov.md
+++ b/.jules/exchange/events/unverified_cli_contracts_cov.md
@@ -1,0 +1,35 @@
+---
+label: "tests"
+created_at: "2024-05-24"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The main `mev` executable's CLI layer has dangerously low or non-existent coverage for its argument parsing and command dispatch. Specifically, `src/app/cli/*` and `src/main.rs` run without sufficient assertion logic that verifies external input.
+
+## Goal
+
+Add testing bounds around the main application command parsing to guarantee the shape of the CLI and its execution contracts remain stable. This focuses on providing basic help, version, and subcommand shape tests without relying heavily on internals.
+
+## Context
+
+Tarpaulin indicates the majority of the `src/app/cli/` modules are untested. This presents a high risk where renaming a flag or misconfiguring `clap` will break user-facing inputs without CI failure.
+
+## Evidence
+
+- path: "src/app/cli/make.rs"
+  loc: "0/3 lines"
+  note: "Command parsing entirely uncovered."
+- path: "src/app/cli/config.rs"
+  loc: "0/3 lines"
+  note: "Config parsing uncovered."
+- path: "src/app/cli/mod.rs"
+  loc: "12/20 lines"
+  note: "Core CLI dispatch is only partially covered, missing branches for specific commands."
+
+## Change Scope
+
+- `tests/cli/`
+- `src/app/cli/mod.rs`


### PR DESCRIPTION
This PR adds new observer event tracking for uncovered/under-tested portions of the codebase using the findings evaluated from running `cargo tarpaulin` via `just coverage`.

These events highlight high-risk gaps where there's little to no boundary tests for command adapters, CLI entry parsing, and important ansible embedded asset extraction logics which currently score 0%-10% in test coverage paths.

---
*PR created automatically by Jules for task [8218417829666238579](https://jules.google.com/task/8218417829666238579) started by @akitorahayashi*