### PR TITLE
fix: make dp alias visible in config command help

### DIFF
--- a/src/app/cli/config.rs
+++ b/src/app/cli/config.rs
@@ -8,7 +8,7 @@ use crate::domain::error::AppError;
 #[derive(Subcommand)]
 pub enum ConfigCommand {
     /// Deploy role configs to ~/.config/mev/roles/.
-    #[command(alias = "dp")]
+    #[command(visible_alias = "dp")]
     Deploy {
         /// Role name to deploy config for. If omitted, deploys all roles.
         role: Option<String>,


### PR DESCRIPTION
Fixes an issue where the `dp` alias for `mev config deploy` was hidden from the CLI help output, contradicting the usage documentation. Changing `#[command(alias = "dp")]` to `#[command(visible_alias = "dp")]` aligns the CLI behavior with documentation.

---
*PR created automatically by Jules for task [6441268593931428295](https://jules.google.com/task/6441268593931428295) started by @akitorahayashi*