### PR TITLE
chore(docs): emit observer events for comment sufficiency

### DIFF
--- a/.jules/exchange/events/doc_comment_contract_omissions_annotator.md
+++ b/.jules/exchange/events/doc_comment_contract_omissions_annotator.md
@@ -1,0 +1,56 @@
+---
+label: "docs"
+created_at: "2024-04-17"
+author_role: "annotator"
+confidence: "high"
+---
+
+## Problem
+
+Several pure domain functions (`validate_backup_component` in `src/domain/backup_component.rs`, `validate_hardware_profile` in `src/domain/profile.rs`, and `Identity::new` in `src/domain/identity.rs`) have missing contracts in their comment blocks. Preconditions, failure paths, and boundary conditions (like empty strings) are absent from the comment blocks where they cannot be inferred purely from type signatures.
+
+## Goal
+
+Ensure that preconditions, failure paths, and silent behaviors/boundary conditions are explicitly documented in the comment blocks for key domain layer functions.
+
+## Context
+
+A boundary condition or failure path absent from a comment block requires callers to investigate the implementation. Explicitly documenting constraints and error behaviors prevents undefined behavior at call sites and clarifies the contract for maintenance.
+
+## Evidence
+
+- path: "src/domain/profile.rs"
+  loc: "55"
+  note: |
+    Current comment:
+    /// Validate that the input maps to a hardware-specific profile (required for `create`).
+
+    Modified comment:
+    /// Validate that the input maps to a hardware-specific profile (required for `create`).
+    /// Fails with `AppError::InvalidProfile` if the profile is not found or is 'global'.
+- path: "src/domain/identity.rs"
+  loc: "23"
+  note: |
+    Current comment:
+    /// Creates a new identity, ensuring fields are not empty.
+
+    Modified comment:
+    /// Creates a new identity, ensuring fields are not empty.
+    /// Returns `None` if either name or email is empty or consists only of whitespace.
+- path: "src/domain/backup_component.rs"
+  loc: "76"
+  note: |
+    Current comment:
+    /// Verify the user's input maps to a known component, producing an actionable error if unrecognized.
+    /// Fails with `AppError::InvalidBackupComponent` if the string cannot be resolved.
+
+    Modified comment:
+    /// Verify the user's input maps to a known component, producing an actionable error if unrecognized.
+    /// Fails with `AppError::InvalidBackupComponent` if the string cannot be resolved.
+    /// Resolution is case-insensitive and supports aliases (e.g., 'vscode-extensions' maps to 'vscode').
+
+## Change Scope
+
+- `src/domain/profile.rs`
+- `src/domain/identity.rs`
+- `src/domain/backup_component.rs`

--- a/.jules/exchange/events/doc_comment_purpose_annotator.md
+++ b/.jules/exchange/events/doc_comment_purpose_annotator.md
@@ -1,0 +1,33 @@
+---
+label: "docs"
+created_at: "2024-04-17"
+author_role: "annotator"
+confidence: "high"
+---
+
+## Problem
+
+Some struct definitions lack a purpose statement that immediately answers what the unit does without restating its name. For instance, `ExecutionPlan`'s comment block "An execution plan describes the ordered sequence of ansible tags to run" is borderline restating the name.
+
+## Goal
+
+Ensure that purpose statements for domain types are explicit and answer what the unit does based on domain constraints.
+
+## Context
+
+A comment block that restates a name adds no information. A proper purpose statement explains the "what" and "why" within the system architecture.
+
+## Evidence
+
+- path: "src/domain/execution_plan.rs"
+  loc: "5"
+  note: |
+    Current comment:
+    /// An execution plan describes the ordered sequence of ansible tags to run.
+
+    Modified comment:
+    /// A deterministic container specifying the exact profile, tags, and verbosity for ansible invocation.
+
+## Change Scope
+
+- `src/domain/execution_plan.rs`

--- a/.jules/exchange/events/missing_rationale_annotator.md
+++ b/.jules/exchange/events/missing_rationale_annotator.md
@@ -1,0 +1,33 @@
+---
+label: "docs"
+created_at: "2024-04-17"
+author_role: "annotator"
+confidence: "high"
+---
+
+## Problem
+
+Non-obvious design decisions lack background justification in inline comments. For example, `tag::resolve_tags` silently assumes that if a tag isn't a group, it must be a valid single tag without performing any validation against the actual tag catalog, deferring that constraint to callers.
+
+## Goal
+
+Provide background rationale for non-obvious fallback behaviors and domain constraints at the relevant code sites.
+
+## Context
+
+Design rationale absent from a comment block will be rediscovered at each maintenance event, producing redundant investigation cost.
+
+## Evidence
+
+- path: "src/domain/tag.rs"
+  loc: "9"
+  note: |
+    Current inline comment at site: None
+
+    Inline comment to add at site:
+    // If not found in groups, assume it's a valid single tag.
+    // Validation against the catalog is deferred to the orchestration layer to keep this function pure and free of I/O.
+
+## Change Scope
+
+- `src/domain/tag.rs`


### PR DESCRIPTION
Emits event files documenting comment block inadequacies per the annotator role constraints.

## Changes

- Generates `.jules/exchange/events/doc_comment_contract_omissions_annotator.md` identifying missing boundary conditions and failure paths in `validate_hardware_profile`, `Identity::new`, and `validate_backup_component`.
- Generates `.jules/exchange/events/doc_comment_purpose_annotator.md` highlighting the missing architectural purpose for `ExecutionPlan`.
- Generates `.jules/exchange/events/missing_rationale_annotator.md` pointing out deferred validation rationale absent in `resolve_tags`.
- Ensures evidence strictly includes both the current state and the exact proposed replacements in the target language syntax.

---
*PR created automatically by Jules for task [16322458702185409526](https://jules.google.com/task/16322458702185409526) started by @akitorahayashi*