### PR TITLE
docs: emit taxonomist event files

### DIFF
--- a/.jules/exchange/events/concept_mapping_taxonomist.md
+++ b/.jules/exchange/events/concept_mapping_taxonomist.md
@@ -1,0 +1,40 @@
+---
+label: "refacts"
+created_at: "2024-04-17"
+author_role: "taxonomist"
+confidence: "high"
+---
+
+## Problem
+
+The codebase employs inconsistent patterns for defining alias mappings for enums across the domain layer, resulting in duplicated and diverging logic to resolve aliases and canonical names for core concepts (`Profile`, `IdentityScope`, `BackupComponent`).
+
+## Goal
+
+Standardize how input string aliases map to enum variants by adopting a single, consistent convention across all domain concepts to improve comprehension and refactor safety.
+
+## Context
+
+Different domain entities handle input resolution differently. `Profile` and `IdentityScope` embed alias definitions as an instance method returning an array of strings (`aliases() -> &'static [&'static str]`). In contrast, `BackupComponent` uses a separate flat tuple array (`BACKUP_COMPONENT_ALIASES: &[(&str, BackupComponent)]`). These different shapes increase cognitive load for a simple, repetitive concept (string-to-enum parsing). Resolving logic also diverges between `resolve_profile` (using `.iter().find()`) and `resolve_backup_component` (using an explicit `for` loop over the custom array format).
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "19-27"
+  note: "Defines aliases via a method returning `&'static [&'static str]` and uses `.iter().find()` for resolution."
+
+- path: "src/domain/identity.rs"
+  loc: "47-52"
+  note: "Defines aliases via a method returning `&'static [&'static str]` and uses `.iter().find()` for resolution."
+
+- path: "src/domain/backup_component.rs"
+  loc: "46-51"
+  note: "Defines aliases via a separate `BACKUP_COMPONENT_ALIASES` const array mapping `&str` to `BackupComponent`."
+
+- path: "src/domain/backup_component.rs"
+  loc: "55-62"
+  note: "Uses a procedural `for` loop to resolve the component instead of the functional mapping used in the other modules."
+
+## Change Scope
+
+- `src/domain/backup_component.rs`

--- a/.jules/exchange/events/naming_shape_taxonomist.md
+++ b/.jules/exchange/events/naming_shape_taxonomist.md
@@ -1,0 +1,43 @@
+---
+label: "refacts"
+created_at: "2024-04-17"
+author_role: "taxonomist"
+confidence: "high"
+---
+
+## Problem
+
+The naming of enum validation and resolution functions is inconsistent across the domain layer, with some modules using `resolve_` and `validate_` prefixes for identical concepts, while their structure and return types differ slightly. Additionally, error names and messages for these resolutions drift.
+
+## Goal
+
+Align the function signatures and naming shapes for resolving and validating enum inputs across `Profile`, `IdentityScope`, `BackupComponent`, and `Tag`.
+
+## Context
+
+Consistency in naming shapes across boundaries (files/modules/types/functions) is a core first principle. Currently, `BackupComponent` provides `resolve_backup_component` and `validate_backup_component`. `Profile` has `resolve_profile`, `validate_hardware_profile` and `validate_profile`. `IdentityScope` has `resolve_identity_scope`, but validation happens implicitly or elsewhere. `Tag` uses `resolve_tags` but returns a `Vec<String>` instead of an `Option` or `Result`. The error messages returned on invalid inputs also drift in formatting.
+
+## Evidence
+
+- path: "src/domain/backup_component.rs"
+  loc: "54-73"
+  note: "Defines `resolve_backup_component` returning `Option<BackupComponent>` and `validate_backup_component` returning `Result<BackupComponent, AppError>`."
+
+- path: "src/domain/profile.rs"
+  loc: "44-67"
+  note: "Defines `resolve_profile` returning `Option<Profile>` but then splits validation into `validate_hardware_profile` and `validate_profile`."
+
+- path: "src/domain/identity.rs"
+  loc: "61-65"
+  note: "Defines `resolve_identity_scope` returning `Option<IdentityScope>`, but no dedicated `validate_identity_scope` exists."
+
+- path: "src/domain/error.rs"
+  loc: "21-36"
+  note: "Error names and formatting drift slightly: `InvalidProfile(p) => invalid profile: {p}`, but `InvalidBackupComponent(t) => invalid backup component: {t}`."
+
+## Change Scope
+
+- `src/domain/backup_component.rs`
+- `src/domain/profile.rs`
+- `src/domain/identity.rs`
+- `src/domain/error.rs`

--- a/.jules/exchange/events/vague_naming_taxonomist.md
+++ b/.jules/exchange/events/vague_naming_taxonomist.md
@@ -1,0 +1,43 @@
+---
+label: "refacts"
+created_at: "2024-04-17"
+author_role: "taxonomist"
+confidence: "high"
+---
+
+## Problem
+
+A violation of the "Anti-Patterns: Vague names that hide responsibility" and "Anti-Patterns: Class and file must not have ambiguous names or responsibilities such as base, common, core, utils, or helpers." is present. There are occurrences of vague or ambiguous names.
+
+## Goal
+
+Identify and rename all vague and ambiguous names (like base, common, core, utils, helpers, manager, handler, service) to conform to the rules, ensuring single, specific responsibilities linked to their domain.
+
+## Context
+
+The `AGENTS.md` and `SKILL.md` rules explicitly prohibit vague names. Searching for "manager", "handler", "service", "base", "common", "core", "utils", or "helpers" yields a number of hits across the project's Ansible configuration and shell aliases, which need to be rectified to match the codebase conventions.
+
+## Evidence
+
+- path: "src/assets/ansible/roles/shell/config/global/alias/brew.sh"
+  loc: "1-10"
+  note: "Uses 'services' in alias definitions."
+
+- path: "src/assets/ansible/roles/system/config/global/definitions/mission_control.yml"
+  loc: "1"
+  note: "Uses 'manager' or related."
+
+- path: "src/assets/ansible/roles/editor/config/global/zed/settings.json"
+  loc: "2"
+  note: "Uses 'base_keymap'."
+
+- path: "src/assets/ansible/roles/rust/config/global/tools.yml"
+  loc: "1-5"
+  note: "Uses 'base' for URL definition."
+
+## Change Scope
+
+- `src/assets/ansible/roles/shell/config/global/alias/brew.sh`
+- `src/assets/ansible/roles/system/config/global/definitions/mission_control.yml`
+- `src/assets/ansible/roles/editor/config/global/zed/settings.json`
+- `src/assets/ansible/roles/rust/config/global/tools.yml`


### PR DESCRIPTION
Emitted event files from the taxonomist role observing the codebase for taxonomy and naming consistencies.

---
*PR created automatically by Jules for task [4352951862212400398](https://jules.google.com/task/4352951862212400398) started by @akitorahayashi*