### PR TITLE
Emit modeler events for domain and error design issues

### DIFF
--- a/.jules/exchange/events/domain_serde_leak_modeler.md
+++ b/.jules/exchange/events/domain_serde_leak_modeler.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2026-04-17"
+author_role: "modeler"
+confidence: "high"
+---
+
+## Problem
+
+Transport/Persistence concerns (Serde macros and attributes) are leaking into the core domain model (`Identity`, `RawIdentity`, `IdentityState`), violating the Boundary Sovereignty principle.
+
+## Goal
+
+Remove `serde` dependencies and serialization concepts from the `src/domain/` layer. Serialization types should belong entirely to the `src/adapters/` layer (e.g., `src/adapters/identity_store.rs`), preserving the core domain models as pure facts.
+
+## Context
+
+The Boundary Sovereignty design rule dictates that core domain models must be kept independent of transport, persistence, UI, or runtime concerns. Currently, `src/domain/identity.rs` and `src/domain/ports/identity_store.rs` directly implement `serde::Serialize` and `serde::Deserialize` and use attributes like `#[serde(try_from)]` or `#[serde(deserialize_with)]`. This couples the pure domain rules of Identity to JSON on-disk persistence formats.
+
+## Evidence
+
+- path: "src/domain/identity.rs"
+  loc: "10"
+  note: "`RawIdentity` derives `serde::Serialize` and `serde::Deserialize`"
+- path: "src/domain/identity.rs"
+  loc: "16-17"
+  note: "`Identity` derives `serde::Serialize` and `serde::Deserialize`, and relies on `#[serde(try_from = "RawIdentity", into = "RawIdentity")]`."
+- path: "src/domain/ports/identity_store.rs"
+  loc: "25-30"
+  note: "`IdentityState` derives `serde::Serialize` and `serde::Deserialize` and applies `deserialize_with` attributes to its fields."
+
+## Change Scope
+
+- `src/domain/identity.rs`
+- `src/domain/ports/identity_store.rs`
+- `src/adapters/identity_store.rs`

--- a/.jules/exchange/events/missing_validation_in_apperror_modeler.md
+++ b/.jules/exchange/events/missing_validation_in_apperror_modeler.md
@@ -1,0 +1,35 @@
+---
+label: "refacts"
+created_at: "2026-04-17"
+author_role: "modeler"
+confidence: "low"
+---
+
+## Problem
+
+Error construction in `AppError` is stringly-typed and does not enforce invariants at the boundary for which strings are valid `AppError::InvalidTag` or `AppError::InvalidProfile`.
+
+## Goal
+
+Encode specific failed parsed values into the error enum instead of stringly-typed messages where possible, or add more structured context, so error modeling captures the invalid state explicitly rather than building display strings during construction.
+
+## Context
+
+`AppError::InvalidTag(String)` stores a formatted error message rather than the invalid tag itself (e.g. `AppError::InvalidTag(String)` instead of `AppError::InvalidTag(Tag)` or `AppError::InvalidTag(RawTag)`). This limits the ability to match on or inspect the exact input that failed, binding the error structure to display logic too early.
+
+## Evidence
+
+- path: "src/domain/error.rs"
+  loc: "12"
+  note: "`InvalidProfile(String)`"
+- path: "src/domain/error.rs"
+  loc: "18"
+  note: "`InvalidTag(String)`"
+- path: "src/app/commands/make/mod.rs"
+  loc: "23-25"
+  note: "Formats the error message directly into the `InvalidTag` enum variant: `return Err(AppError::InvalidTag(format!(\"'{t}'. Use 'mev list' to see available tags.\")));`."
+
+## Change Scope
+
+- `src/domain/error.rs`
+- `src/app/commands/make/mod.rs`

--- a/.jules/exchange/events/primitive_obsession_tags_modeler.md
+++ b/.jules/exchange/events/primitive_obsession_tags_modeler.md
@@ -1,0 +1,36 @@
+---
+label: "refacts"
+created_at: "2026-04-17"
+author_role: "modeler"
+confidence: "medium"
+---
+
+## Problem
+
+Tag concepts (tag name, list of tags) are universally represented as primitive `String` and `Vec<String>` across the domain and port interfaces, lacking a distinct domain type.
+
+## Goal
+
+Consider introducing a `Tag` and `TagGroup` struct or alias to clarify the domain model, encapsulate validation logic, and provide type safety against arbitrary strings being passed as tags.
+
+## Context
+
+In `src/domain/tag.rs`, `src/domain/execution_plan.rs`, and `src/domain/ports/ansible.rs`, tags are represented as `String`. This is primitive obsession. A specific domain model for tags would centralize validation and distinguish raw user input from known, validated catalog tags.
+
+## Evidence
+
+- path: "src/domain/execution_plan.rs"
+  loc: "8"
+  note: "`ExecutionPlan` stores tags as `Vec<String>`"
+- path: "src/domain/ports/ansible.rs"
+  loc: "23-26"
+  note: "`AnsiblePort` methods like `all_tags`, `tag_groups`, and `full_setup_tags` return raw `String` collections."
+- path: "src/domain/tag.rs"
+  loc: "9"
+  note: "`resolve_tags` accepts and returns primitive `String` types."
+
+## Change Scope
+
+- `src/domain/tag.rs`
+- `src/domain/execution_plan.rs`
+- `src/domain/ports/ansible.rs`


### PR DESCRIPTION
This observer run analyzed the `mev` codebase from the modeler perspective, focusing on domain boundaries and type representation.

The following event files were generated:
1. `domain_serde_leak_modeler.md`: Addresses the leakage of `serde` attributes into the core `Identity` domain model, violating Boundary Sovereignty.
2. `missing_validation_in_apperror_modeler.md`: Addresses stringly-typed error construction that fails to capture the invalid state in `AppError`.
3. `primitive_obsession_tags_modeler.md`: Addresses the universal representation of tags as primitive `String`s rather than validated domain types.

---
*PR created automatically by Jules for task [6770418527287549399](https://jules.google.com/task/6770418527287549399) started by @akitorahayashi*