### PR TITLE
Refactor tags to load dynamically from Ansible playbook

### DIFF
--- a/src/adapters/ansible/executor.rs
+++ b/src/adapters/ansible/executor.rs
@@ -66,6 +66,8 @@ pub struct AnsibleAdapter {
     roles_dir: PathBuf,
     tags_by_role: HashMap<String, Vec<String>>,
     tag_to_role: HashMap<String, String>,
+    tag_groups: HashMap<String, Vec<String>>,
+    full_setup_tags: Vec<String>,
 }
 
 impl AnsibleAdapter {
@@ -77,7 +79,7 @@ impl AnsibleAdapter {
         let playbook_path = ansible_dir.join("playbook.yml");
         let roles_dir = ansible_dir.join("roles");
 
-        let (tags_by_role, tag_to_role) = load_catalog(&playbook_path)?;
+        let (tags_by_role, tag_to_role, tag_groups, full_setup_tags) = load_catalog(&playbook_path)?;
 
         Ok(Self {
             ansible_dir: ansible_dir.to_path_buf(),
@@ -85,6 +87,8 @@ impl AnsibleAdapter {
             roles_dir,
             tags_by_role,
             tag_to_role,
+            tag_groups,
+            full_setup_tags,
         })
     }
 
@@ -96,6 +100,8 @@ impl AnsibleAdapter {
             roles_dir: PathBuf::new(),
             tags_by_role: HashMap::new(),
             tag_to_role: HashMap::new(),
+            tag_groups: HashMap::new(),
+            full_setup_tags: Vec::new(),
         }
     }
 
@@ -224,6 +230,14 @@ impl AnsiblePort for AnsibleAdapter {
         tags
     }
 
+    fn tag_groups(&self) -> &HashMap<String, Vec<String>> {
+        &self.tag_groups
+    }
+
+    fn full_setup_tags(&self) -> &[String] {
+        &self.full_setup_tags
+    }
+
     fn tags_by_role(&self) -> &HashMap<String, Vec<String>> {
         &self.tags_by_role
     }
@@ -246,10 +260,15 @@ impl AnsiblePort for AnsibleAdapter {
     }
 }
 
-/// Tag catalog: role→tags mapping and tag→role mapping.
-type Catalog = (HashMap<String, Vec<String>>, HashMap<String, String>);
+/// Tag catalog: role→tags, tag→role, tag_groups, and full_setup_tags.
+type Catalog = (
+    HashMap<String, Vec<String>>,
+    HashMap<String, String>,
+    HashMap<String, Vec<String>>,
+    Vec<String>,
+);
 
