### PR TITLE
Refactor: Enforce Invariants in Identity Model

### DIFF
--- a/src/adapters/identity_store.rs
+++ b/src/adapters/identity_store.rs
@@ -75,8 +75,8 @@ impl IdentityStore for IdentityFileStore {
     fn get_identity(&self, identity: IdentityScope) -> Result<Option<Identity>, AppError> {
         let state = self.load()?;
         match identity {
-            IdentityScope::Personal => Ok(Some(state.personal)),
-            IdentityScope::Work => Ok(Some(state.work)),
+            IdentityScope::Personal => Ok(state.personal),
+            IdentityScope::Work => Ok(state.work),
         }
     }
 
@@ -95,11 +95,8 @@ mod tests {
 
     fn create_dummy_state() -> IdentityState {
         IdentityState {
-            personal: Identity {
-                name: "Personal Name".to_string(),
-                email: "personal@example.com".to_string(),
-            },
-            work: Identity { name: "Work Name".to_string(), email: "work@example.com".to_string() },
+            personal: Identity::new("Personal Name", "personal@example.com"),
+            work: Identity::new("Work Name", "work@example.com"),
         }
     }
 
@@ -144,7 +141,7 @@ mod tests {
 
         let store = IdentityFileStore::new(path);
         let loaded = store.load()?;
-        assert_eq!(loaded.personal.email, "personal@example.com");
+        assert_eq!(loaded.personal.unwrap().email(), "personal@example.com");
         Ok(())
     }
 
@@ -161,7 +158,7 @@ mod tests {
 
         let content = std::fs::read_to_string(&path)?;
         let loaded: IdentityState = serde_json::from_str(&content)?;
-        assert_eq!(loaded.work.name, "Work Name");
+        assert_eq!(loaded.work.unwrap().name(), "Work Name");
         Ok(())
     }
 
@@ -185,10 +182,10 @@ mod tests {
         store.save(&state)?;
 
         let personal = store.get_identity(IdentityScope::Personal)?.ok_or("missing personal")?;
-        assert_eq!(personal.name, "Personal Name");
+        assert_eq!(personal.name(), "Personal Name");
 
         let work = store.get_identity(IdentityScope::Work)?.ok_or("missing work")?;
-        assert_eq!(work.name, "Work Name");
+        assert_eq!(work.name(), "Work Name");
 
         Ok(())
     }

--- a/src/app/commands/identity/mod.rs
+++ b/src/app/commands/identity/mod.rs
@@ -22,8 +22,16 @@ pub fn show(ctx: &DependencyContainer) -> Result<(), AppError> {
     println!();
     println!("{:<12} {:<20} Email", "Profile", "Name");
     println!("{:-<12} {:-<20} {:-<30}", "", "", "");
-    println!("{:<12} {:<20} {}", "personal", state.personal.name, state.personal.email);
-    println!("{:<12} {:<20} {}", "work", state.work.name, state.work.email);
+    if let Some(personal) = state.personal {
+        println!("{:<12} {:<20} {}", "personal", personal.name(), personal.email());
+    } else {
+        println!("{:<12} {:<20} {}", "personal", "Not configured", "");
+    }
+    if let Some(work) = state.work {
+        println!("{:<12} {:<20} {}", "work", work.name(), work.email());
+    } else {
+        println!("{:<12} {:<20} {}", "work", "Not configured", "");
+    }
 
     Ok(())
 }
@@ -37,27 +45,26 @@ pub fn set(ctx: &DependencyContainer) -> Result<(), AppError> {
         if ctx.identity_store.exists() { Some(ctx.identity_store.load()?) } else { None };
 
     let (p_name_default, p_email_default, w_name_default, w_email_default) = match &existing {
-        Some(state) => (
-            state.personal.name.as_str(),
-            state.personal.email.as_str(),
-            state.work.name.as_str(),
-            state.work.email.as_str(),
-        ),
-        None => ("", "", "", ""),
+        Some(state) => {
+            let (pn, pe) = state.personal.as_ref().map(|id| (id.name().to_string(), id.email().to_string())).unwrap_or_default();
+            let (wn, we) = state.work.as_ref().map(|id| (id.name().to_string(), id.email().to_string())).unwrap_or_default();
+            (pn, pe, wn, we)
+        }
+        None => (String::new(), String::new(), String::new(), String::new()),
     };
 
     println!("Personal identity:");
-    let personal_name = prompt("  Name", p_name_default)?;
-    let personal_email = prompt("  Email", p_email_default)?;
+    let personal_name = prompt("  Name", &p_name_default)?;
+    let personal_email = prompt("  Email", &p_email_default)?;
     println!();
 
     println!("Work identity:");
-    let work_name = prompt("  Name", w_name_default)?;
-    let work_email = prompt("  Email", w_email_default)?;
+    let work_name = prompt("  Name", &w_name_default)?;
+    let work_email = prompt("  Email", &w_email_default)?;
 
     let state = IdentityState {
-        personal: Identity { name: personal_name, email: personal_email },
-        work: Identity { name: work_name, email: work_email },
+        personal: Identity::new(personal_name, personal_email),
+        work: Identity::new(work_name, work_email),
     };
 
     ctx.identity_store.save(&state)?;

--- a/src/app/commands/identity/mod.rs
+++ b/src/app/commands/identity/mod.rs
@@ -25,12 +25,12 @@ pub fn show(ctx: &DependencyContainer) -> Result<(), AppError> {
     if let Some(personal) = state.personal {
         println!("{:<12} {:<20} {}", "personal", personal.name(), personal.email());
     } else {
-        println!("{:<12} {:<20} {}", "personal", "Not configured", "");
+        println!("{:<12} {:<20}", "personal", "Not configured");
     }
     if let Some(work) = state.work {
         println!("{:<12} {:<20} {}", "work", work.name(), work.email());
     } else {
-        println!("{:<12} {:<20} {}", "work", "Not configured", "");
+        println!("{:<12} {:<20}", "work", "Not configured");
     }
 
     Ok(())
@@ -46,8 +46,16 @@ pub fn set(ctx: &DependencyContainer) -> Result<(), AppError> {
 
     let (p_name_default, p_email_default, w_name_default, w_email_default) = match &existing {
         Some(state) => {
-            let (pn, pe) = state.personal.as_ref().map(|id| (id.name().to_string(), id.email().to_string())).unwrap_or_default();
-            let (wn, we) = state.work.as_ref().map(|id| (id.name().to_string(), id.email().to_string())).unwrap_or_default();
+            let (pn, pe) = state
+                .personal
+                .as_ref()
+                .map(|id| (id.name().to_string(), id.email().to_string()))
+                .unwrap_or_default();
+            let (wn, we) = state
+                .work
+                .as_ref()
+                .map(|id| (id.name().to_string(), id.email().to_string()))
+                .unwrap_or_default();
             (pn, pe, wn, we)
         }
         None => (String::new(), String::new(), String::new(), String::new()),

--- a/src/app/commands/switch/mod.rs
+++ b/src/app/commands/switch/mod.rs
@@ -17,18 +17,16 @@ pub fn execute(ctx: &DependencyContainer, identity: IdentityScope) -> Result<(),
     let identity_config = ctx
         .identity_store
         .get_identity(identity)?
-        .ok_or_else(|| AppError::Config(format!("failed to load {} identity", identity)))?;
-
-    if !identity_config.is_configured() {
-        return Err(AppError::Config(format!(
-            "{identity} identity is not configured. Run 'mev identity set' to configure."
-        )));
-    }
+        .ok_or_else(|| {
+            AppError::Config(format!(
+                "{identity} identity is not configured. Run 'mev identity set' to configure."
+            ))
+        })?;
 
     println!("Switching to {} identity...", identity);
 
     // Git configuration (required)
-    ctx.git.set_identity(&identity_config.name, &identity_config.email)?;
+    ctx.git.set_identity(identity_config.name(), identity_config.email())?;
 
     // Show current configuration via git.
     let (name, email) = ctx.git.get_identity()?;

--- a/src/app/commands/switch/mod.rs
+++ b/src/app/commands/switch/mod.rs
@@ -14,14 +14,11 @@ pub fn execute(ctx: &DependencyContainer, identity: IdentityScope) -> Result<(),
         return Err(AppError::Config("no identity configuration found".to_string()));
     }
 
-    let identity_config = ctx
-        .identity_store
-        .get_identity(identity)?
-        .ok_or_else(|| {
-            AppError::Config(format!(
-                "{identity} identity is not configured. Run 'mev identity set' to configure."
-            ))
-        })?;
+    let identity_config = ctx.identity_store.get_identity(identity)?.ok_or_else(|| {
+        AppError::Config(format!(
+            "{identity} identity is not configured. Run 'mev identity set' to configure."
+        ))
+    })?;
 
     println!("Switching to {} identity...", identity);
 

--- a/src/domain/identity.rs
+++ b/src/domain/identity.rs
@@ -5,16 +5,55 @@
 
 use std::fmt;
 
-/// Name and email pair applied to global Git configuration.
+/// Raw serialization model for Identity.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct Identity {
+pub struct RawIdentity {
     pub name: String,
     pub email: String,
 }
 
+/// Name and email pair applied to global Git configuration.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "RawIdentity", into = "RawIdentity")]
+pub struct Identity {
+    name: String,
+    email: String,
+}
+
 impl Identity {
-    pub fn is_configured(&self) -> bool {
-        !self.name.is_empty() && !self.email.is_empty()
+    /// Creates a new identity, ensuring fields are not empty.
+    pub fn new(name: impl Into<String>, email: impl Into<String>) -> Option<Self> {
+        let name = name.into();
+        let email = email.into();
+        if name.trim().is_empty() || email.trim().is_empty() {
+            None
+        } else {
+            Some(Self { name, email })
+        }
+    }
+
+    /// Gets the name of the identity.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Gets the email of the identity.
+    pub fn email(&self) -> &str {
+        &self.email
+    }
+}
+
+impl std::convert::TryFrom<RawIdentity> for Identity {
+    type Error = &'static str;
+
+    fn try_from(raw: RawIdentity) -> Result<Self, Self::Error> {
+        Self::new(raw.name, raw.email).ok_or("empty fields")
+    }
+}
+
+impl From<Identity> for RawIdentity {
+    fn from(id: Identity) -> Self {
+        Self { name: id.name, email: id.email }
     }
 }
 

--- a/src/domain/identity.rs
+++ b/src/domain/identity.rs
@@ -23,13 +23,9 @@ pub struct Identity {
 impl Identity {
     /// Creates a new identity, ensuring fields are not empty.
     pub fn new(name: impl Into<String>, email: impl Into<String>) -> Option<Self> {
-        let name = name.into();
-        let email = email.into();
-        if name.trim().is_empty() || email.trim().is_empty() {
-            None
-        } else {
-            Some(Self { name, email })
-        }
+        let name = name.into().trim().to_string();
+        let email = email.into().trim().to_string();
+        if name.is_empty() || email.is_empty() { None } else { Some(Self { name, email }) }
     }
 
     /// Gets the name of the identity.
@@ -105,6 +101,20 @@ pub fn resolve_identity_scope(input: &str) -> Option<IdentityScope> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn identity_validation() {
+        // Valid inputs
+        let id = Identity::new(" Jane Doe ", " jane@example.com ").unwrap();
+        assert_eq!(id.name(), "Jane Doe");
+        assert_eq!(id.email(), "jane@example.com");
+
+        // Empty or whitespace inputs
+        assert!(Identity::new("", "jane@example.com").is_none());
+        assert!(Identity::new("  ", "jane@example.com").is_none());
+        assert!(Identity::new("Jane Doe", "").is_none());
+        assert!(Identity::new("Jane Doe", "  ").is_none());
+    }
 
     #[test]
     fn resolves_identity_scopes() {

--- a/src/domain/ports/identity_store.rs
+++ b/src/domain/ports/identity_store.rs
@@ -26,6 +26,18 @@ pub trait IdentityStore {
 /// Top-level identity model stored on disk.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct IdentityState {
-    pub personal: Identity,
-    pub work: Identity,
+    #[serde(default, deserialize_with = "deserialize_identity_option")]
+    pub personal: Option<Identity>,
+    #[serde(default, deserialize_with = "deserialize_identity_option")]
+    pub work: Option<Identity>,
+}
+
+fn deserialize_identity_option<'de, D>(deserializer: D) -> Result<Option<Identity>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use crate::domain::identity::RawIdentity;
+    use serde::Deserialize;
+    let raw: Option<RawIdentity> = Option::deserialize(deserializer)?;
+    Ok(raw.and_then(|r| Identity::try_from(r).ok()))
 }


### PR DESCRIPTION
This implements the assigned refactor plan to encode invariants at the boundary for `Identity`. Instead of expressing invalid states via an empty model with an `is_configured` method, the application now requires non-empty states upon construction and relies gracefully on `Option<Identity>` mapping where invalid strings exist in legacy configs.

---
*PR created automatically by Jules for task [3163515858037091642](https://jules.google.com/task/3163515858037091642) started by @akitorahayashi*