### PR TITLE
chore(requirements): route complex refactors and missing tests to planner

### DIFF
--- a/.jules/exchange/requirements/error_handling_unwrap_expect.md
+++ b/.jules/exchange/requirements/error_handling_unwrap_expect.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/errors_losing_domain_meaning.md
+++ b/.jules/exchange/requirements/errors_losing_domain_meaning.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/hardcoded_tag_enumerables.md
+++ b/.jules/exchange/requirements/hardcoded_tag_enumerables.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/identity_invalid_state.md
+++ b/.jules/exchange/requirements/identity_invalid_state.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/missing_cli_config_tests.md
+++ b/.jules/exchange/requirements/missing_cli_config_tests.md
@@ -1,6 +1,6 @@
 ---
 label: "tests"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/missing_cli_make_tests.md
+++ b/.jules/exchange/requirements/missing_cli_make_tests.md
@@ -1,6 +1,6 @@
 ---
 label: "tests"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/overloaded_target_terminology.md
+++ b/.jules/exchange/requirements/overloaded_target_terminology.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/persistence_leak_identity.md
+++ b/.jules/exchange/requirements/persistence_leak_identity.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/profile_hardware_coupling.md
+++ b/.jules/exchange/requirements/profile_hardware_coupling.md
@@ -1,6 +1,6 @@
 ---
 label: "feats"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/rename_generic_base_terms.md
+++ b/.jules/exchange/requirements/rename_generic_base_terms.md
@@ -1,6 +1,6 @@
 ---
 label: "refacts"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal

--- a/.jules/exchange/requirements/thread_safety_env_mocks.md
+++ b/.jules/exchange/requirements/thread_safety_env_mocks.md
@@ -1,6 +1,6 @@
 ---
 label: "tests"
-implementation_ready: true
+implementation_ready: false
 ---
 
 ## Goal


### PR DESCRIPTION
The dispatcher has triaged the requirements in `.jules/exchange/requirements/`. Complex changes like domain redesigns, testing global state with `unsafe`, comprehensive test suite additions, and widespread generic term replacements have been flagged with `implementation_ready: false` to be routed to the planner. Trivial documentation fixes and local scope adjustments were left as `implementation_ready: true`.

- Updated 11 complex requirements to `implementation_ready: false`.
- Left 3 requirements as `implementation_ready: true`.

---
*PR created automatically by Jules for task [9236718138303606433](https://jules.google.com/task/9236718138303606433) started by @akitorahayashi*