-/// Load tag-to-role mappings from a playbook.yml file.
+/// Load tag mappings from a playbook.yml file.
 fn load_catalog(playbook_path: &PathBuf) -> Result<Catalog, Box<dyn std::error::Error>> {
     let content = std::fs::read_to_string(playbook_path)?;
     let docs: Vec<serde_yaml::Value> = serde_yaml::from_str(&content)?;
@@ -259,8 +278,24 @@ fn load_catalog(playbook_path: &PathBuf) -> Result<Catalog, Box<dyn std::error::
 
     let mut tags_by_role: HashMap<String, Vec<String>> = HashMap::new();
     let mut tag_to_role = HashMap::new();
+    let mut tag_groups = HashMap::new();
+    let mut full_setup_tags = Vec::new();
 
     for doc in &docs {
+        if let Some(vars) = doc.get("vars").and_then(|v| v.as_mapping()) {
+            if let Some(tg) = vars.get(&serde_yaml::Value::String("tag_groups".to_string())).and_then(|v| v.as_mapping()) {
+                for (k, v) in tg {
+                    if let (Some(group_name), Some(seq)) = (k.as_str(), v.as_sequence()) {
+                        let group_tags: Vec<String> = seq.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect();
+                        tag_groups.insert(group_name.to_string(), group_tags);
+                    }
+                }
+            }
+            if let Some(fst) = vars.get(&serde_yaml::Value::String("full_setup_tags".to_string())).and_then(|v| v.as_sequence()) {
+                full_setup_tags = fst.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect();
+            }
+        }
+
         if let Some(roles) = doc.get("roles").and_then(|r| r.as_sequence()) {
             for role_entry in roles {
                 if let Some(mapping) = role_entry.as_mapping() {
@@ -294,7 +329,7 @@ fn load_catalog(playbook_path: &PathBuf) -> Result<Catalog, Box<dyn std::error::
         }
     }
 
-    Ok((tags_by_role, tag_to_role))
+    Ok((tags_by_role, tag_to_role, tag_groups, full_setup_tags))
 }
 #[cfg(test)]
 mod tests {
@@ -400,6 +435,8 @@ mod tests {
             roles_dir,
             tags_by_role: HashMap::new(),
             tag_to_role: HashMap::new(),
+            tag_groups: HashMap::new(),
+            full_setup_tags: Vec::new(),
         };
 
         let cmd_result = adapter.build_command_with_env(
@@ -435,6 +472,8 @@ mod tests {
             roles_dir: PathBuf::new(),
             tags_by_role: HashMap::new(),
             tag_to_role: HashMap::new(),
+            tag_groups: HashMap::new(),
+            full_setup_tags: Vec::new(),
         };
 
         let result = adapter.build_command("profile", &[], false);

--- a/src/adapters/ansible/executor.rs
+++ b/src/adapters/ansible/executor.rs
@@ -79,7 +79,7 @@ impl AnsibleAdapter {
         let playbook_path = ansible_dir.join("playbook.yml");
         let roles_dir = ansible_dir.join("roles");
 
-        let (tags_by_role, tag_to_role, tag_groups, full_setup_tags) =
+        let TagCatalog { tags_by_role, tag_to_role, tag_groups, full_setup_tags } =
             load_catalog(&playbook_path)?;
 
         Ok(Self {
@@ -262,83 +262,71 @@ impl AnsiblePort for AnsibleAdapter {
 }
 
 /// Tag catalog: role→tags, tag→role, tag_groups, and full_setup_tags.
-type Catalog = (
-    HashMap<String, Vec<String>>,
-    HashMap<String, String>,
-    HashMap<String, Vec<String>>,
-    Vec<String>,
-);
+#[derive(Default)]
+struct TagCatalog {
+    tags_by_role: HashMap<String, Vec<String>>,
+    tag_to_role: HashMap<String, String>,
+    tag_groups: HashMap<String, Vec<String>>,
+    full_setup_tags: Vec<String>,
+}
 
 /// Load tag mappings from a playbook.yml file.
-fn load_catalog(playbook_path: &PathBuf) -> Result<Catalog, Box<dyn std::error::Error>> {
+fn load_catalog(playbook_path: &PathBuf) -> Result<TagCatalog, Box<dyn std::error::Error>> {
     let content = std::fs::read_to_string(playbook_path)?;
     let docs: Vec<serde_yaml::Value> = serde_yaml::from_str(&content)?;
 
-    let role_key = serde_yaml::Value::String("role".to_string());
-    let tags_key = serde_yaml::Value::String("tags".to_string());
-
-    let mut tags_by_role: HashMap<String, Vec<String>> = HashMap::new();
-    let mut tag_to_role = HashMap::new();
-    let mut tag_groups = HashMap::new();
-    let mut full_setup_tags = Vec::new();
+    let mut catalog = TagCatalog::default();
 
     for doc in &docs {
-        if let Some(vars) = doc.get("vars").and_then(|v| v.as_mapping()) {
-            if let Some(tg) = vars
-                .get(serde_yaml::Value::String("tag_groups".to_string()))
-                .and_then(|v| v.as_mapping())
-            {
+        if let Some(vars) = doc.get("vars") {
+            if let Some(tg) = vars.get("tag_groups").and_then(|v| v.as_mapping()) {
                 for (k, v) in tg {
                     if let (Some(group_name), Some(seq)) = (k.as_str(), v.as_sequence()) {
                         let group_tags: Vec<String> =
                             seq.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect();
-                        tag_groups.insert(group_name.to_string(), group_tags);
+                        catalog.tag_groups.insert(group_name.to_string(), group_tags);
                     }
                 }
             }
-            if let Some(fst) = vars
-                .get(serde_yaml::Value::String("full_setup_tags".to_string()))
-                .and_then(|v| v.as_sequence())
-            {
-                full_setup_tags =
-                    fst.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect();
+            if let Some(fst) = vars.get("full_setup_tags").and_then(|v| v.as_sequence()) {
+                catalog
+                    .full_setup_tags
+                    .extend(fst.iter().filter_map(|t| t.as_str().map(|s| s.to_string())));
             }
         }
 
         if let Some(roles) = doc.get("roles").and_then(|r| r.as_sequence()) {
             for role_entry in roles {
-                if let Some(mapping) = role_entry.as_mapping() {
-                    let role_name =
-                        mapping.get(&role_key).and_then(|v| v.as_str()).map(|s| s.to_string());
+                let role_name =
+                    role_entry.get("role").and_then(|v| v.as_str()).map(|s| s.to_string());
 
-                    let tags: Vec<String> = match mapping.get(&tags_key) {
-                        Some(serde_yaml::Value::Sequence(seq)) => {
-                            seq.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect()
-                        }
-                        Some(serde_yaml::Value::String(s)) => vec![s.to_string()],
-                        _ => Vec::new(),
-                    };
-
-                    if let Some(name) = role_name {
-                        for tag in &tags {
-                            if let Some(existing) = tag_to_role.get(tag)
-                                && existing != &name
-                            {
-                                return Err(format!(
-                                    "duplicate tag '{tag}': owned by both '{existing}' and '{name}'"
-                                )
-                                .into());
-                            }
-                            tag_to_role.insert(tag.to_string(), name.to_string());
-                        }
-                        tags_by_role.entry(name).or_default().extend(tags);
+                let tags: Vec<String> = match role_entry.get("tags") {
+                    Some(serde_yaml::Value::Sequence(seq)) => {
+                        seq.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect()
                     }
+                    Some(serde_yaml::Value::String(s)) => vec![s.to_string()],
+                    _ => Vec::new(),
+                };
+
+                if let Some(name) = role_name {
+                    for tag in &tags {
+                        if let Some(existing) = catalog.tag_to_role.get(tag)
+                            && existing != &name
+                        {
+                            return Err(format!(
+                                "duplicate tag '{tag}': owned by both '{existing}' and '{name}'"
+                            )
+                            .into());
+                        }
+                        catalog.tag_to_role.insert(tag.to_string(), name.to_string());
+                    }
+                    catalog.tags_by_role.entry(name).or_default().extend(tags);
                 }
             }
         }
     }
 
-    Ok((tags_by_role, tag_to_role, tag_groups, full_setup_tags))
+    Ok(catalog)
 }
 #[cfg(test)]
 mod tests {

--- a/src/adapters/ansible/executor.rs
+++ b/src/adapters/ansible/executor.rs
@@ -79,7 +79,8 @@ impl AnsibleAdapter {
         let playbook_path = ansible_dir.join("playbook.yml");
         let roles_dir = ansible_dir.join("roles");
 
-        let (tags_by_role, tag_to_role, tag_groups, full_setup_tags) = load_catalog(&playbook_path)?;
+        let (tags_by_role, tag_to_role, tag_groups, full_setup_tags) =
+            load_catalog(&playbook_path)?;
 
         Ok(Self {
             ansible_dir: ansible_dir.to_path_buf(),
@@ -283,16 +284,24 @@ fn load_catalog(playbook_path: &PathBuf) -> Result<Catalog, Box<dyn std::error::
 
     for doc in &docs {
         if let Some(vars) = doc.get("vars").and_then(|v| v.as_mapping()) {
-            if let Some(tg) = vars.get(&serde_yaml::Value::String("tag_groups".to_string())).and_then(|v| v.as_mapping()) {
+            if let Some(tg) = vars
+                .get(&serde_yaml::Value::String("tag_groups".to_string()))
+                .and_then(|v| v.as_mapping())
+            {
                 for (k, v) in tg {
                     if let (Some(group_name), Some(seq)) = (k.as_str(), v.as_sequence()) {
-                        let group_tags: Vec<String> = seq.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect();
+                        let group_tags: Vec<String> =
+                            seq.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect();
                         tag_groups.insert(group_name.to_string(), group_tags);
                     }
                 }
             }
-            if let Some(fst) = vars.get(&serde_yaml::Value::String("full_setup_tags".to_string())).and_then(|v| v.as_sequence()) {
-                full_setup_tags = fst.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect();
+            if let Some(fst) = vars
+                .get(&serde_yaml::Value::String("full_setup_tags".to_string()))
+                .and_then(|v| v.as_sequence())
+            {
+                full_setup_tags =
+                    fst.iter().filter_map(|t| t.as_str().map(|s| s.to_string())).collect();
             }
         }
 

--- a/src/adapters/ansible/executor.rs
+++ b/src/adapters/ansible/executor.rs
@@ -285,7 +285,7 @@ fn load_catalog(playbook_path: &PathBuf) -> Result<Catalog, Box<dyn std::error::
     for doc in &docs {
         if let Some(vars) = doc.get("vars").and_then(|v| v.as_mapping()) {
             if let Some(tg) = vars
-                .get(&serde_yaml::Value::String("tag_groups".to_string()))
+                .get(serde_yaml::Value::String("tag_groups".to_string()))
                 .and_then(|v| v.as_mapping())
             {
                 for (k, v) in tg {
@@ -297,7 +297,7 @@ fn load_catalog(playbook_path: &PathBuf) -> Result<Catalog, Box<dyn std::error::
                 }
             }
             if let Some(fst) = vars
-                .get(&serde_yaml::Value::String("full_setup_tags".to_string()))
+                .get(serde_yaml::Value::String("full_setup_tags".to_string()))
                 .and_then(|v| v.as_sequence())
             {
                 full_setup_tags =

--- a/src/app/commands/create/mod.rs
+++ b/src/app/commands/create/mod.rs
@@ -6,7 +6,6 @@ use crate::domain::error::AppError;
 use crate::domain::execution_plan::ExecutionPlan;
 use crate::domain::ports::ansible::AnsiblePort;
 use crate::domain::profile::Profile;
-use crate::domain::tag::FULL_SETUP_TAGS;
 
 /// Execute the `create` command: deploy configs and run full setup tags.
 pub fn execute(
@@ -15,17 +14,19 @@ pub fn execute(
     overwrite: bool,
     verbose: bool,
 ) -> Result<(), AppError> {
+    let full_setup_tags = ctx.ansible.full_setup_tags();
+
     // Validate all tags exist in catalog
     let all_catalog_tags: std::collections::HashSet<String> =
         ctx.ansible.all_tags().into_iter().collect();
-    let invalid: Vec<&&str> =
-        FULL_SETUP_TAGS.iter().filter(|t| !all_catalog_tags.contains(**t)).collect();
+    let invalid: Vec<&String> =
+        full_setup_tags.iter().filter(|t| !all_catalog_tags.contains(*t)).collect();
     if !invalid.is_empty() {
-        let names: Vec<String> = invalid.iter().map(|t| (**t).to_string()).collect();
+        let names: Vec<String> = invalid.iter().map(|t| (*t).to_string()).collect();
         return Err(AppError::InvalidTag(names.join(", ")));
     }
 
-    let plan = ExecutionPlan::full_setup(profile, verbose);
+    let plan = ExecutionPlan::full_setup(profile, full_setup_tags.to_vec(), verbose);
 
     println!();
     println!("mev: Creating {} environment", plan.profile);

--- a/src/app/commands/list/mod.rs
+++ b/src/app/commands/list/mod.rs
@@ -4,7 +4,6 @@ use crate::app::DependencyContainer;
 use crate::domain::error::AppError;
 use crate::domain::ports::ansible::AnsiblePort;
 use crate::domain::profile;
-use crate::domain::tag;
 
 /// Execute the `list` command: print tags, groups, and profiles.
 pub fn execute(ctx: &DependencyContainer) -> Result<(), AppError> {
@@ -23,7 +22,7 @@ pub fn execute(ctx: &DependencyContainer) -> Result<(), AppError> {
 
     // Tag groups
     println!("Tag Groups (expanded automatically):");
-    let groups = tag::tag_groups();
+    let groups = ctx.ansible.tag_groups();
     let mut group_keys: Vec<_> = groups.keys().collect();
     group_keys.sort();
     for key in group_keys {

--- a/src/app/commands/make/mod.rs
+++ b/src/app/commands/make/mod.rs
@@ -16,7 +16,7 @@ pub fn execute(
     overwrite: bool,
     verbose: bool,
 ) -> Result<(), AppError> {
-    let tags_to_run = tag::resolve_tags(tag_input);
+    let tags_to_run = tag::resolve_tags(tag_input, ctx.ansible.tag_groups());
 
     // Validate tags exist in catalog
     for t in &tags_to_run {

--- a/src/assets/ansible/playbook.yml
+++ b/src/assets/ansible/playbook.yml
@@ -2,6 +2,34 @@
 - name: Setup macOS development environment
   hosts: localhost
   connection: local
+  vars:
+    tag_groups:
+      rust: ["rust-platform", "rust-tools"]
+      python: ["python-platform", "python-tools"]
+      nodejs: ["nodejs-platform", "nodejs-tools"]
+      go: ["go-platform", "go-tools"]
+    full_setup_tags:
+      - brew-formulae
+      - ollama
+      - shell
+      - system
+      - git
+      - gh
+      - python-platform
+      - nodejs-platform
+      - ruby
+      - rust-platform
+      - go-platform
+      - python-tools
+      - uv
+      - nodejs-tools
+      - rust-tools
+      - go-tools
+      - vscode
+      - cursor
+      - coder
+      - mlx
+      - xcode
   roles:
     - { role: brew, tags: ["brew-formulae", "brew-f", "brew-cask", "brew-c"] }
     - { role: python, tags: ["python-platform", "py-p", "python-tools", "py-t", "uv"] }

--- a/src/domain/execution_plan.rs
+++ b/src/domain/execution_plan.rs
@@ -12,8 +12,7 @@ pub struct ExecutionPlan {
 
 impl ExecutionPlan {
     /// Construct a plan for a full environment creation.
-    pub fn full_setup(profile: Profile, verbose: bool) -> Self {
-        let tags = crate::domain::tag::FULL_SETUP_TAGS.iter().map(|s| (*s).to_string()).collect();
+    pub fn full_setup(profile: Profile, tags: Vec<String>, verbose: bool) -> Self {
         Self { profile, tags, verbose }
     }
 
@@ -26,15 +25,15 @@ impl ExecutionPlan {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::domain::tag::FULL_SETUP_TAGS;
 
     #[test]
     fn full_setup_contains_all_tags() {
-        let plan = ExecutionPlan::full_setup(Profile::Macbook, true);
+        let test_tags = vec!["tag1".to_string(), "tag2".to_string()];
+        let plan = ExecutionPlan::full_setup(Profile::Macbook, test_tags.clone(), true);
         assert_eq!(plan.profile, Profile::Macbook);
         assert!(plan.verbose);
 
-        assert_eq!(plan.tags.as_slice(), FULL_SETUP_TAGS);
+        assert_eq!(plan.tags, test_tags);
     }
 
     #[test]

--- a/src/domain/ports/ansible.rs
+++ b/src/domain/ports/ansible.rs
@@ -15,6 +15,12 @@ pub trait AnsiblePort {
     /// Get all available tags.
     fn all_tags(&self) -> Vec<String>;
 
+    /// Get the tag groups defined in the playbook.
+    fn tag_groups(&self) -> &HashMap<String, Vec<String>>;
+
+    /// Get the full setup tags defined in the playbook.
+    fn full_setup_tags(&self) -> &[String];
+
     /// Get mapping of role names to their associated tags.
     fn tags_by_role(&self) -> &HashMap<String, Vec<String>>;
 

--- a/src/domain/tag.rs
+++ b/src/domain/tag.rs
@@ -2,48 +2,13 @@
 
 use std::collections::HashMap;
 
-/// Tag groups that expand a shorthand into multiple tags.
-pub fn tag_groups() -> HashMap<&'static str, Vec<&'static str>> {
-    HashMap::from([
-        ("rust", vec!["rust-platform", "rust-tools"]),
-        ("python", vec!["python-platform", "python-tools"]),
-        ("nodejs", vec!["nodejs-platform", "nodejs-tools"]),
-        ("go", vec!["go-platform", "go-tools"]),
-    ])
-}
-
-/// Ordered tag list for full environment setup (used by `create`).
-pub const FULL_SETUP_TAGS: &[&str] = &[
-    "brew-formulae",
-    "ollama",
-    "shell",
-    "system",
-    "git",
-    "gh",
-    "python-platform",
-    "nodejs-platform",
-    "ruby",
-    "rust-platform",
-    "go-platform",
-    "python-tools",
-    "uv",
-    "nodejs-tools",
-    "rust-tools",
-    "go-tools",
-    "vscode",
-    "cursor",
-    "coder",
-    "mlx",
-    "xcode",
-];
-
 /// Resolve a CLI tag argument into the concrete tags to run.
 ///
 /// If the tag matches a group name, returns the expanded list.
 /// Otherwise returns the tag as-is.
-pub fn resolve_tags(tag: &str) -> Vec<String> {
-    if let Some(group) = tag_groups().get(tag) {
-        group.iter().map(|s| (*s).to_string()).collect()
+pub fn resolve_tags(tag: &str, tag_groups: &HashMap<String, Vec<String>>) -> Vec<String> {
+    if let Some(group) = tag_groups.get(tag) {
+        group.clone()
     } else {
         vec![tag.to_string()]
     }
@@ -53,15 +18,24 @@ pub fn resolve_tags(tag: &str) -> Vec<String> {
 mod tests {
     use super::*;
 
+    fn test_groups() -> HashMap<String, Vec<String>> {
+        let mut groups = HashMap::new();
+        groups.insert(
+            "rust".to_string(),
+            vec!["rust-platform".to_string(), "rust-tools".to_string()],
+        );
+        groups
+    }
+
     #[test]
     fn resolves_group_tag() {
-        let tags = resolve_tags("rust");
+        let tags = resolve_tags("rust", &test_groups());
         assert_eq!(tags, vec!["rust-platform", "rust-tools"]);
     }
 
     #[test]
     fn resolves_single_tag() {
-        let tags = resolve_tags("shell");
+        let tags = resolve_tags("shell", &test_groups());
         assert_eq!(tags, vec!["shell"]);
     }
 }

--- a/src/domain/tag.rs
+++ b/src/domain/tag.rs
@@ -7,11 +7,7 @@ use std::collections::HashMap;
 /// If the tag matches a group name, returns the expanded list.
 /// Otherwise returns the tag as-is.
 pub fn resolve_tags(tag: &str, tag_groups: &HashMap<String, Vec<String>>) -> Vec<String> {
-    if let Some(group) = tag_groups.get(tag) {
-        group.clone()
-    } else {
-        vec![tag.to_string()]
-    }
+    if let Some(group) = tag_groups.get(tag) { group.clone() } else { vec![tag.to_string()] }
 }
 
 #[cfg(test)]

--- a/src/testing/ansible.rs
+++ b/src/testing/ansible.rs
@@ -11,6 +11,8 @@ pub struct FakeAnsiblePort {
     pub roles_config_dir: HashMap<String, PathBuf>,
     pub all_tags: Vec<String>,
     pub tags_by_role: HashMap<String, Vec<String>>,
+    pub tag_groups: HashMap<String, Vec<String>>,
+    pub full_setup_tags: Vec<String>,
     pub events: RefCell<Vec<String>>,
 }
 
@@ -22,6 +24,8 @@ impl FakeAnsiblePort {
             roles_config_dir: HashMap::new(),
             all_tags: Vec::new(),
             tags_by_role: HashMap::new(),
+            tag_groups: HashMap::new(),
+            full_setup_tags: Vec::new(),
             events: RefCell::new(Vec::new()),
         }
     }
@@ -39,6 +43,14 @@ impl AnsiblePort for FakeAnsiblePort {
 
     fn all_tags(&self) -> Vec<String> {
         self.all_tags.clone()
+    }
+
+    fn tag_groups(&self) -> &HashMap<String, Vec<String>> {
+        &self.tag_groups
+    }
+
+    fn full_setup_tags(&self) -> &[String] {
+        &self.full_setup_tags
     }
 
     fn tags_by_role(&self) -> &HashMap<String, Vec<String>> {

--- a/tests/library/domain_exports.rs
+++ b/tests/library/domain_exports.rs
@@ -1,8 +1,15 @@
 //! Verify public API surfaces remain accessible.
 
+use std::collections::HashMap;
+
 #[test]
 fn domain_tag_resolution_is_public() {
-    let tags = mev::domain::tag::resolve_tags("rust");
+    let mut groups = HashMap::new();
+    groups.insert(
+        "rust".to_string(),
+        vec!["rust-platform".to_string(), "rust-tools".to_string()],
+    );
+    let tags = mev::domain::tag::resolve_tags("rust", &groups);
     assert_eq!(tags, vec!["rust-platform", "rust-tools"]);
 }
 

--- a/tests/library/domain_exports.rs
+++ b/tests/library/domain_exports.rs
@@ -5,10 +5,7 @@ use std::collections::HashMap;
 #[test]
 fn domain_tag_resolution_is_public() {
     let mut groups = HashMap::new();
-    groups.insert(
-        "rust".to_string(),
-        vec!["rust-platform".to_string(), "rust-tools".to_string()],
-    );
+    groups.insert("rust".to_string(), vec!["rust-platform".to_string(), "rust-tools".to_string()]);
     let tags = mev::domain::tag::resolve_tags("rust", &groups);
     assert_eq!(tags, vec!["rust-platform", "rust-tools"]);
 }


### PR DESCRIPTION
Moves `tag_groups` and `full_setup_tags` out of hardcoded Rust constants and into the `playbook.yml` variables. Modifies the adapter, `AnsiblePort` trait, and dependent application commands to read these values dynamically at runtime. Tests have been fully updated.

---
*PR created automatically by Jules for task [2108015382566476366](https://jules.google.com/task/2108015382566476366) started by @akitorahayashi*