### PR TITLE
feat: emit rustacean observer event files

### DIFF
--- a/.jules/exchange/events/error_handling_unwrap_expect_rustacean.md
+++ b/.jules/exchange/events/error_handling_unwrap_expect_rustacean.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2024-04-04"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Widespread use of `unwrap()` and `expect()` bypasses structured error handling and poses a panicking risk, especially in testing and domain models where errors should be clearly propagated and typed.
+
+## Goal
+
+Replace usages of `unwrap()` and `expect()` with explicit error propagation using `Result<(), Box<dyn std::error::Error>>` (for tests) or custom typed errors (for domain types) to adhere to the explicit error handling principles.
+
+## Context
+
+Using `unwrap()` and `expect()` circumvents Rust's type-safe error boundaries. Even in tests, failures should be structured and propagated rather than panicking, which can interrupt test execution and obscure diagnosis. In `mev-internal/src/domain/repository_ref.rs`, `expect()` is used extensively to bypass error handling for `from_repo_arg` and remote parsing tests.
+
+## Evidence
+
+- path: "crates/mev-internal/src/testing/env_mock.rs"
+  loc: "44, 46, 12, 14, 15, 84"
+  note: "Uses `unwrap()` and `expect()` heavily for file system and environment manipulation during testing."
+
+- path: "crates/mev-internal/src/domain/repository_ref.rs"
+  loc: "42-53"
+  note: "Tests use `.expect()` extensively instead of explicitly propagating errors and using `?`."
+
+- path: "src/testing/fs.rs"
+  loc: "58, 62"
+  note: "Uses `.unwrap()` to strip path prefixes."
+
+## Change Scope
+
+- `crates/mev-internal/src/testing/env_mock.rs`
+- `crates/mev-internal/src/domain/repository_ref.rs`
+- `src/testing/fs.rs`

--- a/.jules/exchange/events/errors_losing_domain_meaning_rustacean.md
+++ b/.jules/exchange/events/errors_losing_domain_meaning_rustacean.md
@@ -1,0 +1,38 @@
+---
+label: "refacts"
+created_at: "2024-04-04"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Errors are losing domain meaning and explicit context because they collapse specific failures into broadly typed variants (`AppError::Config` and `AppError::Backup`) wrapping only a `String` message.
+
+## Goal
+
+Refactor error propagation to use more specific types or variants that retain structured data (like the failed path, operation, or nested error types) rather than collapsing everything into strings. This ensures actionable diagnosis and boundary context retention.
+
+## Context
+
+In `src/domain/error.rs`, variants like `AppError::Config(String)` and `AppError::Backup(String)` are used heavily throughout the codebase (`src/adapters/identity_store.rs`, `src/app/commands/backup/system.rs`, `src/app/commands/config/mod.rs`, etc.) to wrap arbitrary error strings via `format!`. This practice of "stringification" discards the original error type and makes programmatic error handling or specific logging impossible, reducing the semantic value of the error enum.
+
+## Evidence
+
+- path: "src/domain/error.rs"
+  loc: "11-12"
+  note: "Defines `Config(String)` and `Backup(String)` which are used as catch-alls."
+
+- path: "src/adapters/identity_store.rs"
+  loc: "48, 62, 67, 70"
+  note: "Converts `serde_json` and IO errors into `AppError::Config` strings using `format!`."
+
+- path: "src/app/commands/backup/system.rs"
+  loc: "38, 46, 86, 118, 184"
+  note: "Uses `format!` to collapse YAML parsing and generic IO failures into `AppError::Backup` strings."
+
+## Change Scope
+
+- `src/domain/error.rs`
+- `src/adapters/identity_store.rs`
+- `src/app/commands/backup/system.rs`

--- a/.jules/exchange/events/unsafe_thread_safety_rustacean.md
+++ b/.jules/exchange/events/unsafe_thread_safety_rustacean.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2024-04-04"
+author_role: "rustacean"
+confidence: "high"
+---
+
+## Problem
+
+Global process state (`std::env::set_var`) is being modified within tests. This is inherently thread-unsafe and can cause unpredictable test failures if tests run concurrently, even if marked with `#[serial]` to prevent local execution overlaps, as other system states might interact with the environment variable modifications in unexpected ways.
+
+## Goal
+
+Ensure that global process state modification is fully encapsulated or clearly scoped to prevent thread-safety issues during testing, adhering to the "safety contract" requirements for `unsafe` blocks.
+
+## Context
+
+The `unsafe` block in `test_format_string` modifies `std::env::set_var("HOME", "/mock/home")`. While it has `#[serial]` and `#[allow(unused_unsafe)]`, modifying the environment is a process-global operation that poses a risk in Rust tests if not strictly managed, as tests default to running concurrently. This requires better isolation, ideally using dependency injection or a safe abstraction instead of mutating global state.
+
+## Evidence
+
+- path: "src/app/commands/backup/system.rs"
+  loc: "258"
+  note: "Test function `test_format_string` mutates global environment `std::env::set_var` inside an `unsafe` block without strict safe encapsulation or dependency injection of the home directory path."
+
+- path: "crates/mev-internal/src/testing/env_mock.rs"
+  loc: "57, 69, 75"
+  note: "Mocking functions modify global process state (`std::env::set_var`, `std::env::set_current_dir`) within `unsafe` blocks. Although annotated with `#[allow(unused_unsafe)]` and typically used with `#[serial]`, this modifies global environment state and could lead to flaky tests or un-encapsulated obligations for users."
+
+## Change Scope
+
+- `src/app/commands/backup/system.rs`
+- `crates/mev-internal/src/testing/env_mock.rs`


### PR DESCRIPTION
# Issue

Emit observer events for the `rustacean` role to identify opportunities for improving Rust code safety, error handling, and architecture.

# Implementation

1. Created `.jules/exchange/events/unsafe_thread_safety_rustacean.md` highlighting `std::env::set_var` global state mutations inside `unsafe` test blocks.
2. Created `.jules/exchange/events/error_handling_unwrap_expect_rustacean.md` highlighting the widespread bypass of typed error boundaries with `.unwrap()` and `.expect()`.
3. Created `.jules/exchange/events/errors_losing_domain_meaning_rustacean.md` highlighting the stringification of specific errors into broad `AppError` variants.
4. Assigned valid labels (`refacts`) matching `.jules/github-labels.json`.

---
*PR created automatically by Jules for task [4042730134695487119](https://jules.google.com/task/4042730134695487119) started by @akitorahayashi*