### PR TITLE
Refactor: Remove serde from core Identity domain

### DIFF
--- a/src/adapters/identity_store.rs
+++ b/src/adapters/identity_store.rs
@@ -7,8 +7,58 @@
 use std::path::{Path, PathBuf};
 
 use crate::domain::error::AppError;
-use crate::domain::identity::{Identity, IdentityScope};
-use crate::domain::ports::identity_store::{IdentityState, IdentityStore};
+use crate::domain::identity::{Identity, IdentityConfig, IdentityScope};
+use crate::domain::ports::identity_store::IdentityStore;
+
+/// Top-level identity model stored on disk.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IdentityState {
+    pub personal: IdentityDto,
+    pub work: IdentityDto,
+}
+
+/// DTO for a single identity in the identity store.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct IdentityDto {
+    pub name: String,
+    pub email: String,
+}
+
+impl From<IdentityConfig> for IdentityState {
+    fn from(config: IdentityConfig) -> Self {
+        Self {
+            personal: config.personal.into(),
+            work: config.work.into(),
+        }
+    }
+}
+
+impl From<IdentityState> for IdentityConfig {
+    fn from(state: IdentityState) -> Self {
+        Self {
+            personal: state.personal.into(),
+            work: state.work.into(),
+        }
+    }
+}
+
+impl From<Identity> for IdentityDto {
+    fn from(identity: Identity) -> Self {
+        Self {
+            name: identity.name,
+            email: identity.email,
+        }
+    }
+}
+
+impl From<IdentityDto> for Identity {
+    fn from(dto: IdentityDto) -> Self {
+        Self {
+            name: dto.name,
+            email: dto.email,
+        }
+    }
+}
 
 fn dot_config_dir() -> Result<PathBuf, AppError> {
     dirs::home_dir()
@@ -41,24 +91,26 @@ impl IdentityStore for IdentityFileStore {
         self.identity_path.exists()
     }
 
-    fn load(&self) -> Result<IdentityState, AppError> {
+    fn load(&self) -> Result<IdentityConfig, AppError> {
         if self.identity_path.exists() {
             let content = std::fs::read_to_string(&self.identity_path)?;
-            return serde_json::from_str(&content)
-                .map_err(|e| AppError::Config(format!("failed to parse identity config: {e}")));
+            let state: IdentityState = serde_json::from_str(&content)
+                .map_err(|e| AppError::Config(format!("failed to parse identity config: {e}")))?;
+            return Ok(state.into());
         }
 
         Err(AppError::Config("identity configuration does not exist".to_string()))
     }
 
-    fn save(&self, state: &IdentityState) -> Result<(), AppError> {
+    fn save(&self, config: &IdentityConfig) -> Result<(), AppError> {
         let parent = self
             .identity_path
             .parent()
             .ok_or_else(|| AppError::Config("identity path has no parent directory".to_string()))?;
         std::fs::create_dir_all(parent)?;
 
-        let content = serde_json::to_string_pretty(state)
+        let state: IdentityState = config.clone().into();
+        let content = serde_json::to_string_pretty(&state)
             .map_err(|e| AppError::Config(format!("failed to serialize identity config: {e}")))?;
 
         // Atomic write: write to temp file in same directory, then rename.
@@ -87,14 +139,14 @@ impl IdentityStore for IdentityFileStore {
 
 #[cfg(test)]
 mod tests {
-    use super::IdentityFileStore;
-    use crate::domain::identity::{Identity, IdentityScope};
-    use crate::domain::ports::identity_store::{IdentityState, IdentityStore};
+    use super::{IdentityFileStore, IdentityState};
+    use crate::domain::identity::{Identity, IdentityConfig, IdentityScope};
+    use crate::domain::ports::identity_store::IdentityStore;
     use std::path::PathBuf;
     use tempfile::tempdir;
 
-    fn create_dummy_state() -> IdentityState {
-        IdentityState {
+    fn create_dummy_config() -> IdentityConfig {
+        IdentityConfig {
             personal: Identity {
                 name: "Personal Name".to_string(),
                 email: "personal@example.com".to_string(),
@@ -138,7 +190,8 @@ mod tests {
     fn load_succeeds_from_new_path() -> Result<(), Box<dyn std::error::Error>> {
         let dir = tempdir()?;
         let path = dir.path().join("identity.json");
-        let state = create_dummy_state();
+        let config = create_dummy_config();
+        let state: IdentityState = config.into();
         let content = serde_json::to_string(&state)?;
         std::fs::write(&path, content)?;
 
@@ -154,8 +207,8 @@ mod tests {
         let path = dir.path().join("nested").join("identity.json");
         let store = IdentityFileStore::new(path.clone());
 
-        let state = create_dummy_state();
-        store.save(&state)?;
+        let config = create_dummy_config();
+        store.save(&config)?;
 
         assert!(path.exists());
 
@@ -170,8 +223,8 @@ mod tests {
         let path = PathBuf::from("");
         let store = IdentityFileStore::new(path);
 
-        let state = create_dummy_state();
-        assert!(store.save(&state).is_err());
+        let config = create_dummy_config();
+        assert!(store.save(&config).is_err());
         Ok(())
     }
 
@@ -181,8 +234,8 @@ mod tests {
         let path = dir.path().join("identity.json");
         let store = IdentityFileStore::new(path);
 
-        let state = create_dummy_state();
-        store.save(&state)?;
+        let config = create_dummy_config();
+        store.save(&config)?;
 
         let personal = store.get_identity(IdentityScope::Personal)?.ok_or("missing personal")?;
         assert_eq!(personal.name, "Personal Name");

--- a/src/adapters/identity_store.rs
+++ b/src/adapters/identity_store.rs
@@ -26,37 +26,25 @@ pub struct IdentityDto {
 
 impl From<IdentityConfig> for IdentityState {
     fn from(config: IdentityConfig) -> Self {
-        Self {
-            personal: config.personal.into(),
-            work: config.work.into(),
-        }
+        Self { personal: config.personal.into(), work: config.work.into() }
     }
 }
 
 impl From<IdentityState> for IdentityConfig {
     fn from(state: IdentityState) -> Self {
-        Self {
-            personal: state.personal.into(),
-            work: state.work.into(),
-        }
+        Self { personal: state.personal.into(), work: state.work.into() }
     }
 }
 
 impl From<Identity> for IdentityDto {
     fn from(identity: Identity) -> Self {
-        Self {
-            name: identity.name,
-            email: identity.email,
-        }
+        Self { name: identity.name, email: identity.email }
     }
 }
 
 impl From<IdentityDto> for Identity {
     fn from(dto: IdentityDto) -> Self {
-        Self {
-            name: dto.name,
-            email: dto.email,
-        }
+        Self { name: dto.name, email: dto.email }
     }
 }
 

--- a/src/app/commands/identity/mod.rs
+++ b/src/app/commands/identity/mod.rs
@@ -4,8 +4,8 @@ use std::io::Write;
 
 use crate::app::DependencyContainer;
 use crate::domain::error::AppError;
-use crate::domain::identity::Identity;
-use crate::domain::ports::identity_store::{IdentityState, IdentityStore};
+use crate::domain::identity::{Identity, IdentityConfig};
+use crate::domain::ports::identity_store::IdentityStore;
 
 /// Show current Git identity configuration.
 pub fn show(ctx: &DependencyContainer) -> Result<(), AppError> {
@@ -55,12 +55,12 @@ pub fn set(ctx: &DependencyContainer) -> Result<(), AppError> {
     let work_name = prompt("  Name", w_name_default)?;
     let work_email = prompt("  Email", w_email_default)?;
 
-    let state = IdentityState {
+    let config = IdentityConfig {
         personal: Identity { name: personal_name, email: personal_email },
         work: Identity { name: work_name, email: work_email },
     };
 
-    ctx.identity_store.save(&state)?;
+    ctx.identity_store.save(&config)?;
 
     println!();
     println!("Identity configuration saved to {}", ctx.identity_store.identity_path().display());

--- a/src/domain/identity.rs
+++ b/src/domain/identity.rs
@@ -6,7 +6,7 @@
 use std::fmt;
 
 /// Name and email pair applied to global Git configuration.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Identity {
     pub name: String,
     pub email: String,
@@ -16,6 +16,13 @@ impl Identity {
     pub fn is_configured(&self) -> bool {
         !self.name.is_empty() && !self.email.is_empty()
     }
+}
+
+/// Top-level identity configuration containing personal and work identities.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IdentityConfig {
+    pub personal: Identity,
+    pub work: Identity,
 }
 
 /// A resolved, valid identity target for switching.

--- a/src/domain/ports/identity_store.rs
+++ b/src/domain/ports/identity_store.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use crate::domain::error::AppError;
-use crate::domain::identity::{Identity, IdentityScope};
+use crate::domain::identity::{Identity, IdentityConfig, IdentityScope};
 
 /// Persists and retrieves Git identity configuration.
 pub trait IdentityStore {
@@ -11,21 +11,14 @@ pub trait IdentityStore {
     fn exists(&self) -> bool;
 
     /// Load the full identity configuration.
-    fn load(&self) -> Result<IdentityState, AppError>;
+    fn load(&self) -> Result<IdentityConfig, AppError>;
 
     /// Save the full identity configuration.
-    fn save(&self, state: &IdentityState) -> Result<(), AppError>;
+    fn save(&self, config: &IdentityConfig) -> Result<(), AppError>;
 
     /// Get the identity for the given switch target.
     fn get_identity(&self, identity: IdentityScope) -> Result<Option<Identity>, AppError>;
 
     /// Get the identity configuration file path.
     fn identity_path(&self) -> &Path;
-}
-
-/// Top-level identity model stored on disk.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct IdentityState {
-    pub personal: Identity,
-    pub work: Identity,
 }


### PR DESCRIPTION
Executed plan to keep domain models independent of transport/persistence concerns by removing `serde` derivations from the core domain.

- `src/domain/identity.rs`: Replaced `serde` traits with `PartialEq, Eq` on `Identity` and added `IdentityConfig` as top-level aggregate.
- `src/domain/ports/identity_store.rs`: Removed `IdentityState` DTO and updated methods to handle `IdentityConfig` objects instead.
- `src/adapters/identity_store.rs`: Created localized DTOs (`IdentityState`, `IdentityDto`) to handle serde derivations and integrated bidirectional mappings `From` and `Into` to convert configurations upon reading and writing JSON files.
- Tests passing and clean compilation.

---
*PR created automatically by Jules for task [7527583879778818768](https://jules.google.com/task/7527583879778818768) started by @akitorahayashi*