### PR TITLE
test: emit test coverage event files

### DIFF
--- a/.jules/exchange/events/uncovered_config_command_tracer.md
+++ b/.jules/exchange/events/uncovered_config_command_tracer.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2025-05-24"
+author_role: "tracer"
+confidence: "high"
+---
+
+## Problem
+
+The `config` command CLI contract tests are entirely missing, and the command logic (`src/app/commands/config/mod.rs`) only has 16/33 lines covered.
+
+## Goal
+
+Add CLI tests for the `config` command to verify that `mev config deploy` properly triggers the domain logic.
+
+## Context
+
+The `config` command orchestration interacts heavily with `AnsiblePort` and `FsPort` to orchestrate file system modifications (moving role config directories into `.config`). A failure in this path would silently fail to configure essential development tools on new environments. The unit test `test_deploy_config_success` checks a happy path, but there are multiple paths in `deploy_internal` (e.g. invalid role, no roles, existing target without overwrite) and zero CLI contract tests in `tests/cli/config.rs`.
+
+## Evidence
+
+- path: "src/app/commands/config/mod.rs"
+  loc: "16/33 lines tested"
+  note: "Only the primary success path is unit-tested. Error paths like invalid role are uncovered."
+- path: "tests/cli/config.rs"
+  loc: "whole file"
+  note: "File exists but contains no test code."
+
+## Change Scope
+
+- `src/app/commands/config/mod.rs`
+- `tests/cli/config.rs`

--- a/.jules/exchange/events/uncovered_make_command_tracer.md
+++ b/.jules/exchange/events/uncovered_make_command_tracer.md
@@ -1,0 +1,32 @@
+---
+label: "tests"
+created_at: "2025-05-24"
+author_role: "tracer"
+confidence: "high"
+---
+
+## Problem
+
+The `make` command orchestration (`src/app/commands/make/mod.rs`) has 0% line coverage, and its corresponding CLI contract test file (`tests/cli/make.rs`) is completely empty.
+
+## Goal
+
+Implement CLI contract tests for the `make` command to ensure the execution plan creation, tag validation, and Ansible playbook invocation are covered and protected from regressions.
+
+## Context
+
+The `make` command is a critical state-transitioning path for the CLI that orchestrates system provisioning and configuration via Ansible. A complete lack of test coverage in this area means that regressions in tag validation, profile loading, and playbook dispatching will go unnoticed and silently fail in production. High-confidence test coverage in these critical paths is essential.
+
+## Evidence
+
+- path: "src/app/commands/make/mod.rs"
+  loc: "0/20 lines covered"
+  note: "The cargo tarpaulin report indicates 0/20 lines tested in the execution orchestration."
+- path: "tests/cli/make.rs"
+  loc: "whole file"
+  note: "The test file is initialized but contains no test assertions or test logic."
+
+## Change Scope
+
+- `src/app/commands/make/mod.rs`
+- `tests/cli/make.rs`

--- a/.jules/exchange/events/unmeasured_internal_crate_coverage_tracer.md
+++ b/.jules/exchange/events/unmeasured_internal_crate_coverage_tracer.md
@@ -1,0 +1,34 @@
+---
+label: "tests"
+created_at: "2025-05-24"
+author_role: "tracer"
+confidence: "high"
+---
+
+## Problem
+
+The internal crate modules `crates/mev-internal/src/domain/repo_target.rs` and `crates/mev-internal/src/domain/repository_ref.rs` are reported as having 0% code coverage despite having comprehensive unit test modules in their files.
+
+## Goal
+
+Determine why the `cargo tarpaulin` coverage report generated via `just coverage` is completely omitting the test execution for `mev-internal` unit tests, and adjust the coverage command or testing bounds to capture these critical path assertions.
+
+## Context
+
+The `repo_target` and `repository_ref` modules validate and resolve Git remote targets. Failure in this path will break label provisioning tools. The codebase clearly contains tests for these domains (e.g. `prefers_explicit_repo`, `parses_owner_name_repo_arg`), but they are not reflected in the coverage metrics. This is a false negative in the risk signal because `just coverage` calls `cargo tarpaulin --packages mev`, explicitly omitting `mev-internal` from the report.
+
+## Evidence
+
+- path: "justfile"
+  loc: "line 53 (`--packages mev`)"
+  note: "The tarpaulin invocation is restricted to the `mev` package and explicitly excludes workspace members."
+- path: "crates/mev-internal/src/domain/repo_target.rs"
+  loc: "0/8 lines covered"
+  note: "Tests are present in the file but not run during the coverage step."
+- path: "crates/mev-internal/src/domain/repository_ref.rs"
+  loc: "0/50 lines covered"
+  note: "Tests are present in the file but not run during the coverage step."
+
+## Change Scope
+
+- `justfile`


### PR DESCRIPTION
This PR reports critical path test coverage gaps and identifies a tooling misconfiguration omitting workspace libraries from the coverage execution.

The event artifacts are emitted into `.jules/exchange/events/` and include:
- `uncovered_config_command_tracer.md`: 0% CLI test coverage for `mev config deploy`.
- `uncovered_make_command_tracer.md`: 0% unit/CLI test coverage for `mev make` and `ExecutionPlan`.
- `unmeasured_internal_crate_coverage_tracer.md`: Identifies that `cargo tarpaulin` in `justfile` explicitly limits tests to `--packages mev`, resulting in a false-negative 0% coverage report for the `mev-internal` domain bounds.

---
*PR created automatically by Jules for task [6205184876610465613](https://jules.google.com/task/6205184876610465613) started by @akitorahayashi*