### PR TITLE
feat(taxonomy): add naming consistency observation events

### DIFF
--- a/.jules/exchange/events/backup_target_taxonomy.md
+++ b/.jules/exchange/events/backup_target_taxonomy.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The term `target` is overloaded across the codebase. It refers to:
+1. `backup_target.rs` (`BackupTarget::System`, `BackupTarget::Vscode`) - representing a logical backup unit or operation.
+2. Build outputs (e.g. "target output", "target directory", "all-targets") in comments and aliases.
+
+Specifically, `backup_target` is a problematic name. In a domain where tasks are executed using Ansible "tags" (e.g., `system`, `vscode`, `rust`), the `backup` command operates on the exact same domain nouns (e.g. "system", "vscode"), but it calls them "backup targets" instead of "backup scopes", "backup entities", or even just "backup tags". This creates two parallel terms (tags vs targets) pointing to essentially the same underlying concept (a logical unit of configuration), muddying the domain vocabulary.
+
+## Goal
+
+Rename `backup_target` to a more precise domain term, such as `backup_scope` or `backup_component`, to differentiate it from other uses of the word "target" (like repositories or build artifacts) and to align it better with the broader system terminology. Given that we backup a "system" or "vscode", "scope" is a fitting noun. So, `backup_target` becomes `backup_scope`, `BackupTarget` becomes `BackupScope`, and its variants stay the same.
+
+## Context
+
+Using `target` generically hides the actual responsibility. In `src/app/commands/backup/mod.rs`, we do `execute(ctx: &DependencyContainer, target_input: &str)` and resolve `BackupTarget`. Changing it to `scope` makes it explicit that we are backing up a specific scope of the system.
+
+## Evidence
+
+- path: "src/domain/backup_target.rs"
+  loc: "enum BackupTarget"
+  note: "Defines `BackupTarget` enum to represent backup entities like `System` and `Vscode`."
+- path: "src/app/cli/backup.rs"
+  loc: "struct BackupArgs"
+  note: "CLI argument is named `target`."
+
+## Change Scope
+
+- `src/domain/backup_target.rs`
+- `src/domain/error.rs`
+- `src/app/cli/backup.rs`
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/machine_profile_taxonomy.md
+++ b/.jules/exchange/events/machine_profile_taxonomy.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The term "profile" is used inconsistently. In `src/domain/profile.rs`, functions like `validate_machine_profile` and `is_machine_profile` introduce the term "machine" as a modifier for "profile" to mean any profile except `Global` (i.e., `Macbook` or `MacMini`). This creates a new concept ("machine profile") that isn't cleanly separated from the domain concept of "profile" and isn't reflected in the user-facing CLI terminology, violating the "One Concept, One Preferred Term" and "Domain Language First" principles.
+
+Furthermore, the CLI help text for `create` uses "Profile to create" whereas the `make` command uses "Profile to use", while the internal enum is just `Profile` representing `Global`, `Macbook`, `MacMini`. Using "machine" to differentiate these profiles internally creates an inconsistent dialect.
+
+## Goal
+
+Unify the naming around the concept of a profile. Rename `is_machine_profile` and `validate_machine_profile` to use a more consistent domain term, such as `is_device` and `validate_device` (or `validate_device_profile`), or just remove "machine" and use "device" instead. A "device" represents a physical machine, which correctly contrasts with the "global" profile.
+
+## Context
+
+The `create` command can only run against a concrete device profile (e.g. `macbook`, `mac-mini`), whereas the `make` command can run against `global` or a device profile. The distinction between a global profile and a device profile is important, but "machine" is an incidental implementation detail that should be replaced with "device" to better align with the concept of a physical target.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "fn validate_machine_profile"
+  note: "Uses 'machine_profile' in function names like `is_machine_profile` and `validate_machine_profile`."
+
+- path: "src/app/cli/create.rs"
+  loc: "fn run"
+  note: "Calls `profile::validate_machine_profile` to ensure the profile is not global."
+
+## Change Scope
+
+- `src/domain/profile.rs`
+- `src/app/cli/create.rs`

--- a/.jules/exchange/events/switch_identity_taxonomy.md
+++ b/.jules/exchange/events/switch_identity_taxonomy.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-05-18"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+In `src/domain/vcs_identity.rs`, there is a struct `VcsIdentity` (name, email) and an enum `SwitchIdentity` (`Personal`, `Work`). `SwitchIdentity` represents the profile or category of the identity, but naming it `SwitchIdentity` focuses on the command action (`switch`) rather than the domain concept. It's essentially an `IdentityProfile` or `IdentityContext`. This violates the "Names Are Interfaces" and "Domain Language First" principles by naming the domain concept after a CLI command action.
+
+## Goal
+
+Rename `SwitchIdentity` to a domain-appropriate noun that doesn't couple the type to the `switch` command. A good candidate is `IdentityProfile`, `IdentityContext`, or simply `IdentityKind`. Let's choose `IdentityContext` or `IdentityProfile` (given "profile" is a known repository term, "context" or "kind" might be safer to avoid collision).
+
+## Context
+
+The enum `SwitchIdentity` defines the available identities (Personal, Work), but its name is tied to the verb "switch", making it awkward to use outside of that command (e.g. if we want to list or validate an identity kind).
+
+## Evidence
+
+- path: "src/domain/vcs_identity.rs"
+  loc: "enum SwitchIdentity"
+  note: "Defines `SwitchIdentity` Enum which includes Personal and Work"
+- path: "src/adapters/identity_store/local_json.rs"
+  loc: "fn get_identity"
+  note: "Method uses `SwitchIdentity` in store interface."
+
+## Change Scope
+
+- `src/domain/vcs_identity.rs`
+- `src/adapters/identity_store/local_json.rs`


### PR DESCRIPTION
This change implements the taxonomy observer tasks by analyzing the codebase for domain terminology drift, mapping missing definitions, and outlining findings. Three key areas were identified and documented: 1. the use of `machine_profile` in contrast to `device`, 2. the overloaded usage of `target` where `scope` is more appropriate for backups, and 3. the coupling of `SwitchIdentity` to the switch action rather than a correct domain noun.

---
*PR created automatically by Jules for task [11038817047586824968](https://jules.google.com/task/11038817047586824968) started by @akitorahayashi*