### PR TITLE
Emit Data Architecture Events

### DIFF
--- a/.jules/exchange/events/redundant_enum_aliases_data_arch.md
+++ b/.jules/exchange/events/redundant_enum_aliases_data_arch.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-05-23"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Domain models map user strings to enum variants using static alias arrays (`PROFILE_ALIASES`, `SWITCH_IDENTITY_ALIASES`, `BACKUP_TARGET_ALIASES`) that hardcode and duplicate the canonical string names and aliases already associated with the enums.
+
+## Goal
+
+Consolidate the string-to-variant mapping logic to use a single source of truth by dynamically checking variant canonical names and explicitly defined aliases, removing the redundant static arrays.
+
+## Context
+
+The Single Source of Truth principle dictates that each fact has one canonical representation. Hardcoding mapping arrays forces developers to update multiple places when adding new variants or aliases, increasing the risk of data drift and mapping inconsistencies.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "55-62"
+  note: "`PROFILE_ALIASES` duplicates the canonical names from `as_str()` and aliases from `aliases()`."
+- path: "src/domain/identity.rs"
+  loc: "44-49"
+  note: "`SWITCH_IDENTITY_ALIASES` hardcodes variants and strings redundantly."
+- path: "src/domain/backup_target.rs"
+  loc: "54-59"
+  note: "`BACKUP_TARGET_ALIASES` duplicates the canonical names from `name()`."
+
+## Change Scope
+
+- `src/domain/profile.rs`
+- `src/domain/identity.rs`
+- `src/domain/backup_target.rs`

--- a/.jules/exchange/events/untyped_error_boundaries_data_arch.md
+++ b/.jules/exchange/events/untyped_error_boundaries_data_arch.md
@@ -1,0 +1,37 @@
+---
+label: "refacts"
+created_at: "2024-05-23"
+author_role: "data_arch"
+confidence: "high"
+---
+
+## Problem
+
+Boundary error definitions use untyped `Box<dyn std::error::Error>` across internal crate domain logic instead of using explicit typed errors.
+
+## Goal
+
+Replace the generic `Box<dyn std::error::Error>` boundaries with an explicit domain typed error enum (e.g., `DomainError` or `InternalError`) that models explicit failure states.
+
+## Context
+
+The Boundary Sovereignty and Error Modeling principles state that boundary entry points should use explicit error types to encode expected failure states and prevent panics, ensuring callers handle errors safely. Using `Box<dyn std::error::Error>` causes caller ambiguity and masks specific operational failures.
+
+## Evidence
+
+- path: "crates/mev-internal/src/domain/repository_ref.rs"
+  loc: "12-16"
+  note: "`from_repo_arg` and `from_remote_url` return `Result<Self, Box<dyn std::error::Error>>`."
+- path: "crates/mev-internal/src/domain/submodule_path.rs"
+  loc: "5"
+  note: "`validate_submodule_path` returns `Result<(), Box<dyn std::error::Error>>`."
+- path: "crates/mev-internal/src/domain/repo_target.rs"
+  loc: "6"
+  note: "`resolve_repo_ref` returns `Result<RepositoryRef, Box<dyn std::error::Error>>`."
+
+## Change Scope
+
+- `crates/mev-internal/src/domain/repository_ref.rs`
+- `crates/mev-internal/src/domain/submodule_path.rs`
+- `crates/mev-internal/src/domain/repo_target.rs`
+- `crates/mev-internal/src/domain/label_catalog.rs`

--- a/.jules/exchange/events/unverified_tag_catalog_data_arch.md
+++ b/.jules/exchange/events/unverified_tag_catalog_data_arch.md
@@ -1,0 +1,32 @@
+---
+label: "refacts"
+created_at: "2024-05-23"
+author_role: "data_arch"
+confidence: "medium"
+---
+
+## Problem
+
+Tag values, used to drive Ansible execution mapping, are hardcoded in the domain model rather than explicitly validated against a single source of truth or the external Ansible asset catalog itself.
+
+## Goal
+
+Generate or validate available tags dynamically from authoritative Ansible catalog definitions instead of keeping a duplicated, manual array up to date.
+
+## Context
+
+The Single Source of Truth principle states that each concept must have one canonical representation. Hardcoded tag groups (`FULL_SETUP_TAGS`, `tag_groups()`) duplicate knowledge of the underlying Ansible roles, leading to a disconnect if roles are added or removed dynamically.
+
+## Evidence
+
+- path: "src/domain/tag.rs"
+  loc: "5-33"
+  note: "`tag_groups()` and `FULL_SETUP_TAGS` define static arrays containing hardcoded string tags."
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "21"
+  note: "`deploy_for_tags` consumes the tags blindly and maps them via `role_for_tag`, silently skipping missing dependencies without explicit validation."
+
+## Change Scope
+
+- `src/domain/tag.rs`
+- `src/domain/execution_plan.rs`


### PR DESCRIPTION
This submission fulfills the layer contract for the `data_arch` observer role.

It outputs three `.md` event files in the `.jules/exchange/events` directory documenting data architecture issues in the domain boundaries:
1. **Redundant Enum Aliases**: Hardcoded arrays mapping aliases to variants unnecessarily duplicate dynamic access methods.
2. **Untyped Error Boundaries**: Parts of the codebase, notably in internal domain objects like `repository_ref.rs`, return unmapped `Box<dyn std::error::Error>` rather than explicitly modeled error boundaries.
3. **Unverified Tag Catalog**: The list of tags is hardcoded and validated loosely in `tag.rs` rather than being mapped correctly to an external source of truth.

All changes were added cleanly and safely within the `.jules/exchange/events/` scope. Workspace tests passed cleanly.

---
*PR created automatically by Jules for task [16073115659608709622](https://jules.google.com/task/16073115659608709622) started by @akitorahayashi*