### PR TITLE
Emit Rustacean Observer Events

### DIFF
--- a/.jules/exchange/events/box_dyn_error_usage_rustacean.md
+++ b/.jules/exchange/events/box_dyn_error_usage_rustacean.md
@@ -1,0 +1,42 @@
+---
+label: "refacts"
+created_at: "2024-03-31"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+The internal crate (`crates/mev-internal`) and some adapters use `Box<dyn std::error::Error>` extensively for error handling, which violates the architecture rule specifying that typed errors (e.g. `DomainError` or `AppError`) must be used instead of generic `Box<dyn std::error::Error>`.
+
+## Goal
+
+Refactor error handling in `crates/mev-internal` to use a typed domain error (e.g. `InternalError` or `DomainError`) that preserves error semantics and classification instead of falling back to untyped `Box<dyn std::error::Error>`. Update function signatures in `mev-internal/src/domain/` and `mev-internal/src/adapters/` accordingly.
+
+## Context
+
+Using `Box<dyn std::error::Error>` collapses errors, making it difficult to match on or handle specific error types at the boundary. The architecture rule for Error Types requires the use of explicit typed errors across internal crates to ensure errors are part of the contract and context is maintained.
+
+## Evidence
+
+- path: "crates/mev-internal/src/domain/repository_ref.rs"
+  loc: "line 12, 20"
+  note: "`from_repo_arg` and `from_remote_url` return `Result<Self, Box<dyn std::error::Error>>`"
+- path: "crates/mev-internal/src/domain/submodule_path.rs"
+  loc: "line 5"
+  note: "`validate_submodule_path` returns `Result<(), Box<dyn std::error::Error>>`"
+- path: "crates/mev-internal/src/adapters/process.rs"
+  loc: "line 5, 15"
+  note: "`run_status` and `run_output` return `Result<_, Box<dyn std::error::Error>>`"
+
+## Change Scope
+
+- `crates/mev-internal/src/domain/mod.rs`
+- `crates/mev-internal/src/domain/error.rs`
+- `crates/mev-internal/src/domain/repository_ref.rs`
+- `crates/mev-internal/src/domain/submodule_path.rs`
+- `crates/mev-internal/src/domain/repo_target.rs`
+- `crates/mev-internal/src/domain/label_catalog.rs`
+- `crates/mev-internal/src/adapters/process.rs`
+- `crates/mev-internal/src/adapters/git.rs`
+- `crates/mev-internal/src/adapters/gh.rs`

--- a/.jules/exchange/events/silent_fallback_serde_json_rustacean.md
+++ b/.jules/exchange/events/silent_fallback_serde_json_rustacean.md
@@ -1,0 +1,31 @@
+---
+label: "refacts"
+created_at: "2024-03-31"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Silent fallback `unwrap_or_else` is used during JSON serialization of system settings backup in `src/app/commands/backup/system.rs`. This violates the Design Rule that prohibits silent fallbacks.
+
+## Goal
+
+Remove silent `unwrap_or_else` during JSON serialization in `src/app/commands/backup/system.rs` and properly surface serialization failures.
+
+## Context
+
+The rule "Silent fallbacks are prohibited; any fallback is explicit, opt-in, and surfaced as a failure or a clearly logged, reviewed decision" is broken here. If `serde_json::to_string` fails (which can happen, e.g. with invalid strings, though `Cow<str>` is generally safe, falling back silently to raw string value masks potential issues and violates explicit error handling).
+
+## Evidence
+
+- path: "src/app/commands/backup/system.rs"
+  loc: "line 117"
+  note: "`serde_json::to_string(&value).unwrap_or_else(|_| value.into_owned())`"
+- path: "src/app/commands/backup/system.rs"
+  loc: "line 177"
+  note: "`serde_json::to_string(&value).unwrap_or_else(|_| value.into_owned())`"
+
+## Change Scope
+
+- `src/app/commands/backup/system.rs`

--- a/.jules/exchange/events/unsafe_thread_safety_rustacean.md
+++ b/.jules/exchange/events/unsafe_thread_safety_rustacean.md
@@ -1,0 +1,31 @@
+---
+label: "refacts"
+created_at: "2024-03-31"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Global state modifications like `env::set_current_dir` and `env::set_var` are used in test helpers (e.g. `DirGuard` and `PathGuard`), which alters the current process state and can cause data races across tests. The code properly uses `unsafe` for `env::set_var`, but misses wrapping `env::set_current_dir` with `unsafe` and `#[allow(unused_unsafe)]`, violating thread safety expectations for concurrent tests.
+
+## Goal
+
+Ensure functions modifying global process state in tests (like `env::set_current_dir` in `DirGuard` and `env::set_var` in `PathGuard`) are explicitly wrapped in `unsafe { ... }` blocks and annotated with `#[allow(unused_unsafe)]` to emphasize thread-unsafe nature, per the Testing Rule (Thread Safety Marking).
+
+## Context
+
+Modifying global state in Rust is intrinsically unsafe in a multi-threaded context like `cargo test`. Memory specifically dictates: "When using functions that modify global process state (e.g., `env::set_current_dir`) in tests, explicitly wrap them in an `unsafe { ... }` block and annotate with `#[allow(unused_unsafe)]` to emphasize their thread-unsafe nature...". `PathGuard` and `DirGuard` are used in parallel test runs unless serialized.
+
+## Evidence
+
+- path: "crates/mev-internal/src/testing/env_mock.rs"
+  loc: "line 15, 23"
+  note: "`env::set_current_dir` is used without `unsafe` blocks or `#[allow(unused_unsafe)]`"
+- path: "crates/mev-internal/src/testing/env_mock.rs"
+  loc: "line 47, 56, 61"
+  note: "`env::set_var` and `env::remove_var` are used with `unsafe` but missing `#[allow(unused_unsafe)]` annotations"
+
+## Change Scope
+
+- `crates/mev-internal/src/testing/env_mock.rs`


### PR DESCRIPTION
Emit 3 event files representing architectural issues related to typed errors, unsafe block thread safety, and silent fallbacks per the rustacean observer directives.

---
*PR created automatically by Jules for task [15754935946179135346](https://jules.google.com/task/15754935946179135346) started by @akitorahayashi*