### PR TITLE
Emit modeler observer events

### DIFF
--- a/.jules/exchange/events/hardcoded_tag_enumerables_modeler.md
+++ b/.jules/exchange/events/hardcoded_tag_enumerables_modeler.md
@@ -1,0 +1,29 @@
+---
+label: "refacts"
+created_at: "2024-10-24"
+author_role: "modeler"
+confidence: "high"
+---
+
+## Problem
+
+Tags and tag groups are hardcoded in `src/domain/tag.rs` rather than being generated dynamically from an authoritative source (like the Ansible catalog).
+
+## Goal
+
+Generate enumerable values for tags dynamically from an authoritative source (e.g., the Ansible catalog/registry) to avoid hardcoding.
+
+## Context
+
+Design principles state "Enumerable values are generated dynamically from authoritative sources (catalog, registry, schema) rather than hardcoded." Currently, `FULL_SETUP_TAGS` and `tag_groups()` are hardcoded arrays/maps. This requires manual synchronization whenever the Ansible roles change.
+
+## Evidence
+
+- path: "src/domain/tag.rs"
+  loc: "6-16"
+  note: "`tag_groups()` and `FULL_SETUP_TAGS` are hardcoded in the domain layer, lacking an authoritative source generation."
+
+## Change Scope
+
+- `src/domain/tag.rs`
+- `src/app/commands/create/mod.rs`

--- a/.jules/exchange/events/invalid_state_identity_modeler.md
+++ b/.jules/exchange/events/invalid_state_identity_modeler.md
@@ -1,0 +1,33 @@
+---
+label: "refacts"
+created_at: "2024-10-24"
+author_role: "modeler"
+confidence: "high"
+---
+
+## Problem
+
+The `Identity` model allows invalid states (empty strings for name and email) by relying on a runtime `is_configured` check instead of enforcing invariants via types.
+
+## Goal
+
+Encode invariants at the boundaries so that invalid states (empty identities) are hard or impossible to express in the core domain model.
+
+## Context
+
+First Principles dictate "Represent Valid States Only: encode invariants so invalid states are hard to express." The current `Identity` model allows instantiation with empty strings and defers validation to `is_configured()`, meaning call sites might process an unconfigured identity.
+
+## Evidence
+
+- path: "src/domain/identity.rs"
+  loc: "Identity struct"
+  note: "`Identity` struct has `name` and `email` as `String`, allowing empty values, with a separate `is_configured` method."
+- path: "src/app/commands/switch/mod.rs"
+  loc: "22"
+  note: "The `switch::execute` command has to manually check `!identity_config.is_configured()` and fail, demonstrating validation scattered to call sites."
+
+## Change Scope
+
+- `src/domain/identity.rs`
+- `src/app/commands/switch/mod.rs`
+- `src/app/commands/identity/mod.rs`

--- a/.jules/exchange/events/persistence_leak_identity_modeler.md
+++ b/.jules/exchange/events/persistence_leak_identity_modeler.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2024-10-24"
+author_role: "modeler"
+confidence: "high"
+---
+
+## Problem
+
+Persistence concerns (`serde::Serialize`, `serde::Deserialize`) are leaking into core domain models (`Identity` and `IdentityState`).
+
+## Goal
+
+Keep domain models independent of transport/persistence concerns by removing `serde` derivations from the core domain and handling serialization in the adapter layer.
+
+## Context
+
+First Principles dictate "Boundary Sovereignty: keep domain models independent of transport/UI/runtime concerns." The `Identity` struct and `IdentityState` struct have `#[derive(..., serde::Serialize, serde::Deserialize)]`. Anti-patterns include "Transport DTOs or persistence types leaking into core domain logic."
+
+## Evidence
+
+- path: "src/domain/identity.rs"
+  loc: "Identity struct"
+  note: "`Identity` struct derives `serde::Serialize` and `serde::Deserialize`."
+- path: "src/domain/ports/identity_store.rs"
+  loc: "IdentityState struct"
+  note: "`IdentityState` struct derives `serde::Serialize` and `serde::Deserialize`."
+- path: "src/adapters/identity_store.rs"
+  loc: "29-39"
+  note: "Adapter uses these traits for JSON persistence."
+
+## Change Scope
+
+- `src/domain/identity.rs`
+- `src/domain/ports/identity_store.rs`
+- `src/adapters/identity_store.rs`


### PR DESCRIPTION
This change emits three event files from the perspective of a modeler analyzing data flow and model efficiency:

1. `invalid_state_identity_modeler.md` - Documents the `Identity` model allowing empty states rather than enforcing invariants at the boundary.
2. `hardcoded_tag_enumerables_modeler.md` - Documents that tag groups and setup tags are hardcoded rather than being derived dynamically.
3. `persistence_leak_identity_modeler.md` - Documents that persistence concerns (`serde` derivations) leak into core domain models instead of being handled in the adapter layer.

---
*PR created automatically by Jules for task [3941643335925416564](https://jules.google.com/task/3941643335925416564) started by @akitorahayashi*