### PR TITLE
feat(observers): Emit event files for factorer role

### DIFF
--- a/.jules/exchange/events/copy_dir_recursive_factorer.md
+++ b/.jules/exchange/events/copy_dir_recursive_factorer.md
@@ -1,17 +1,34 @@
 ---
 label: "refacts"
+created_at: "2024-04-17"
 author_role: "factorer"
+confidence: "high"
 ---
 
-# Boundary Issue: Wrapper Sprawl / Misplaced Code
-The `copy_dir_recursive` function is defined in `src/app/commands/deploy_configs.rs`, but it is also used by `src/app/commands/config/mod.rs`. This function is a pure filesystem operation wrapper (`FsPort`) and does not contain any application/domain logic specific to deploying configurations. It acts as a shared utility. As an implementation acting over `FsPort`, it conceptually belongs to the adapter layer where file system operations are implemented (e.g. `src/adapters/fs.rs`), or as a default implementation on the `FsPort` trait itself.
+## Problem
 
-# Evidence
-- Location: `src/app/commands/deploy_configs.rs`
-- LOC: `52-69`
-- Usage: Used in `src/app/commands/deploy_configs.rs` and `src/app/commands/config/mod.rs` (lines 4-5 and 55).
+Wrapper Sprawl and Misplaced Code: The `copy_dir_recursive` function is defined in `src/app/commands/deploy_configs.rs`, but it is also used by `src/app/commands/config/mod.rs`. This function is a pure filesystem operation wrapper (`FsPort`) and does not contain any application/domain logic specific to deploying configurations.
 
-# Change Scope
+## Goal
+
+Relocate `copy_dir_recursive` to act as a shared utility. As an implementation acting over `FsPort`, it conceptually belongs to the adapter layer where file system operations are implemented (e.g. `src/adapters/fs.rs`), or as a default implementation on the `FsPort` trait itself.
+
+## Context
+
+Functions should live where their authority and conceptual ownership lie. A generic filesystem utility should not be coupled with the specific `deploy_configs` command logic.
+
+## Evidence
+
+- path: "src/app/commands/deploy_configs.rs"
+  loc: "52-69"
+  note: "Definition of copy_dir_recursive"
+- path: "src/app/commands/config/mod.rs"
+  loc: "55"
+  note: "External caller of copy_dir_recursive"
+
+## Change Scope
+
 - `src/app/commands/deploy_configs.rs`
 - `src/app/commands/config/mod.rs`
-- `src/domain/ports/fs.rs` / `src/adapters/fs.rs` (or equivalent location for shared filesystem utilities over `FsPort`).
+- `src/domain/ports/fs.rs`
+- `src/adapters/fs.rs`

--- a/.jules/exchange/events/copy_dir_recursive_factorer.md
+++ b/.jules/exchange/events/copy_dir_recursive_factorer.md
@@ -1,0 +1,17 @@
+---
+label: "refacts"
+author_role: "factorer"
+---
+
+# Boundary Issue: Wrapper Sprawl / Misplaced Code
+The `copy_dir_recursive` function is defined in `src/app/commands/deploy_configs.rs`, but it is also used by `src/app/commands/config/mod.rs`. This function is a pure filesystem operation wrapper (`FsPort`) and does not contain any application/domain logic specific to deploying configurations. It acts as a shared utility. As an implementation acting over `FsPort`, it conceptually belongs to the adapter layer where file system operations are implemented (e.g. `src/adapters/fs.rs`), or as a default implementation on the `FsPort` trait itself.
+
+# Evidence
+- Location: `src/app/commands/deploy_configs.rs`
+- LOC: `52-69`
+- Usage: Used in `src/app/commands/deploy_configs.rs` and `src/app/commands/config/mod.rs` (lines 4-5 and 55).
+
+# Change Scope
+- `src/app/commands/deploy_configs.rs`
+- `src/app/commands/config/mod.rs`
+- `src/domain/ports/fs.rs` / `src/adapters/fs.rs` (or equivalent location for shared filesystem utilities over `FsPort`).

