### PR TITLE
docs: emit taxonomy events for domain models and ambiguous names

### DIFF
--- a/.jules/exchange/events/ambiguous_names_taxonomy.md
+++ b/.jules/exchange/events/ambiguous_names_taxonomy.md
@@ -1,0 +1,44 @@
+---
+label: "refacts"
+created_at: "2026-03-31"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+Files and variables are named using generic terms like `utils`, `helper`, `base`, `common`, or `core`, which violates the specific design anti-patterns.
+
+## Goal
+
+Identify and rename all instances of `utils`, `helper`, `base`, `common`, and `core` to names that describe their specific responsibilities, eliminating ambiguous module and variable names.
+
+## Context
+
+The rule "Class and file must not have ambiguous names or responsibilities such as base, common, core, utils, or helpers" explicitly prohibits these terms because they lead to dumping grounds for unrelated code and do not specify the problem domain. Several files and variables in the codebase violate this rule.
+For example, `src/adapters/identity_store/paths.rs` contains `fn config_base()`. There are references to "Common development commands" and "Helper function". Several Cargo.lock entries also show usage of `-core` crates (though we might not be able to change external dependency names, we should avoid them in our code).
+
+## Evidence
+
+- path: "src/adapters/identity_store/paths.rs"
+  loc: "fn config_base()"
+  note: "Violates the naming rule by using the suffix `_base`."
+
+- path: "src/assets/ansible/roles/shell/config/global/alias/dev/dev.sh"
+  loc: "line 13: # Helper function..."
+  note: "Violates the naming rule in a comment describing a function as a helper."
+
+- path: "src/assets/ansible/roles/shell/config/global/alias/dev/dev.sh"
+  loc: "line 19: # Common development commands"
+  note: "Uses the term 'Common'."
+
+- path: "src/assets/ansible/roles/nodejs/config/global/coder/skills/svo-cli-design/SKILL.md"
+  loc: "line 8: ## Core Objective"
+  note: "Uses the term 'Core'."
+
+## Change Scope
+
+- `src/adapters/identity_store/paths.rs`
+- `src/assets/ansible/roles/shell/config/global/alias/dev/dev.sh`
+- `src/assets/ansible/roles/nodejs/config/global/coder/skills/svo-cli-design/SKILL.md`
+- `src/assets/ansible/roles/nodejs/config/global/coder/skills/effective-prompting/SKILL.md`

--- a/.jules/exchange/events/domain_model_naming_taxonomy.md
+++ b/.jules/exchange/events/domain_model_naming_taxonomy.md
@@ -1,0 +1,51 @@
+---
+label: "refacts"
+created_at: "2026-03-31"
+author_role: "taxonomy"
+confidence: "high"
+---
+
+## Problem
+
+The domain layer uses different conceptual naming conventions for CLI command targets, leading to overloaded and inconsistent terms like `Profile`, `SwitchIdentity`, `BackupTarget`, and `tag`.
+
+## Goal
+
+Establish a consistent naming convention and structural taxonomy for domain entities that act as targets or parameters for various system operations, ensuring a unified conceptual language.
+
+## Context
+
+The repository contains several domain types representing entities that can be targeted or operated on:
+1. `Profile` (hardware profile like macbook, mac-mini).
+2. `SwitchIdentity` (Git identity target like personal, work).
+3. `BackupTarget` (backup operation target like system, vscode).
+4. `tag` (Ansible task execution target).
+
+These names lack consistency. Some use the command action (`SwitchIdentity`, `BackupTarget`), while others are standalone nouns (`Profile`, `tag`). The anti-pattern "Domain models must not be named after CLI command actions" is explicitly stated in the design rules: "(e.g., naming a type 'SwitchIdentity' because it is used by a 'switch' command is prohibited; use a domain noun instead)."
+
+Renaming `SwitchIdentity` to something like `GitIdentityScope` (or `IdentityScope` / `IdentityProfile`), and `BackupTarget` to something like `BackupComponent` or `SystemComponent` would align better with the domain language.
+
+## Evidence
+
+- path: "src/domain/identity.rs"
+  loc: "pub enum SwitchIdentity"
+  note: "Named after the 'switch' CLI command, violating the domain language first rule."
+
+- path: "src/domain/backup_target.rs"
+  loc: "pub enum BackupTarget"
+  note: "Contains 'Target' which is a generic overloaded term, and is closely tied to the 'backup' command action."
+
+- path: "src/domain/profile.rs"
+  loc: "pub enum Profile"
+  note: "Standalone domain noun, correctly named."
+
+## Change Scope
+
+- `src/domain/identity.rs`
+- `src/domain/backup_target.rs`
+- `src/domain/error.rs`
+- `src/app/commands/switch/mod.rs`
+- `src/app/commands/backup/mod.rs`
+- `src/app/cli/switch.rs`
+- `src/app/cli/backup.rs`
+- `src/app/api.rs`


### PR DESCRIPTION
This PR emits observer events analyzing the codebase for taxonomy and naming consistency.

- Identifies domain models (`SwitchIdentity`, `BackupTarget`) that violate the "Domain Language First" rule by being named after CLI commands instead of standalone nouns.
- Identifies usages of prohibited generic terms (`base`, `helper`, `common`, `core`) across files and configuration settings.
- Outputs findings into the `.jules/exchange/events/` directory as requested.

---
*PR created automatically by Jules for task [6017985293772315760](https://jules.google.com/task/6017985293772315760) started by @akitorahayashi*