### PR TITLE
Refactor testing utilities to use explicit error handling

### DIFF
--- a/crates/mev-internal/src/adapters/gh.rs
+++ b/crates/mev-internal/src/adapters/gh.rs
@@ -90,7 +90,7 @@ mod tests {
             r#"#!/bin/sh
             echo "bug\nfeature\nhelp wanted"
             "#,
-        );
+        )?;
 
         let repo = RepositoryRef::from_repo_arg("owner/repo")?;
         let adapter = GhAdapter { mock_env_path: Some(bin_path.to_string_lossy().to_string()) };
@@ -113,7 +113,7 @@ mod tests {
                 "#,
                 args_file.display()
             ),
-        );
+        )?;
 
         let repo = RepositoryRef::from_repo_arg("owner/repo")?;
         let label = LabelSpec {
@@ -147,7 +147,7 @@ mod tests {
                 "#,
                 args_file.display()
             ),
-        );
+        )?;
 
         let repo = RepositoryRef::from_repo_arg("owner/repo")?;
         let adapter = GhAdapter { mock_env_path: Some(bin_path.to_string_lossy().to_string()) };

--- a/crates/mev-internal/src/adapters/git.rs
+++ b/crates/mev-internal/src/adapters/git.rs
@@ -104,7 +104,7 @@ mod tests {
             r#"#!/bin/sh
             echo "git@github.com:owner/repo.git"
             "#,
-        );
+        )?;
 
         let adapter = GitAdapter {
             mock_env_path: Some(bin_path.to_string_lossy().to_string()),
@@ -126,7 +126,7 @@ mod tests {
             r#"#!/bin/sh
             exit 0
             "#,
-        );
+        )?;
 
         let adapter = GitAdapter {
             mock_env_path: Some(bin_path.to_string_lossy().to_string()),
@@ -149,7 +149,7 @@ mod tests {
             echo "No such section" >&2
             exit 1
             "#,
-        );
+        )?;
 
         let adapter = GitAdapter {
             mock_env_path: Some(bin_path.to_string_lossy().to_string()),
@@ -191,7 +191,7 @@ mod tests {
                 "#,
                 args_file.display()
             ),
-        );
+        )?;
 
         let adapter = GitAdapter {
             mock_env_path: Some(bin_path.to_string_lossy().to_string()),

--- a/crates/mev-internal/src/app/commands/gh/labels_deploy.rs
+++ b/crates/mev-internal/src/app/commands/gh/labels_deploy.rs
@@ -64,7 +64,7 @@ mod tests {
             "#,
                 test_env.gh_args_path.display()
             ),
-        );
+        )?;
 
         run(LabelsDeployArgs { repo: None })?;
 
@@ -93,7 +93,7 @@ mod tests {
             "#,
                 test_env.gh_args_path.display()
             ),
-        );
+        )?;
 
         run(LabelsDeployArgs { repo: Some("owner/repo".to_string()) })?;
 

--- a/crates/mev-internal/src/app/commands/gh/labels_reset.rs
+++ b/crates/mev-internal/src/app/commands/gh/labels_reset.rs
@@ -61,7 +61,7 @@ mod tests {
             "#,
                 test_env.gh_args_path.display()
             ),
-        );
+        )?;
 
         run(LabelsResetArgs { repo: None })?;
 
@@ -90,7 +90,7 @@ mod tests {
             "#,
                 test_env.gh_args_path.display()
             ),
-        );
+        )?;
 
         run(LabelsResetArgs { repo: Some("owner/repo".to_string()) })?;
 

--- a/crates/mev-internal/src/app/commands/gh/mod.rs
+++ b/crates/mev-internal/src/app/commands/gh/mod.rs
@@ -30,12 +30,12 @@ pub(crate) fn setup_gh_labels_command_test_environment()
     let gh_args_path = temp_dir.path().join("gh_args.txt");
 
     let bin_path =
