### PR TITLE
Add taxonomist event files for naming and vocabulary alignment

### DIFF
--- a/.jules/exchange/events/generic_layer_utils_taxonomist.md
+++ b/.jules/exchange/events/generic_layer_utils_taxonomist.md
@@ -1,0 +1,49 @@
+---
+label: "refacts"
+created_at: "2024-04-04"
+author_role: "taxonomist"
+confidence: "high"
+---
+
+## Problem
+
+The term `base` is used vaguely in multiple contexts:
+1. "base path" (`src/adapters/identity_store.rs:1: //! The base path is ~/.config/...`)
+2. "base_dir" (`crates/mev-internal/src/adapters/git.rs`)
+3. Generic model layer attributes `llm_common_models_mlx`, etc (`src/assets/ansible/roles/llm/tasks/mlx.yml`)
+4. Generic model layer attributes `llm_common_models`, etc (`src/assets/ansible/roles/llm/tasks/ollama.yml`)
+
+These names hide their responsibility and violate "One Concept, One Preferred Term". The principles explicitly say "Class and file must not have ambiguous names or responsibilities such as base, common, core, utils, or helpers."
+
+## Goal
+
+Rename vague usages of "base" and "common" across variables, files, and domains to be specific to their domain. "base path" should become "config_directory" or "root_path". "base_dir" should be "repository_root". "llm_common_models" should be "llm_default_models" or "llm_global_models".
+
+## Context
+
+The principles require domain language first, no generic names, and explicitly prohibit "base" and "common".
+
+## Evidence
+
+- path: "src/adapters/identity_store.rs"
+  loc: "line 1"
+  note: "Refers to '~/.config' as 'base path'."
+
+- path: "crates/mev-internal/src/adapters/git.rs"
+  loc: "line 31"
+  note: "Uses 'base_dir' for what is a repository working directory."
+
+- path: "src/assets/ansible/roles/llm/tasks/mlx.yml"
+  loc: "line 10: `name: llm_common_models_mlx`"
+  note: "Uses 'common' inappropriately as a variable root."
+
+- path: "src/assets/ansible/roles/llm/tasks/ollama.yml"
+  loc: "line 17: `name: llm_common_models`"
+  note: "Uses 'common' inappropriately as a variable root."
+
+## Change Scope
+
+- `src/adapters/identity_store.rs`
+- `crates/mev-internal/src/adapters/git.rs`
+- `src/assets/ansible/roles/llm/tasks/mlx.yml`
+- `src/assets/ansible/roles/llm/tasks/ollama.yml`

--- a/.jules/exchange/events/multiple_terms_target_taxonomist.md
+++ b/.jules/exchange/events/multiple_terms_target_taxonomist.md
@@ -1,0 +1,48 @@
+---
+label: "refacts"
+created_at: "2024-04-04"
+author_role: "taxonomist"
+confidence: "high"
+---
+
+## Problem
+
+The word `target` is heavily overloaded across the codebase. It represents at least three distinct concepts:
+1. A GitHub repository to act upon (`repo_target.rs`).
+2. A generic CLI argument value for Backup components (`backup target`).
+3. A destination directory when moving or copying files (`deploy_configs.rs`).
+4. The cargo compilation output directory (`tests/harness/test_context.rs`).
+
+## Goal
+
+Standardize terminology by replacing the generic term "target" with more specific domain nouns where appropriate to prevent conceptual overloading.
+
+## Context
+
+The guiding principles mandate that domain models must not be generic and should follow 'One Concept, One Preferred Term'. Generic terms like "target" should be avoided across different contexts, especially when dealing with specific domain entities like Repositories or Components.
+
+## Evidence
+
+- path: "crates/mev-internal/src/domain/repo_target.rs"
+  loc: "line 1: `//! Repository target resolution.`"
+  note: "Uses 'target' to describe a repository."
+
+- path: "src/app/cli/backup.rs"
+  loc: "line 19: `pub target: Option<String>,`"
+  note: "Uses 'target' as the CLI struct field for what is functionally a 'BackupComponent'."
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "line 37: `let target = local_config_root.join(role);`"
+  note: "Uses 'target' to represent a file system destination directory."
+
+- path: "tests/harness/test_context.rs"
+  loc: "line 18: `let test_tmp_dir = std::path::Path::new(manifest_dir).join(\"target\").join(\"test_tmp\");`"
+  note: "Standard cargo build directory usage."
+
+## Change Scope
+
+- `crates/mev-internal/src/domain/repo_target.rs`
+- `src/app/cli/backup.rs`
+- `src/app/commands/backup/system.rs`
+- `crates/mev-internal/src/app/commands/gh/labels_deploy.rs`
+- `crates/mev-internal/src/app/commands/gh/labels_reset.rs`

--- a/.jules/exchange/events/profile_hardware_coupling_taxonomist.md
+++ b/.jules/exchange/events/profile_hardware_coupling_taxonomist.md
@@ -1,0 +1,32 @@
+---
+label: "feats"
+created_at: "2024-04-04"
+author_role: "taxonomist"
+confidence: "high"
+---
+
+## Problem
+
+The term `Profile` currently mixes hardware variants (`Macbook`, `MacMini`) with a `Global` configuration state. A Profile shouldn't be defined strictly as hardware constraints while also including a `global` identifier, confusing the domain noun "Profile" which usually means user-centric configuration sets instead of hardware targets.
+
+## Goal
+
+Consider splitting or renaming `Profile` to clarify whether it means "HardwareTarget" or "ConfigurationProfile". Alternatively, remove the hardware-specific naming convention from the concept of a `Profile`.
+
+## Context
+
+"One Concept, One Preferred Term". The domain noun "Profile" is overloaded to mean both "The hardware being provisioned" (via `validate_hardware_profile`) and "A global configuration scope".
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "line 9: `pub enum Profile { Macbook, MacMini, Global }`"
+  note: "Mixes hardware targets with global scope."
+
+- path: "src/domain/profile.rs"
+  loc: "line 25: `fn is_hardware_profile(self) -> bool { matches!(self, Self::Macbook | Self::MacMini) }`"
+  note: "Explicitly defines hardware within a Profile."
+
+## Change Scope
+
+- `src/domain/profile.rs`


### PR DESCRIPTION
This adds three event files in `.jules/exchange/events/` identifying areas where the system vocabulary is inconsistent with the conventions and design guidelines.

- `multiple_terms_target_taxonomist.md`: highlights the overloaded use of "target".
- `generic_layer_utils_taxonomist.md`: highlights generic terms like "base" and "common" which obscure responsibility.
- `profile_hardware_coupling_taxonomist.md`: highlights the overloading of the `Profile` concept to include both hardware types and global setup context.

---
*PR created automatically by Jules for task [12254797748665813120](https://jules.google.com/task/12254797748665813120) started by @akitorahayashi*