--- a/.jules/exchange/events/resolve_backup_component_factorer.md
+++ b/.jules/exchange/events/resolve_backup_component_factorer.md
@@ -1,16 +1,32 @@
 ---
 label: "refacts"
+created_at: "2024-04-17"
 author_role: "factorer"
+confidence: "high"
 ---
 
-# Boundary Issue: Wrapper Sprawl / Discrepancy between name and contract
-`src/domain/backup_component.rs` contains `resolve_backup_component` which looks up a string alias and returns `Option<BackupComponent>`, and `validate_backup_component` which wraps it to return a `Result<BackupComponent, AppError>`. `validate_backup_component` is exactly parsing a string into an enum variant. It would be more idiomatic as `impl std::str::FromStr for BackupComponent`. The separation between resolve and validate represents wrapper sprawl and an unnecessary indirection that could be simplified by just implementing standard traits (`FromStr` and potentially `TryFrom<&str>`).
+## Problem
 
-# Evidence
-- Location: `src/domain/backup_component.rs`
-- LOC: `68-88`
-- Usage: Used in `src/app/commands/backup/mod.rs` (line 16) where user input is parsed.
+Wrapper Sprawl and Discrepancy between name and contract: `src/domain/backup_component.rs` contains `resolve_backup_component` which looks up a string alias and returns `Option<BackupComponent>`, and `validate_backup_component` which wraps it to return a `Result<BackupComponent, AppError>`. `validate_backup_component` is exactly parsing a string into an enum variant.
 
