### PR TITLE
docs: emit events for missing or inadequate doc comments

### DIFF
--- a/.jules/exchange/events/backup_component_missing_docs_annotator.md
+++ b/.jules/exchange/events/backup_component_missing_docs_annotator.md
@@ -1,0 +1,26 @@
+---
+label: "docs"
+created_at: "2024-04-05"
+author_role: "annotator"
+confidence: "high"
+---
+
+## Problem
+The purpose statements for `resolve_backup_component` and `validate_backup_component` restate their names and lack failure path descriptions.
+
+## Goal
+Improve the doc comments for `resolve_backup_component` and `validate_backup_component` to answer what the units do without restating their names, and outline their failure paths.
+
+## Context
+First principles state that a comment block that restates a name adds no information, and missing failure paths lead to undiagnosed failures.
+
+## Evidence
+- path: "src/domain/backup_component.rs"
+  loc: "67"
+  note: "Current: `/// Resolve a backup component identifier or alias to a \`BackupComponent\`.`\nReplacement:\n```rust\n/// Look up a domain component corresponding to the user's input.\n/// Returns `None` if the input does not map to a known canonical name or alias.\npub fn resolve_backup_component(input: &str) -> Option<BackupComponent> {\n```"
+- path: "src/domain/backup_component.rs"
+  loc: "78"
+  note: "Current: `/// Validate that the input maps to a \`BackupComponent\`.`\nReplacement:\n```rust\n/// Verify the user's input maps to a known component, producing an actionable error if unrecognized.\n/// Fails with `AppError::InvalidBackupComponent` if the string cannot be resolved.\npub fn validate_backup_component(input: &str) -> Result<BackupComponent, AppError> {\n```"
+
+## Change Scope
+- `src/domain/backup_component.rs`

--- a/.jules/exchange/events/domain_missing_docs_annotator.md
+++ b/.jules/exchange/events/domain_missing_docs_annotator.md
@@ -1,0 +1,27 @@
+---
+label: "docs"
+created_at: "2024-04-05"
+author_role: "annotator"
+confidence: "high"
+---
+
+## Problem
+Missing doc comments for `resolve_repo_ref` and `validate_submodule_path`.
+
+## Goal
+Provide doc comments that describe the purpose of the functions without restating their names, and outline their behavior, boundaries, and failure paths.
+
+## Context
+Functions that lack documentation create cognitive load for developers trying to understand their purpose, edge cases, and failure modes.
+
+## Evidence
+- path: "crates/mev-internal/src/domain/repo_target.rs"
+  loc: "6"
+  note: "Current: `pub fn resolve_repo_ref(`\nReplacement:\n```rust\n/// Determine the repository to operate on based on explicit input or ambient environment.\n/// Fails with `DomainError::MissingRepository` if no explicit repo is provided and no origin remote is configured.\npub fn resolve_repo_ref(\n```"
+- path: "crates/mev-internal/src/domain/submodule_path.rs"
+  loc: "7"
+  note: "Current: `pub fn validate_submodule_path(path: &str) -> Result<(), DomainError> {`\nReplacement:\n```rust\n/// Verify a string is a safe, relative path suitable for a submodule location.\n/// Fails with `DomainError::InvalidSubmodulePath` if the path is absolute, empty, or traverses parents.\npub fn validate_submodule_path(path: &str) -> Result<(), DomainError> {\n```"
+
+## Change Scope
+- `crates/mev-internal/src/domain/repo_target.rs`
+- `crates/mev-internal/src/domain/submodule_path.rs`

--- a/.jules/exchange/events/identity_scope_missing_docs_annotator.md
+++ b/.jules/exchange/events/identity_scope_missing_docs_annotator.md
@@ -1,0 +1,23 @@
+---
+label: "docs"
+created_at: "2024-04-05"
+author_role: "annotator"
+confidence: "high"
+---
+
+## Problem
+The purpose statement for `resolve_identity_scope` restates its name and signature.
+
+## Goal
+Improve the doc comment for `resolve_identity_scope` to answer what the unit does without restating its name, and explicitly mention the failure path.
+
+## Context
+First principles state that a comment block that restates a name adds no information, and missing failure paths lead to undiagnosed failures.
+
+## Evidence
+- path: "src/domain/identity.rs"
+  loc: "58"
+  note: "Current: `/// Resolve a identity scope input (alias or canonical) to a \`IdentityScope\`.`\nReplacement:\n```rust\n/// Look up a switch target corresponding to the user's input.\n/// Returns `None` if the input does not match any known canonical name or alias.\npub fn resolve_identity_scope(input: &str) -> Option<IdentityScope> {\n```"
+
+## Change Scope
+- `src/domain/identity.rs`


### PR DESCRIPTION
Emits annotator event files to flag missing and inadequate doc comments across several `pub fn` units in the codebase.

---
*PR created automatically by Jules for task [6638251902849203953](https://jules.google.com/task/6638251902849203953) started by @akitorahayashi*