### PR TITLE
Update VS Code global settings

### DIFF
--- a/src/assets/ansible/roles/editor/config/global/vscode/settings.json
+++ b/src/assets/ansible/roles/editor/config/global/vscode/settings.json
@@ -31,5 +31,8 @@
   "window.commandCenter": true,
   "chat.agent.maxRequests": 500,
   "python.languageServer": "Default",
-  "application.shellEnvironmentResolutionTimeout": 10
+  "application.shellEnvironmentResolutionTimeout": 10,
+  "workbench.browser.openLocalhostLinks": false,
+  "workbench.externalBrowser": "chrome",
+  "extensions.autoUpdate": false
 }


### PR DESCRIPTION
This PR updates the global VS Code settings in the Ansible role to:
1. Prevent localhost links from opening in internal VS Code tabs.
2. Explicitly set Chrome as the external browser.
3. Disable automatic extension updates.

Fixes #856

---
*PR created automatically by Jules for task [15194642008684232327](https://jules.google.com/task/15194642008684232327) started by @akitorahayashi*