-# Change Scope
+## Goal
+
+Implement standard traits (`FromStr` and potentially `TryFrom<&str>`) for `BackupComponent` to remove unnecessary indirection.
+
+## Context
+
+The separation between resolve and validate represents wrapper sprawl and an unnecessary indirection that could be simplified by using idiomatic Rust trait implementations.
+
+## Evidence
+
+- path: "src/domain/backup_component.rs"
+  loc: "68-88"
+  note: "Contains resolve_backup_component and validate_backup_component wrappers."
+- path: "src/app/commands/backup/mod.rs"
+  loc: "16"
+  note: "User input is parsed via validate_backup_component."
+
+## Change Scope
+
 - `src/domain/backup_component.rs`
 - `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/resolve_backup_component_factorer.md
+++ b/.jules/exchange/events/resolve_backup_component_factorer.md
@@ -1,0 +1,16 @@
+---
+label: "refacts"
+author_role: "factorer"
+---
+
+# Boundary Issue: Wrapper Sprawl / Discrepancy between name and contract
+`src/domain/backup_component.rs` contains `resolve_backup_component` which looks up a string alias and returns `Option<BackupComponent>`, and `validate_backup_component` which wraps it to return a `Result<BackupComponent, AppError>`. `validate_backup_component` is exactly parsing a string into an enum variant. It would be more idiomatic as `impl std::str::FromStr for BackupComponent`. The separation between resolve and validate represents wrapper sprawl and an unnecessary indirection that could be simplified by just implementing standard traits (`FromStr` and potentially `TryFrom<&str>`).
+
+# Evidence
+- Location: `src/domain/backup_component.rs`
+- LOC: `68-88`
+- Usage: Used in `src/app/commands/backup/mod.rs` (line 16) where user input is parsed.
+
+# Change Scope
+- `src/domain/backup_component.rs`
+- `src/app/commands/backup/mod.rs`

--- a/.jules/exchange/events/resolve_tags_factorer.md
+++ b/.jules/exchange/events/resolve_tags_factorer.md
@@ -1,17 +1,33 @@
 ---
 label: "refacts"
+created_at: "2024-04-17"
 author_role: "factorer"
+confidence: "high"
 ---
 
-# Boundary Issue: Signature Drift / Placement
-The `resolve_tags` function in `src/domain/tag.rs` takes a tag string and a `tag_groups: &HashMap<String, Vec<String>>` to expand tags. However, the concept of resolving tags, including groups, is tightly coupled to the catalog data which is owned by `AnsiblePort`. The function signature expects callers to extract `tag_groups` from `AnsiblePort` and pass it in (as seen in `src/app/commands/make/mod.rs`), which is an example of an incomplete/drifting signature where ambient state is passed manually. `resolve_tags` should probably be a method on the `AnsiblePort` trait since `AnsiblePort` owns the `tag_groups` configuration.
+## Problem
 
-# Evidence
-- Location: `src/domain/tag.rs`
-- LOC: `8-10`
-- Usage: Used in `src/app/commands/make/mod.rs` (line 35) as `tag::resolve_tags(tag_input, ctx.ansible.tag_groups())`.
+Signature Drift and Placement: The `resolve_tags` function in `src/domain/tag.rs` takes a tag string and a `tag_groups: &HashMap<String, Vec<String>>` to expand tags. However, the concept of resolving tags, including groups, is tightly coupled to the catalog data which is owned by `AnsiblePort`.
 
-# Change Scope
+## Goal
+
+Move `resolve_tags` to be a method on the `AnsiblePort` trait since `AnsiblePort` owns the `tag_groups` configuration.
+
+## Context
+
+The function signature expects callers to extract `tag_groups` from `AnsiblePort` and pass it in, which is an example of an incomplete/drifting signature where ambient state is passed manually instead of coupling behavior to the owner.
+
+## Evidence
+
+- path: "src/domain/tag.rs"
+  loc: "8-10"
+  note: "Definition of resolve_tags that requires passing the HashMap state."
+- path: "src/app/commands/make/mod.rs"
+  loc: "35"
+  note: "Usage: tag::resolve_tags(tag_input, ctx.ansible.tag_groups())"
+
+## Change Scope
+
 - `src/domain/tag.rs`
 - `src/domain/ports/ansible.rs`
 - `src/app/commands/make/mod.rs`

--- a/.jules/exchange/events/resolve_tags_factorer.md
+++ b/.jules/exchange/events/resolve_tags_factorer.md
@@ -1,0 +1,17 @@
+---
+label: "refacts"
+author_role: "factorer"
+---
+
+# Boundary Issue: Signature Drift / Placement
+The `resolve_tags` function in `src/domain/tag.rs` takes a tag string and a `tag_groups: &HashMap<String, Vec<String>>` to expand tags. However, the concept of resolving tags, including groups, is tightly coupled to the catalog data which is owned by `AnsiblePort`. The function signature expects callers to extract `tag_groups` from `AnsiblePort` and pass it in (as seen in `src/app/commands/make/mod.rs`), which is an example of an incomplete/drifting signature where ambient state is passed manually. `resolve_tags` should probably be a method on the `AnsiblePort` trait since `AnsiblePort` owns the `tag_groups` configuration.
+
+# Evidence
+- Location: `src/domain/tag.rs`
+- LOC: `8-10`
+- Usage: Used in `src/app/commands/make/mod.rs` (line 35) as `tag::resolve_tags(tag_input, ctx.ansible.tag_groups())`.
+
+# Change Scope
+- `src/domain/tag.rs`
+- `src/domain/ports/ansible.rs`
+- `src/app/commands/make/mod.rs`


### PR DESCRIPTION
This PR implements the factorer role task by analyzing the codebase for boundary issues and generating 3 event files in `.jules/exchange/events/`.

The generated files highlight:
1. Wrapper sprawl and misplaced filesystem utilities in `deploy_configs.rs`.
2. Unnecessary indirection in parsing logic in `backup_component.rs`.
3. Signature drift in `tag.rs` regarding state ownership.

All event files adhere to the provided schema and project formatting principles.

---
*PR created automatically by Jules for task [17891879291941702945](https://jules.google.com/task/17891879291941702945) started by @akitorahayashi*