### PR TITLE
Emit QA events for unhandled test unwraps and unmarked thread-unsafe tests

### DIFF
--- a/.jules/exchange/events/unhandled_unwraps_in_tests_qa.md
+++ b/.jules/exchange/events/unhandled_unwraps_in_tests_qa.md
@@ -1,0 +1,38 @@
+---
+label: "tests"
+created_at: "2024-03-31"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Tests in `tests/adapters/git.rs` and `tests/cli/backup.rs` extensively use `.unwrap()` for operations that could fail (like `fs::write`, `fs::set_permissions`, and `tempdir()`), violating the testing error handling rule. Tests should return `Result<(), Box<dyn std::error::Error>>` and explicitly propagate errors with the `?` operator.
+
+## Goal
+
+Ensure all test functions propagate errors correctly using `Result` and `?` rather than panicking on `unwrap()`, improving diagnosability when tests fail due to setup or IO issues.
+
+## Context
+
+When tests fail via `.unwrap()` inside test setup logic, the resulting panic trace often obfuscates the root cause (e.g., IO error vs actual behavior failure). Returning an explicit `Result` allows the test runner to format a clearer failure message and maintains a cleaner boundary between pure logic testing and test side-effect preparation.
+
+## Evidence
+
+- path: "tests/adapters/git.rs"
+  loc: "tests module"
+  note: "Tests in `tests/adapters/git.rs` panic via `.unwrap()` on `fs::write` and `tempdir()`."
+
+- path: "tests/cli/backup.rs"
+  loc: "tests module"
+  note: "Tests like `backup_system_success` use `.unwrap()` directly for `std::fs::create_dir_all`, `std::fs::write`, and `std::fs::read_to_string`."
+
+- path: "tests/cli/switch.rs"
+  loc: "tests module"
+  note: "Tests like `switch_success_with_git` use `.unwrap()` directly for `std::fs::create_dir_all` and `std::fs::write`."
+
+## Change Scope
+
+- `tests/adapters/git.rs`
+- `tests/cli/backup.rs`
+- `tests/cli/switch.rs`

--- a/.jules/exchange/events/unmarked_unsafe_tests_qa.md
+++ b/.jules/exchange/events/unmarked_unsafe_tests_qa.md
@@ -1,0 +1,38 @@
+---
+label: "tests"
+created_at: "2024-03-31"
+author_role: "qa"
+confidence: "high"
+---
+
+## Problem
+
+Global state modifications are not explicitly marked as thread-unsafe, and tests using global state aren't always run serially. `crates/mev-internal/src/testing/env_mock.rs` defines `DirGuard` which modifies `std::env::set_current_dir` globally. `tests/adapters/git.rs` modifies `std::env::set_var` / `std::env::set_current_dir` indirectly. `tests/harness/test_context.rs` isolates PATH via `Command`, but internal adapter tests like `crates/mev-internal/src/adapters/git.rs` and `crates/mev-internal/src/adapters/gh.rs` directly modify the mock `PATH` or current directory globally without `#serial` bounds, potentially leading to flakiness.
+
+## Goal
+
+Identify tests using global state overrides (e.g., in `env_mock` and `DirGuard`) and ensure they are explicitly marked as `#[serial]` to prevent flaky test execution, and that any global state operations explicitly use `unsafe` and `#[allow(unused_unsafe)]` to emphasize their non-deterministic nature.
+
+## Context
+
+Running tests concurrently is the default in Rust. Modifying global environment variables like `PATH` or current directory within concurrent execution can interfere, causing non-deterministic test failures (flakes). The architecture strictly requires explicitly isolating global modifications to serial execution, and wrapping modifications in `unsafe` blocks.
+
+## Evidence
+
+- path: "crates/mev-internal/src/testing/env_mock.rs"
+  loc: "line 15-23"
+  note: "`DirGuard::new()` and `DirGuard::drop()` modify global process state (`env::set_current_dir`) without an `unsafe` block or `#[allow(unused_unsafe)]` annotation."
+
+- path: "crates/mev-internal/src/adapters/git.rs"
+  loc: "tests module"
+  note: "Tests in `crates/mev-internal/src/adapters/git.rs` use mock binaries and potentially global state (e.g., `git` bin location) but lack `#[serial]` markings."
+
+- path: "crates/mev-internal/src/adapters/gh.rs"
+  loc: "tests module"
+  note: "Tests in `crates/mev-internal/src/adapters/gh.rs` lack `#[serial]` markings while relying on environmental mocking structures."
+
+## Change Scope
+
+- `crates/mev-internal/src/testing/env_mock.rs`
+- `crates/mev-internal/src/adapters/git.rs`
+- `crates/mev-internal/src/adapters/gh.rs`


### PR DESCRIPTION
Emit QA events for unhandled test unwraps and unmarked thread-unsafe tests

- Add `.jules/exchange/events/unmarked_unsafe_tests_qa.md` targeting `#[serial]` omission
- Add `.jules/exchange/events/unhandled_unwraps_in_tests_qa.md` targeting test panics

---
*PR created automatically by Jules for task [2751142990701345166](https://jules.google.com/task/2751142990701345166) started by @akitorahayashi*