### PR TITLE
docs: clarify domain component and target logic intents

### DIFF
--- a/crates/mev-internal/src/domain/repo_target.rs
+++ b/crates/mev-internal/src/domain/repo_target.rs
@@ -3,6 +3,8 @@
 use crate::domain::DomainError;
 use crate::domain::repository_ref::RepositoryRef;
 
+/// Determine the repository to operate on based on explicit input or ambient environment.
+/// Fails with `DomainError::MissingRepository` if no explicit repo is provided and no origin remote is configured.
 pub fn resolve_repo_ref(
     explicit_repo: Option<&str>,
     origin_url: Option<&str>,

--- a/crates/mev-internal/src/domain/submodule_path.rs
+++ b/crates/mev-internal/src/domain/submodule_path.rs
@@ -4,6 +4,8 @@ use std::path::{Component, Path};
 
 use crate::domain::DomainError;
 
+/// Verify a string is a safe, relative path suitable for a submodule location.
+/// Fails with `DomainError::InvalidSubmodulePath` if the path is absolute, empty, or traverses parents.
 pub fn validate_submodule_path(path: &str) -> Result<(), DomainError> {
     let path = Path::new(path);
 

--- a/src/domain/backup_component.rs
+++ b/src/domain/backup_component.rs
@@ -63,7 +63,7 @@ const BACKUP_COMPONENT_ALIASES: &[(&str, BackupComponent)] = &[
     ("vscode-extensions", BackupComponent::Vscode),
 ];
 
-/// Look up a domain component corresponding to the user's input.
+/// Look up a backup component corresponding to the user's input.
 /// Returns `None` if the input does not map to a known canonical name or alias.
 pub fn resolve_backup_component(input: &str) -> Option<BackupComponent> {
     let lower = input.to_lowercase();

--- a/src/domain/backup_component.rs
+++ b/src/domain/backup_component.rs
@@ -63,7 +63,8 @@ const BACKUP_COMPONENT_ALIASES: &[(&str, BackupComponent)] = &[
     ("vscode-extensions", BackupComponent::Vscode),
 ];
 
-/// Resolve a backup component identifier or alias to a `BackupComponent`.
+/// Look up a domain component corresponding to the user's input.
+/// Returns `None` if the input does not map to a known canonical name or alias.
 pub fn resolve_backup_component(input: &str) -> Option<BackupComponent> {
     let lower = input.to_lowercase();
     for &(alias, component) in BACKUP_COMPONENT_ALIASES {
@@ -74,7 +75,8 @@ pub fn resolve_backup_component(input: &str) -> Option<BackupComponent> {
     None
 }
 
-/// Validate that the input maps to a `BackupComponent`.
+/// Verify the user's input maps to a known component, producing an actionable error if unrecognized.
+/// Fails with `AppError::InvalidBackupComponent` if the string cannot be resolved.
 pub fn validate_backup_component(input: &str) -> Result<BackupComponent, AppError> {
     resolve_backup_component(input).ok_or_else(|| {
         let valid: Vec<_> = BackupComponent::all().iter().map(|t| t.name()).collect();

--- a/src/domain/identity.rs
+++ b/src/domain/identity.rs
@@ -54,7 +54,8 @@ impl fmt::Display for IdentityScope {
     }
 }
 
-/// Resolve a identity scope input (alias or canonical) to a `IdentityScope`.
+/// Look up a switch target corresponding to the user's input.
+/// Returns `None` if the input does not match any known canonical name or alias.
 pub fn resolve_identity_scope(input: &str) -> Option<IdentityScope> {
     let lower = input.to_lowercase();
     IdentityScope::all()


### PR DESCRIPTION
Implements updated doc comments for several functions in the `domain` logic of `mev` and `mev-internal` to better explain their actual purpose and explicit failure cases, addressing the problem of redundant name-restating doc comments.

---
*PR created automatically by Jules for task [11217897800047794200](https://jules.google.com/task/11217897800047794200) started by @akitorahayashi*