### PR TITLE
test: implement CLI contract tests for make command

### DIFF
--- a/tests/cli/make.rs
+++ b/tests/cli/make.rs
@@ -1,1 +1,42 @@
 //! CLI contract tests for the `make` command.
+
+use crate::harness::TestContext;
+use predicates::prelude::*;
+use std::os::unix::fs::PermissionsExt;
+
+#[test]
+fn make_executes_ansible_playbook_successfully() {
+    let ctx = TestContext::new();
+
+    let ansible_mock = r#"#!/bin/bash
+echo "PLAY RECAP *********************************************************************"
+echo "localhost                  : ok=10   changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   "
+"#;
+
+    let mocks_dir = ctx.work_dir().join(".local/pipx/venvs/ansible/bin");
+    std::fs::create_dir_all(&mocks_dir).unwrap();
+    let ansible_path = mocks_dir.join("ansible-playbook");
+
+    std::fs::write(&ansible_path, ansible_mock).unwrap();
+    std::fs::set_permissions(&ansible_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    ctx.cli()
+        .env("HOME", ctx.work_dir())
+        .env("ANSIBLE_PLAYBOOK_BIN", &ansible_path)
+        .args(["make", "shell"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Completed successfully!"));
+}
+
+#[test]
+fn make_invalid_tag_fails() {
+    let ctx = TestContext::new();
+
+    ctx.cli()
+        .env("HOME", ctx.work_dir())
+        .args(["make", "invalid-tag"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid tag: 'invalid-tag'"));
+}


### PR DESCRIPTION
This submission introduces CLI contract tests for the `make` command. 

Two tests were added to `tests/cli/make.rs`:
- `make_executes_ansible_playbook_successfully`: Ensures that calling the `make` command successfully resolves to `ansible-playbook` by dynamically mocking its path and asserting successful execution output.
- `make_invalid_tag_fails`: Verifies that invalid tags supplied to the `make` command yield a failure and the correct error message, aligning with expected validation logic.

These additions fulfill the requirement to increase testing and regression coverage on the previously uncovered `make` orchestration.

---
*PR created automatically by Jules for task [11692947180016972021](https://jules.google.com/task/11692947180016972021) started by @akitorahayashi*