### PR TITLE
Emit test coverage event files

### DIFF
--- a/.jules/exchange/events/untested_backup_system_cov.md
+++ b/.jules/exchange/events/untested_backup_system_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2024-05-30"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The system backup logic in `src/app/commands/backup/system.rs` lacks coverage on edge cases related to formatting logic and default handling, increasing regression risk.
+
+## Goal
+
+Add tests to ensure all `format_bool`, `format_numeric`, `format_string` fallback/default logic paths are verified, as well as the missing coverage on directory fallback orchestration.
+
+## Context
+
+The system backup functionality evaluates macOS system settings against defined definition files. Value parsing handles coercions (e.g., bool parsing, float/int parsing, and home directory replacement strings). The tarpaulin coverage report (default configuration, line coverage metric) shows significant uncovered logic paths when mapping default states, executing the file writing sequence, or parsing truthy values. These data formatting decisions are critical as a failure here results in a corrupted, unusable backup configuration.
+
+## Evidence
+
+- path: "src/app/commands/backup/system.rs"
+  loc: "execute, format_bool, format_numeric, format_string"
+  note: "The missed regions comprise nearly the entirety of the format_* mapping logic which handles critical coercion paths. We need to test the file execution generation as well as value formatting."
+
+## Change Scope
+
+- `src/app/commands/backup/system.rs`

--- a/.jules/exchange/events/untested_cli_commands_cov.md
+++ b/.jules/exchange/events/untested_cli_commands_cov.md
@@ -1,0 +1,36 @@
+---
+label: "tests"
+created_at: "2024-05-30"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The CLI command implementation modules in `crates/mev-internal/src/app/commands/` (e.g., `git/delete_submodule.rs`, `gh/labels_deploy.rs`, `gh/labels_reset.rs`) have 0% test coverage.
+
+## Goal
+
+Ensure that the core command logic is covered by tests, verifying that commands parse arguments and execute the correct adapter methods or correctly handle errors.
+
+## Context
+
+These command modules are the entry points for the CLI functionality in `mev-internal`. While the underlying adapters (like `GitAdapter` and `GhAdapter`) have some tests, the command logic itself (argument validation, orchestration of adapter calls) is completely untested. This creates a regression risk where changes to argument parsing or command orchestration could break functionality without being detected. The coverage gaps were identified using default `cargo tarpaulin` configuration, evaluating the line coverage metric.
+
+## Evidence
+
+- path: "crates/mev-internal/src/app/commands/gh/labels_deploy.rs"
+  loc: "run"
+  note: "This command orchestrates reading existing labels and creating/replacing labels via the GhAdapter, but the logic is untested."
+- path: "crates/mev-internal/src/app/commands/gh/labels_reset.rs"
+  loc: "run"
+  note: "This command orchestrates listing and deleting labels via the GhAdapter, but the logic is untested."
+- path: "crates/mev-internal/src/app/commands/git/delete_submodule.rs"
+  loc: "run"
+  note: "This command orchestrates the steps to delete a git submodule via the GitAdapter, but the logic is untested."
+
+## Change Scope
+
+- `crates/mev-internal/src/app/commands/gh/labels_deploy.rs`
+- `crates/mev-internal/src/app/commands/gh/labels_reset.rs`
+- `crates/mev-internal/src/app/commands/git/delete_submodule.rs`

--- a/.jules/exchange/events/untested_identity_store_adapter_cov.md
+++ b/.jules/exchange/events/untested_identity_store_adapter_cov.md
@@ -1,0 +1,28 @@
+---
+label: "tests"
+created_at: "2024-05-30"
+author_role: "cov"
+confidence: "high"
+---
+
+## Problem
+
+The JSON identity store implementation in `src/adapters/identity_store/local_json.rs` has very low test coverage and is missing critical path assertions, especially around persistence and error handling.
+
+## Goal
+
+Ensure that all methods of the `IdentityFileStore` adapter (`exists`, `load`, `save`, and `get_identity`) are fully tested, particularly its atomic saving logic, legacy config migration behavior, and error paths.
+
+## Context
+
+The `IdentityFileStore` manages reading and writing the user's identities (`personal` and `work`) to disk. This involves reading legacy locations, atomic writes via temporary files, and parsing JSON state. The coverage report (generated via default `cargo tarpaulin` configuration) indicates that the logic for file loading, atomic writing, and fetching specific identities is not completely covered by tests according to the line coverage metric. Untested code in an identity configuration adapter risks data loss or corruption during save operations.
+
+## Evidence
+
+- path: "src/adapters/identity_store/local_json.rs"
+  loc: "load, save, get_identity"
+  note: "Untested paths include legacy path reading/migration, atomic save steps (temporary file creation, serialization error handling, renaming and cleanup), and retrieving specific identities."
+
+## Change Scope
+
+- `src/adapters/identity_store/local_json.rs`


### PR DESCRIPTION
Evaluated the codebase using `cargo tarpaulin` and emitted 3 high-signal event files to `.jules/exchange/events/` documenting critical coverage gaps in:

1. CLI command orchestration (`untested_cli_commands_cov.md`)
2. Identity store adapter (`untested_identity_store_adapter_cov.md`)
3. System backup logic (`untested_backup_system_cov.md`)

Each file cites the specific coverage tool, metric (line coverage), and context, fulfilling the `cov` role requirements without modifying the main codebase.

---
*PR created automatically by Jules for task [16323130371299727425](https://jules.google.com/task/16323130371299727425) started by @akitorahayashi*