-        env_mock::create_mock_bin("git", &temp_dir, &git_origin_capture_script(&git_args_path));
+        env_mock::create_mock_bin("git", &temp_dir, &git_origin_capture_script(&git_args_path))?;
 
     Ok(GhLabelsCommandTestEnvironment {
         temp_dir,
         gh_args_path,
-        _path_guard: env_mock::PathGuard::new(&bin_path),
+        _path_guard: env_mock::PathGuard::new(&bin_path)?,
     })
 }
 

--- a/crates/mev-internal/src/app/commands/git/delete_submodule.rs
+++ b/crates/mev-internal/src/app/commands/git/delete_submodule.rs
@@ -47,10 +47,10 @@ mod tests {
             "#,
                 git_args.display()
             ),
-        );
+        )?;
 
-        let _guard = env_mock::PathGuard::new(&bin_path);
-        let _dir_guard = env_mock::DirGuard::new(temp_dir.path());
+        let _guard = env_mock::PathGuard::new(&bin_path)?;
+        let _dir_guard = env_mock::DirGuard::new(temp_dir.path())?;
 
         let modules_path = temp_dir.path().join(".git").join("modules").join("vendor/some-dep");
         fs::create_dir_all(&modules_path)?;

--- a/crates/mev-internal/src/domain/repository_ref.rs
+++ b/crates/mev-internal/src/domain/repository_ref.rs
@@ -101,57 +101,58 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parses_owner_name_repo_arg() {
-        let repo = RepositoryRef::from_repo_arg("owner/repo").expect("repo arg should parse");
+    fn parses_owner_name_repo_arg() -> Result<(), Box<dyn std::error::Error>> {
+        let repo = RepositoryRef::from_repo_arg("owner/repo")?;
         assert_eq!(repo.as_gh_repo_arg(), "owner/repo");
+        Ok(())
     }
 
     #[test]
-    fn parses_host_owner_name_repo_arg() {
-        let repo = RepositoryRef::from_repo_arg("github.example.com/owner/repo")
-            .expect("repo arg should parse");
+    fn parses_host_owner_name_repo_arg() -> Result<(), Box<dyn std::error::Error>> {
+        let repo = RepositoryRef::from_repo_arg("github.example.com/owner/repo")?;
         assert_eq!(repo.as_gh_repo_arg(), "github.example.com/owner/repo");
+        Ok(())
     }
 
     #[test]
-    fn parses_https_remote_url() {
-        let repo = RepositoryRef::from_remote_url("https://github.com/owner/repo.git")
-            .expect("https remote should parse");
+    fn parses_https_remote_url() -> Result<(), Box<dyn std::error::Error>> {
+        let repo = RepositoryRef::from_remote_url("https://github.com/owner/repo.git")?;
         assert_eq!(repo.as_gh_repo_arg(), "github.com/owner/repo");
+        Ok(())
     }
 
     #[test]
-    fn parses_ssh_remote_url() {
-        let repo = RepositoryRef::from_remote_url("git@github.com:owner/repo.git")
-            .expect("ssh remote should parse");
+    fn parses_ssh_remote_url() -> Result<(), Box<dyn std::error::Error>> {
+        let repo = RepositoryRef::from_remote_url("git@github.com:owner/repo.git")?;
         assert_eq!(repo.as_gh_repo_arg(), "github.com/owner/repo");
+        Ok(())
     }
 
     #[test]
-    fn from_remote_url_parses_scp_like_ssh() {
-        let repo = RepositoryRef::from_remote_url("git@github.com:owner/repo.git")
-            .expect("scp-like ssh remote should parse");
+    fn from_remote_url_parses_scp_like_ssh() -> Result<(), Box<dyn std::error::Error>> {
+        let repo = RepositoryRef::from_remote_url("git@github.com:owner/repo.git")?;
         assert_eq!(repo.host.as_deref(), Some("github.com"));
         assert_eq!(repo.owner, "owner");
         assert_eq!(repo.name, "repo");
+        Ok(())
     }
 
     #[test]
-    fn from_remote_url_parses_standard_ssh() {
-        let repo = RepositoryRef::from_remote_url("ssh://git@github.com/owner/repo.git")
-            .expect("standard ssh remote should parse");
+    fn from_remote_url_parses_standard_ssh() -> Result<(), Box<dyn std::error::Error>> {
+        let repo = RepositoryRef::from_remote_url("ssh://git@github.com/owner/repo.git")?;
         assert_eq!(repo.host.as_deref(), Some("github.com"));
         assert_eq!(repo.owner, "owner");
         assert_eq!(repo.name, "repo");
+        Ok(())
     }
 
     #[test]
-    fn from_remote_url_parses_http() {
-        let repo = RepositoryRef::from_remote_url("http://github.com/owner/repo.git")
-            .expect("http remote should parse");
+    fn from_remote_url_parses_http() -> Result<(), Box<dyn std::error::Error>> {
+        let repo = RepositoryRef::from_remote_url("http://github.com/owner/repo.git")?;
         assert_eq!(repo.host.as_deref(), Some("github.com"));
         assert_eq!(repo.owner, "owner");
         assert_eq!(repo.name, "repo");
+        Ok(())
     }
 
     #[test]

--- a/crates/mev-internal/src/testing/env_mock.rs
+++ b/crates/mev-internal/src/testing/env_mock.rs
@@ -13,10 +13,10 @@ pub struct DirGuard {
 }
 
 impl DirGuard {
-    pub fn new(target_dir: &Path) -> Self {
-        let original_dir = env::current_dir().unwrap();
-        env::set_current_dir(target_dir).unwrap();
-        Self { original_dir }
+    pub fn new(target_dir: &Path) -> Result<Self, Box<dyn std::error::Error>> {
+        let original_dir = env::current_dir()?;
+        env::set_current_dir(target_dir)?;
+        Ok(Self { original_dir })
     }
 }
 
@@ -28,15 +28,19 @@ impl Drop for DirGuard {
 
 /// Creates a mock binary in the given temporary directory.
 /// Returns a `PathBuf` to the temporary directory path containing the script.
-pub fn create_mock_bin(name: &str, temp_dir: &TempDir, script_content: &str) -> PathBuf {
+pub fn create_mock_bin(
+    name: &str,
+    temp_dir: &TempDir,
+    script_content: &str,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
     let bin_path = temp_dir.path().join(name);
-    fs::write(&bin_path, script_content).unwrap();
+    fs::write(&bin_path, script_content)?;
 
-    let mut perms = fs::metadata(&bin_path).unwrap().permissions();
+    let mut perms = fs::metadata(&bin_path)?.permissions();
     perms.set_mode(0o755);
-    fs::set_permissions(&bin_path, perms).unwrap();
+    fs::set_permissions(&bin_path, perms)?;
 
-    temp_dir.path().to_path_buf()
+    Ok(temp_dir.path().to_path_buf())
 }
 
 /// Guard that prepends a directory to the PATH environment variable and restores it when dropped.
@@ -46,18 +50,18 @@ pub struct PathGuard {
 }
 
 impl PathGuard {
-    pub fn new(bin_dir: &Path) -> Self {
+    pub fn new(bin_dir: &Path) -> Result<Self, Box<dyn std::error::Error>> {
         let original_path = env::var_os("PATH");
         let mut paths =
             env::split_paths(original_path.as_deref().unwrap_or_default()).collect::<Vec<_>>();
         paths.insert(0, bin_dir.to_path_buf());
-        let new_path = env::join_paths(paths).expect("Failed to construct new PATH");
+        let new_path = env::join_paths(paths)?;
         // SAFETY: In tests, we ensure thread safety by using the `serial_test` crate.
         #[allow(unused_unsafe)]
         unsafe {
             env::set_var("PATH", new_path);
         }
-        Self { original_path }
+        Ok(Self { original_path })
     }
 }
 

--- a/crates/mev-internal/tests/gh_contracts.rs
+++ b/crates/mev-internal/tests/gh_contracts.rs
@@ -12,40 +12,44 @@ fn create_gh_mock_script(log_path: &std::path::Path) -> String {
 
 #[test]
 #[serial(env_path)]
-fn test_gh_labels_deploy() {
-    let temp_dir = tempfile::tempdir().unwrap();
+fn test_gh_labels_deploy() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
     let gh_log = temp_dir.path().join("gh_log.txt");
 
     let mock_script = create_gh_mock_script(&gh_log);
 
-    let mock_bin_dir = create_mock_bin("gh", &temp_dir, &mock_script);
-    let _path_guard = PathGuard::new(&mock_bin_dir);
+    let mock_bin_dir = create_mock_bin("gh", &temp_dir, &mock_script)?;
+    let _path_guard = PathGuard::new(&mock_bin_dir)?;
 
     let args = labels_deploy::LabelsDeployArgs { repo: Some("owner/repo".to_string()) };
 
-    labels_deploy::run(args).expect("deploy should succeed");
+    labels_deploy::run(args)?;
 
-    let log_content = fs::read_to_string(gh_log).unwrap();
+    let log_content = fs::read_to_string(gh_log)?;
     assert!(log_content.contains("label list"));
     assert!(log_content.contains("label delete bugs"));
     assert!(log_content.contains("label create bugs"));
+
+    Ok(())
 }
 
 #[test]
 #[serial(env_path)]
-fn test_gh_labels_reset() {
-    let temp_dir = tempfile::tempdir().unwrap();
+fn test_gh_labels_reset() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = tempfile::tempdir()?;
     let gh_log = temp_dir.path().join("gh_log.txt");
 
     let mock_script = create_gh_mock_script(&gh_log);
 
-    let mock_bin_dir = create_mock_bin("gh", &temp_dir, &mock_script);
-    let _path_guard = PathGuard::new(&mock_bin_dir);
+    let mock_bin_dir = create_mock_bin("gh", &temp_dir, &mock_script)?;
+    let _path_guard = PathGuard::new(&mock_bin_dir)?;
 
     let args = labels_reset::LabelsResetArgs { repo: Some("owner/repo".to_string()) };
 
-    labels_reset::run(args).expect("reset should succeed");
+    labels_reset::run(args)?;
 
-    let log_content = fs::read_to_string(gh_log).unwrap();
+    let log_content = fs::read_to_string(gh_log)?;
     assert!(log_content.contains("label delete bugs"));
+
+    Ok(())
 }

--- a/src/testing/fs.rs
+++ b/src/testing/fs.rs
@@ -137,7 +137,9 @@ impl FsPort for FakeFsPort {
             self.dirs.borrow().iter().filter(|p| p.starts_with(from)).cloned().collect();
         for p in to_rename_dirs {
             self.dirs.borrow_mut().remove(&p);
-            let rel = p.strip_prefix(from).unwrap();
+            let rel = p.strip_prefix(from).map_err(|e| {
+                AppError::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+            })?;
             self.dirs.borrow_mut().insert(to.join(rel));
         }
 
@@ -151,7 +153,9 @@ impl FsPort for FakeFsPort {
 
         for (p, content) in to_rename_files {
             self.files.borrow_mut().remove(&p);
-            let rel = p.strip_prefix(from).unwrap();
+            let rel = p.strip_prefix(from).map_err(|e| {
+                AppError::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, e))
+            })?;
             let new_path = to.join(rel);
             self.files.borrow_mut().insert(new_path.clone(), content);
             if let Some(parent) = new_path.parent() {


### PR DESCRIPTION
This change implements explicit error handling in testing utilities and domain modules by removing panicking `unwrap()` and `expect()` calls.

- **`env_mock.rs`**: Modified `DirGuard::new`, `PathGuard::new`, and `create_mock_bin` to return `Result<_, Box<dyn std::error::Error>>`.
- **`repository_ref.rs`**: Updated all test functions to return `Result<(), Box<dyn std::error::Error>>` and propagate errors using `?` instead of `expect()`.
- **`fs.rs`**: Refactored `rename` to explicitly map `StripPrefixError` to `AppError::Io` instead of panicking on `unwrap()`.
- **Call sites**: Updated usage of `env_mock` utilities across tests in `git`, `gh`, `labels_deploy`, `labels_reset`, and `gh_contracts` to handle the new `Result` signatures properly.

All changes successfully adhere to the project's explicit error handling principles and have been verified to compile and pass all tests.

---
*PR created automatically by Jules for task [1064782043256855274](https://jules.google.com/task/1064782043256855274) started by @akitorahayashi*