### PR TITLE
feat: enhance provisioning command with execution order and parallel …

### DIFF
--- a/.github/workflows/setup-bun.yml
+++ b/.github/workflows/setup-bun.yml
@@ -6,12 +6,6 @@ on:
 jobs:
   setup-bun:
     runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        tag:
-          - bun-platform
-          - bun-tools
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -22,13 +16,16 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run ${{ matrix.tag }} setup
-        run: mise exec -- just run make ${{ matrix.tag }}
+      - name: Run bun-platform setup
+        run: mise exec -- just run make bun-platform
 
       - name: Verify Bun after bun-platform setup
         run: |
           bun --version
           bun --revision
+
+      - name: Run bun-tools setup
+        run: mise exec -- just run make bun-tools
 
       - name: Verify Bun after bun-tools setup
         run: |

--- a/.github/workflows/setup-bun.yml
+++ b/.github/workflows/setup-bun.yml
@@ -6,6 +6,12 @@ on:
 jobs:
   setup-bun:
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - bun-platform
+          - bun-tools
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -16,16 +22,13 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run bun-platform setup
-        run: mise exec -- just run make bun-platform
+      - name: Run ${{ matrix.tag }} setup
+        run: mise exec -- just run make ${{ matrix.tag }}
 
       - name: Verify Bun after bun-platform setup
         run: |
           bun --version
           bun --revision
-
-      - name: Run bun-tools setup
-        run: mise exec -- just run make bun-tools
 
       - name: Verify Bun after bun-tools setup
         run: |

--- a/.github/workflows/setup-go.yml
+++ b/.github/workflows/setup-go.yml
@@ -6,12 +6,6 @@ on:
 jobs:
   setup-go:
     runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        tag:
-          - go-platform
-          - go-tools
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -22,5 +16,8 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run ${{ matrix.tag }} setup
-        run: mise exec -- just run make ${{ matrix.tag }}
+      - name: Run go-platform setup
+        run: mise exec -- just run make go-platform
+
+      - name: Run go-tools setup
+        run: mise exec -- just run make go-tools

--- a/.github/workflows/setup-go.yml
+++ b/.github/workflows/setup-go.yml
@@ -6,6 +6,12 @@ on:
 jobs:
   setup-go:
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - go-platform
+          - go-tools
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -16,5 +22,5 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Setup go
-        run: mise exec -- just run make go
+      - name: Run ${{ matrix.tag }} setup
+        run: mise exec -- just run make ${{ matrix.tag }}

--- a/.github/workflows/setup-ide.yml
+++ b/.github/workflows/setup-ide.yml
@@ -6,14 +6,6 @@ on:
 jobs:
   setup-ide:
     runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        tag:
-          - vscode
-          - antigravity
-          - zed
-          - xcode
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -24,5 +16,14 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run ${{ matrix.tag }} setup
-        run: mise exec -- just run make ${{ matrix.tag }}
+      - name: Run vscode setup
+        run: mise exec -- just run make vscode
+
+      - name: Run antigravity setup
+        run: mise exec -- just run make antigravity
+
+      - name: Run zed setup
+        run: mise exec -- just run make zed
+
+      - name: Run xcode setup
+        run: mise exec -- just run make xcode

--- a/.github/workflows/setup-ide.yml
+++ b/.github/workflows/setup-ide.yml
@@ -6,6 +6,14 @@ on:
 jobs:
   setup-ide:
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - vscode
+          - antigravity
+          - zed
+          - xcode
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -16,14 +24,5 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Setup VSCode configuration
-        run: mise exec -- just run make vscode
-
-      - name: Setup Antigravity configuration
-        run: mise exec -- just run make antigravity
-
-      - name: Setup Zed configuration
-        run: mise exec -- just run make zed
-
-      - name: Setup Xcode configuration
-        run: mise exec -- just run make xcode
+      - name: Run ${{ matrix.tag }} setup
+        run: mise exec -- just run make ${{ matrix.tag }}

--- a/.github/workflows/setup-nodejs.yml
+++ b/.github/workflows/setup-nodejs.yml
@@ -6,6 +6,13 @@ on:
 jobs:
   setup-nodejs:
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - nodejs-platform
+          - nodejs-tools
+          - coder
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -16,11 +23,5 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run nodejs-platform setup
-        run: mise exec -- just run make nodejs-platform
-
-      - name: Run nodejs-tools setup
-        run: mise exec -- just run make nodejs-tools
-
-      - name: Setup Node.js LLM Tools
-        run: mise exec -- just run make coder
+      - name: Run ${{ matrix.tag }} setup
+        run: mise exec -- just run make ${{ matrix.tag }}

--- a/.github/workflows/setup-nodejs.yml
+++ b/.github/workflows/setup-nodejs.yml
@@ -6,13 +6,6 @@ on:
 jobs:
   setup-nodejs:
     runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        tag:
-          - nodejs-platform
-          - nodejs-tools
-          - coder
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -23,5 +16,11 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run ${{ matrix.tag }} setup
-        run: mise exec -- just run make ${{ matrix.tag }}
+      - name: Run nodejs-platform setup
+        run: mise exec -- just run make nodejs-platform
+
+      - name: Run nodejs-tools setup
+        run: mise exec -- just run make nodejs-tools
+
+      - name: Run coder setup
+        run: mise exec -- just run make coder

--- a/.github/workflows/setup-python.yml
+++ b/.github/workflows/setup-python.yml
@@ -6,6 +6,12 @@ on:
 jobs:
   setup-python:
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - python-platform
+          - python-tools
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -16,8 +22,5 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run python-platform setup
-        run: mise exec -- just run make python-platform
-
-      - name: Run python-tools setup
-        run: mise exec -- just run make python-tools
+      - name: Run ${{ matrix.tag }} setup
+        run: mise exec -- just run make ${{ matrix.tag }}

--- a/.github/workflows/setup-python.yml
+++ b/.github/workflows/setup-python.yml
@@ -6,12 +6,6 @@ on:
 jobs:
   setup-python:
     runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        tag:
-          - python-platform
-          - python-tools
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -22,5 +16,8 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run ${{ matrix.tag }} setup
-        run: mise exec -- just run make ${{ matrix.tag }}
+      - name: Run python-platform setup
+        run: mise exec -- just run make python-platform
+
+      - name: Run python-tools setup
+        run: mise exec -- just run make python-tools

--- a/.github/workflows/setup-rust.yml
+++ b/.github/workflows/setup-rust.yml
@@ -6,6 +6,12 @@ on:
 jobs:
   setup-rust:
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - rust-platform
+          - rust-tools
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -16,5 +22,5 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Setup rust
-        run: mise exec -- just run make rust
+      - name: Run ${{ matrix.tag }} setup
+        run: mise exec -- just run make ${{ matrix.tag }}

--- a/.github/workflows/setup-rust.yml
+++ b/.github/workflows/setup-rust.yml
@@ -6,12 +6,6 @@ on:
 jobs:
   setup-rust:
     runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        tag:
-          - rust-platform
-          - rust-tools
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -22,5 +16,8 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run ${{ matrix.tag }} setup
-        run: mise exec -- just run make ${{ matrix.tag }}
+      - name: Run rust-platform setup
+        run: mise exec -- just run make rust-platform
+
+      - name: Run rust-tools setup
+        run: mise exec -- just run make rust-tools

--- a/.github/workflows/setup-system.yml
+++ b/.github/workflows/setup-system.yml
@@ -6,6 +6,15 @@ on:
 jobs:
   setup-system:
     runs-on: macos-15
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - git
+          - gh
+          - shell
+          - ssh
+          - system
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -16,24 +25,13 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Setup Git configuration
-        run: mise exec -- just run make git
+      - name: Run ${{ matrix.tag }} setup
+        run: mise exec -- just run make ${{ matrix.tag }}
 
-      - name: Setup GitHub CLI configuration
-        run: mise exec -- just run make gh
-
-      - name: Setup shell configuration
-        run: mise exec -- just run make shell
-        
       - name: Test shell aliases functionality
+        if: matrix.tag == 'shell'
         shell: zsh {0}
         run: |
           set -euo pipefail
           source ~/.zshrc
           mk --version
-
-      - name: Setup SSH configuration
-        run: mise exec -- just run make ssh
-
-      - name: Apply macOS system defaults
-        run: mise exec -- just run make system

--- a/.github/workflows/setup-system.yml
+++ b/.github/workflows/setup-system.yml
@@ -6,15 +6,6 @@ on:
 jobs:
   setup-system:
     runs-on: macos-15
-    strategy:
-      fail-fast: false
-      matrix:
-        tag:
-          - git
-          - gh
-          - shell
-          - ssh
-          - system
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -25,13 +16,24 @@ jobs:
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
-      - name: Run ${{ matrix.tag }} setup
-        run: mise exec -- just run make ${{ matrix.tag }}
+      - name: Run git setup
+        run: mise exec -- just run make git
+
+      - name: Run gh setup
+        run: mise exec -- just run make gh
+
+      - name: Run shell setup
+        run: mise exec -- just run make shell
 
       - name: Test shell aliases functionality
-        if: matrix.tag == 'shell'
         shell: zsh {0}
         run: |
           set -euo pipefail
           source ~/.zshrc
           mk --version
+
+      - name: Run ssh setup
+        run: mise exec -- just run make ssh
+
+      - name: Run system setup
+        run: mise exec -- just run make system

--- a/src/app/provisioning/create.rs
+++ b/src/app/provisioning/create.rs
@@ -1,13 +1,11 @@
 //! `create` command orchestration — full environment setup.
 
-use std::process::Stdio;
-use std::thread;
-
 use crate::app::AppContext;
 use crate::error::AppError;
 use crate::provisioning::catalog::ProvisioningCatalog;
 use crate::provisioning::execution_order;
 use crate::provisioning::execution_plan::{ExecutionUnit, LayeredExecutionPlan};
+use crate::provisioning::playbook_execution;
 use crate::provisioning::profile::Profile;
 use crate::provisioning::role_configs;
 
@@ -53,50 +51,12 @@ pub fn execute(
         overwrite,
     )?;
 
-    for (layer_index, layer) in plan.layers.iter().enumerate() {
-        let layer_number = layer_index + 1;
-        println!("Layer {layer_number}/{}:", plan.layer_count());
-        println!(
-            "  Running: {}",
-            layer.iter().map(|unit| unit.name.as_str()).collect::<Vec<_>>().join(", ")
-        );
-
-        let mut results = Vec::with_capacity(layer.len());
-        thread::scope(|scope| {
-            let mut handles = Vec::with_capacity(layer.len());
-            for unit in layer {
-                let unit_name = unit.name.clone();
-                let unit_tags = unit.ansible_tags.clone();
-                handles.push(scope.spawn(move || {
-                    (
-                        unit_name,
-                        run_playbook_summarized(
-                            &ctx.provisioning,
-                            plan.profile.as_str(),
-                            &unit_tags,
-                            plan.verbose,
-                        ),
-                    )
-                }));
-            }
-
-            for handle in handles {
-                results.push(handle.join().expect("layer execution thread panicked"));
-            }
-        });
-
-        if let Some((failed_unit, error)) =
-            results.into_iter().find_map(|(name, result)| result.err().map(|err| (name, err)))
-        {
-            eprintln!(
-                "Failed at layer {layer_number}/{}: {failed_unit}: {error}",
-                plan.layer_count()
-            );
-            return Err(error);
-        }
-
-        println!("  ✓ Completed");
-    }
+    playbook_execution::run_layered_playbook(
+        &ctx.provisioning,
+        plan.profile.as_str(),
+        &plan.layers,
+        plan.verbose,
+    )?;
 
     println!();
     println!("✓ Environment created successfully!");
@@ -109,55 +69,4 @@ pub fn execute(
     println!("  MLX Models:        mev make mlx-models");
 
     Ok(())
-}
-
-fn run_playbook_summarized(
-    runtime: &crate::provisioning::ansible_runtime::AnsibleRuntime,
-    profile: &str,
-    tags: &[String],
-    verbose: bool,
-) -> Result<(), AppError> {
-    let mut cmd = runtime.build_command(profile, tags, verbose)?;
-    cmd.stdout(Stdio::piped());
-    cmd.stderr(Stdio::piped());
-
-    let output = cmd.output().map_err(|e| AppError::AnsibleExecution {
-        message: format!("failed to run ansible-playbook: {e}"),
-        exit_code: None,
-    })?;
-
-    if output.status.success() {
-        return Ok(());
-    }
-
-    let exit_code = output.status.code();
-    let summary = capture_failure_summary(&output.stdout, &output.stderr);
-
-    Err(AppError::AnsibleExecution {
-        message: match summary {
-            Some(line) => format!(
-                "ansible-playbook failed{}; reason: {line}",
-                exit_code.map(|code| format!(" with exit code {code}")).unwrap_or_default()
-            ),
-            None => format!(
-                "ansible-playbook failed{}",
-                exit_code.map(|code| format!(" with exit code {code}")).unwrap_or_default()
-            ),
-        },
-        exit_code,
-    })
-}
-
-fn capture_failure_summary(stdout: &[u8], stderr: &[u8]) -> Option<String> {
-    let stdout = String::from_utf8_lossy(stdout);
-    let stderr = String::from_utf8_lossy(stderr);
-
-    stdout
-        .lines()
-        .chain(stderr.lines())
-        .map(str::trim)
-        .find(|line| {
-            line.starts_with("fatal:") || line.contains("cannot rehash") || line.contains("FAILED!")
-        })
-        .map(ToOwned::to_owned)
 }

--- a/src/app/provisioning/create.rs
+++ b/src/app/provisioning/create.rs
@@ -1,12 +1,15 @@
 //! `create` command orchestration — full environment setup.
 
+use std::process::Stdio;
+use std::thread;
+
 use crate::app::AppContext;
 use crate::error::AppError;
 use crate::provisioning::catalog::ProvisioningCatalog;
-use crate::provisioning::execution_plan::ExecutionPlan;
+use crate::provisioning::execution_order;
+use crate::provisioning::execution_plan::{ExecutionUnit, LayeredExecutionPlan};
 use crate::provisioning::profile::Profile;
 use crate::provisioning::role_configs;
-use crate::provisioning::runner::ProvisioningRunner;
 
 /// Execute the `create` command: deploy configs and run full setup tags.
 pub fn execute(
@@ -17,26 +20,32 @@ pub fn execute(
 ) -> Result<(), AppError> {
     let full_setup_tags = ctx.provisioning.full_setup_tags();
 
-    // Validate all tags exist in catalog
     let all_catalog_tags: std::collections::HashSet<String> =
         ctx.provisioning.all_tags().into_iter().collect();
     let invalid: Vec<&String> =
-        full_setup_tags.iter().filter(|t| !all_catalog_tags.contains(*t)).collect();
+        full_setup_tags.iter().filter(|tag| !all_catalog_tags.contains(*tag)).collect();
     if !invalid.is_empty() {
-        let names: Vec<String> = invalid.iter().map(|t| (*t).to_string()).collect();
+        let names: Vec<String> = invalid.iter().map(|tag| (*tag).to_string()).collect();
         return Err(AppError::InvalidTag(names.join(", ")));
     }
 
-    let plan = ExecutionPlan::full_setup(profile, full_setup_tags.to_vec(), verbose);
+    let units: Vec<ExecutionUnit> =
+        full_setup_tags.iter().cloned().map(ExecutionUnit::atomic).collect();
+    let layers = execution_order::layer_units(units, ctx.provisioning.order_constraints())?;
+    let plan = LayeredExecutionPlan::full_setup(profile, layers, verbose);
 
     println!();
     println!("mev: Creating {} environment", plan.profile);
-    println!("This will run {} tasks.", plan.tags.len());
+    println!(
+        "This will run {} tasks across {} layers.",
+        plan.running_units().len(),
+        plan.layer_count()
+    );
     println!();
 
     // Deploy configs for roles about to be executed
     role_configs::deploy_for_tags(
-        &plan.tags,
+        &plan.ansible_tags(),
         &ctx.host_fs,
         &ctx.local_config_root,
         &ctx.provisioning,
@@ -44,17 +53,48 @@ pub fn execute(
         overwrite,
     )?;
 
-    // Execute each tag
-    for (i, tag) in plan.tags.iter().enumerate() {
-        let step = i + 1;
-        let total = plan.tags.len();
-        println!("[{step}/{total}] Running: {tag}");
+    for (layer_index, layer) in plan.layers.iter().enumerate() {
+        let layer_number = layer_index + 1;
+        println!("Layer {layer_number}/{}:", plan.layer_count());
+        println!(
+            "  Running: {}",
+            layer.iter().map(|unit| unit.name.as_str()).collect::<Vec<_>>().join(", ")
+        );
 
-        ctx.provisioning
-            .run_playbook(plan.profile.as_str(), std::slice::from_ref(tag), plan.verbose)
-            .inspect_err(|e| {
-                eprintln!("Failed at step {step}/{total}: {tag}: {e}");
-            })?;
+        let mut results = Vec::with_capacity(layer.len());
+        thread::scope(|scope| {
+            let mut handles = Vec::with_capacity(layer.len());
+            for unit in layer {
+                let unit_name = unit.name.clone();
+                let unit_tags = unit.ansible_tags.clone();
+                handles.push(scope.spawn(move || {
+                    (
+                        unit_name,
+                        run_playbook_summarized(
+                            &ctx.provisioning,
+                            plan.profile.as_str(),
+                            &unit_tags,
+                            plan.verbose,
+                        ),
+                    )
+                }));
+            }
+
+            for handle in handles {
+                results.push(handle.join().expect("layer execution thread panicked"));
+            }
+        });
+
+        if let Some((failed_unit, error)) =
+            results.into_iter().find_map(|(name, result)| result.err().map(|err| (name, err)))
+        {
+            eprintln!(
+                "Failed at layer {layer_number}/{}: {failed_unit}: {error}",
+                plan.layer_count()
+            );
+            return Err(error);
+        }
+
         println!("  ✓ Completed");
     }
 
@@ -69,4 +109,55 @@ pub fn execute(
     println!("  MLX Models:        mev make mlx-models");
 
     Ok(())
+}
+
+fn run_playbook_summarized(
+    runtime: &crate::provisioning::ansible_runtime::AnsibleRuntime,
+    profile: &str,
+    tags: &[String],
+    verbose: bool,
+) -> Result<(), AppError> {
+    let mut cmd = runtime.build_command(profile, tags, verbose)?;
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let output = cmd.output().map_err(|e| AppError::AnsibleExecution {
+        message: format!("failed to run ansible-playbook: {e}"),
+        exit_code: None,
+    })?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let exit_code = output.status.code();
+    let summary = capture_failure_summary(&output.stdout, &output.stderr);
+
+    Err(AppError::AnsibleExecution {
+        message: match summary {
+            Some(line) => format!(
+                "ansible-playbook failed{}; reason: {line}",
+                exit_code.map(|code| format!(" with exit code {code}")).unwrap_or_default()
+            ),
+            None => format!(
+                "ansible-playbook failed{}",
+                exit_code.map(|code| format!(" with exit code {code}")).unwrap_or_default()
+            ),
+        },
+        exit_code,
+    })
+}
+
+fn capture_failure_summary(stdout: &[u8], stderr: &[u8]) -> Option<String> {
+    let stdout = String::from_utf8_lossy(stdout);
+    let stderr = String::from_utf8_lossy(stderr);
+
+    stdout
+        .lines()
+        .chain(stderr.lines())
+        .map(str::trim)
+        .find(|line| {
+            line.starts_with("fatal:") || line.contains("cannot rehash") || line.contains("FAILED!")
+        })
+        .map(ToOwned::to_owned)
 }

--- a/src/app/provisioning/make.rs
+++ b/src/app/provisioning/make.rs
@@ -6,10 +6,10 @@ use crate::app::AppContext;
 use crate::error::AppError;
 use crate::provisioning::catalog::ProvisioningCatalog;
 use crate::provisioning::execution_order;
-use crate::provisioning::execution_plan::ExecutionPlan;
+use crate::provisioning::execution_plan::LayeredExecutionPlan;
+use crate::provisioning::playbook_execution;
 use crate::provisioning::profile::Profile;
 use crate::provisioning::role_configs;
-use crate::provisioning::runner::ProvisioningRunner;
 use crate::provisioning::tag_selection;
 
 /// Execute the `make` command: deploy configs and run specified tags.
@@ -26,9 +26,8 @@ pub fn execute(
         ctx.provisioning.tag_groups(),
         &atomic_tags,
     )?;
-    let ordered_units =
-        execution_order::order_units(normalized, ctx.provisioning.order_constraints())?;
-    let plan = ExecutionPlan::make(profile, ordered_units, verbose);
+    let layers = execution_order::layer_units(normalized, ctx.provisioning.order_constraints())?;
+    let plan = LayeredExecutionPlan::new(profile, layers, verbose);
 
     // Deploy configs for roles about to be executed
     role_configs::deploy_for_tags(
@@ -40,20 +39,21 @@ pub fn execute(
         overwrite,
     )?;
 
-    println!("Running units: {}", plan.unit_names().join(", "));
-    if plan.profile != Profile::Global {
-        println!("Profile: {}", plan.profile);
-    }
-    if plan.verbose {
-        for unit in &plan.units {
-            println!("{} => {}", unit.name, unit.ansible_tags.join(","));
-        }
-    }
+    println!();
+    println!("mev: Running selected provisioning plan");
+    println!(
+        "This will run {} tasks across {} layers.",
+        plan.running_units().len(),
+        plan.layer_count()
+    );
     println!();
 
-    for unit in &plan.units {
-        ctx.provisioning.run_playbook(plan.profile.as_str(), &unit.ansible_tags, plan.verbose)?;
-    }
+    playbook_execution::run_layered_playbook(
+        &ctx.provisioning,
+        plan.profile.as_str(),
+        &plan.layers,
+        plan.verbose,
+    )?;
 
     println!();
     println!("✓ Completed successfully!");

--- a/src/app/provisioning/make.rs
+++ b/src/app/provisioning/make.rs
@@ -1,8 +1,11 @@
 //! `make` command orchestration — run individual tasks by tag.
 
+use std::collections::HashSet;
+
 use crate::app::AppContext;
 use crate::error::AppError;
 use crate::provisioning::catalog::ProvisioningCatalog;
+use crate::provisioning::execution_order;
 use crate::provisioning::execution_plan::ExecutionPlan;
 use crate::provisioning::profile::Profile;
 use crate::provisioning::role_configs;
@@ -13,26 +16,23 @@ use crate::provisioning::tag_selection;
 pub fn execute(
     ctx: &AppContext,
     profile: Profile,
-    tag_input: &str,
+    tags: Vec<String>,
     overwrite: bool,
     verbose: bool,
 ) -> Result<(), AppError> {
-    let tags_to_run = tag_selection::resolve_tags(tag_input, ctx.provisioning.tag_groups());
-
-    // Validate tags exist in catalog
-    for t in &tags_to_run {
-        if ctx.provisioning.role_for_tag(t).is_none() {
-            return Err(AppError::InvalidTag(format!(
-                "'{t}'. Use 'mev list' to see available tags."
-            )));
-        }
-    }
-
-    let plan = ExecutionPlan::make(profile, tags_to_run, verbose);
+    let atomic_tags: HashSet<String> = ctx.provisioning.all_tags().into_iter().collect();
+    let normalized = tag_selection::normalize_requested_tags(
+        &tags,
+        ctx.provisioning.tag_groups(),
+        &atomic_tags,
+    )?;
+    let ordered_units =
+        execution_order::order_units(normalized, ctx.provisioning.order_constraints())?;
+    let plan = ExecutionPlan::make(profile, ordered_units, verbose);
 
     // Deploy configs for roles about to be executed
     role_configs::deploy_for_tags(
-        &plan.tags,
+        &plan.ansible_tags(),
         &ctx.host_fs,
         &ctx.local_config_root,
         &ctx.provisioning,
@@ -40,13 +40,20 @@ pub fn execute(
         overwrite,
     )?;
 
-    println!("Running tags: {}", plan.tags.join(", "));
+    println!("Running units: {}", plan.unit_names().join(", "));
     if plan.profile != Profile::Global {
         println!("Profile: {}", plan.profile);
     }
+    if plan.verbose {
+        for unit in &plan.units {
+            println!("{} => {}", unit.name, unit.ansible_tags.join(","));
+        }
+    }
     println!();
 
-    ctx.provisioning.run_playbook(plan.profile.as_str(), &plan.tags, plan.verbose)?;
+    for unit in &plan.units {
+        ctx.provisioning.run_playbook(plan.profile.as_str(), &unit.ansible_tags, plan.verbose)?;
+    }
 
     println!();
     println!("✓ Completed successfully!");

--- a/src/assets/ansible/playbook.yml
+++ b/src/assets/ansible/playbook.yml
@@ -9,6 +9,22 @@
       nodejs: ["nodejs-platform", "nodejs-tools"]
       bun: ["bun-platform", "bun-tools"]
       go: ["go-platform", "go-tools"]
+    execution_order:
+      rust-tools:
+        after:
+          - rust-platform
+      python-tools:
+        after:
+          - python-platform
+      nodejs-tools:
+        after:
+          - nodejs-platform
+      bun-tools:
+        after:
+          - bun-platform
+      go-tools:
+        after:
+          - go-platform
     full_setup_tags:
       - brew-formulae
       - ollama

--- a/src/assets/ansible/roles/brew/config/global/formulae/Brewfile
+++ b/src/assets/ansible/roles/brew/config/global/formulae/Brewfile
@@ -20,6 +20,8 @@ brew "eza"
 brew "fzf"
 brew "fd"
 brew "zoxide"
+brew "dust"
+brew "xh"
 
 ## Zsh
 brew "zsh-autosuggestions"
@@ -34,5 +36,3 @@ brew "tokei"
 
 ## Media
 brew "ffmpeg"
-brew "tesseract"
-brew "tesseract-lang"

--- a/src/assets/ansible/roles/go/tasks/platform.yml
+++ b/src/assets/ansible/roles/go/tasks/platform.yml
@@ -49,6 +49,11 @@
     PATH: "{{ go_command_path }}"
     GOENV_ROOT: "{{ go_environment_root }}"
 
+- name: "Remove stale goenv rehash lock"
+  ansible.builtin.file:
+    path: "{{ go_environment_root }}/shims/.goenv-shim"
+    state: absent
+
 - name: "Rehash goenv shims"
   ansible.builtin.command:
     cmd: "goenv rehash"

--- a/src/assets/ansible/roles/nodejs/tasks/tools.yml
+++ b/src/assets/ansible/roles/nodejs/tasks/tools.yml
@@ -21,5 +21,5 @@
   loop: "{{ nodejs_packages_to_install }}"
   changed_when: false
   environment:
-    PNPM_HOME: "{{ ansible_facts['env']['HOME'] }}/Library/pnpm"
-    PATH: "{{ nodejs_homebrew_bin_path }}:{{ ansible_facts['env']['HOME'] }}/Library/pnpm:{{ ansible_facts['env']['PATH'] }}"
+    PNPM_HOME: "{{ [ansible_facts['env']['HOME'], 'Library', 'pnpm'] | path_join }}"
+    PATH: "{{ nodejs_homebrew_bin_path }}:{{ [ansible_facts['env']['HOME'], 'Library', 'pnpm', 'bin'] | path_join }}:{{ ansible_facts['env']['PATH'] }}"

--- a/src/cli/make.rs
+++ b/src/cli/make.rs
@@ -7,8 +7,9 @@ use crate::provisioning::profile;
 
 #[derive(Args)]
 pub struct MakeArgs {
-    /// Ansible tag to run (e.g., rust, python-tools, shell, br-c).
-    pub tag: String,
+    /// Ansible tags to run (e.g., rust, python-tools, shell, br-c).
+    #[arg(required = true, num_args = 1.., value_name = "TAG")]
+    pub tags: Vec<String>,
 
     /// Profile to use (global, macbook/mbk, mac-mini/mmn).
     #[arg(short = 'p', long, default_value = "global")]
@@ -25,5 +26,5 @@ pub struct MakeArgs {
 
 pub fn run(args: MakeArgs) -> Result<(), AppError> {
     let profile = profile::validate_profile(&args.profile)?;
-    crate::make(profile, &args.tag, args.overwrite, args.verbose)
+    crate::make(profile, args.tags, args.overwrite, args.verbose)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,9 @@ pub enum AppError {
     /// Invalid or unknown tag.
     InvalidTag(String),
 
+    /// Invalid execution order.
+    InvalidExecutionOrder(String),
+
     /// Configuration error.
     Config(String),
 
@@ -46,6 +49,7 @@ impl fmt::Display for AppError {
             Self::InvalidProfile(p) => write!(f, "invalid profile: {p}"),
             Self::InvalidIdentityScope(i) => write!(f, "invalid identity scope: {i}"),
             Self::InvalidTag(t) => write!(f, "invalid tag: {t}"),
+            Self::InvalidExecutionOrder(o) => write!(f, "invalid execution order: {o}"),
             Self::InvalidBackupComponent(t) => write!(f, "invalid backup component: {t}"),
             Self::Config(msg) => write!(f, "configuration error: {msg}"),
             Self::Update(msg) => write!(f, "update failed: {msg}"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,15 @@ pub fn create(profile: Profile, overwrite: bool, verbose: bool) -> Result<(), Ap
     app::provisioning::create::execute(&ctx, profile, overwrite, verbose)
 }
 
-/// Run a single provisioning task by tag within a profile.
-pub fn make(profile: Profile, tag: &str, overwrite: bool, verbose: bool) -> Result<(), AppError> {
+/// Run provisioning tasks by tags within a profile.
+pub fn make(
+    profile: Profile,
+    tags: Vec<String>,
+    overwrite: bool,
+    verbose: bool,
+) -> Result<(), AppError> {
     let ctx = provisioning_context()?;
-    app::provisioning::make::execute(&ctx, profile, tag, overwrite, verbose)
+    app::provisioning::make::execute(&ctx, profile, tags, overwrite, verbose)
 }
 
 /// Print the available tags, tag groups, and profiles.

--- a/src/provisioning/ansible_runtime.rs
+++ b/src/provisioning/ansible_runtime.rs
@@ -5,13 +5,15 @@
 //! a separate `build_command` method to enable unit testing without triggering
 //! side effects such as long-running playbook executions.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 use crate::error::AppError;
 use crate::provisioning::catalog::ProvisioningCatalog;
+use crate::provisioning::execution_order;
+use crate::provisioning::execution_plan::ExecutionUnit;
 use crate::provisioning::role_configs::RoleConfigLocator;
 use crate::provisioning::runner::ProvisioningRunner;
 
@@ -69,6 +71,7 @@ pub struct AnsibleRuntime {
     tags_by_role: HashMap<String, Vec<String>>,
     tag_to_role: HashMap<String, String>,
     tag_groups: HashMap<String, Vec<String>>,
+    order_constraints: HashMap<String, Vec<String>>,
     full_setup_tags: Vec<String>,
 }
 
@@ -81,8 +84,13 @@ impl AnsibleRuntime {
         let playbook_path = ansible_dir.join("playbook.yml");
         let roles_dir = ansible_dir.join("roles");
 
-        let TagCatalog { tags_by_role, tag_to_role, tag_groups, full_setup_tags } =
-            load_catalog(&playbook_path)?;
+        let TagCatalog {
+            tags_by_role,
+            tag_to_role,
+            tag_groups,
+            order_constraints,
+            full_setup_tags,
+        } = load_catalog(&playbook_path)?;
 
         Ok(Self {
             ansible_dir: ansible_dir.to_path_buf(),
@@ -91,6 +99,7 @@ impl AnsibleRuntime {
             tags_by_role,
             tag_to_role,
             tag_groups,
+            order_constraints,
             full_setup_tags,
         })
     }
@@ -104,6 +113,7 @@ impl AnsibleRuntime {
             tags_by_role: HashMap::new(),
             tag_to_role: HashMap::new(),
             tag_groups: HashMap::new(),
+            order_constraints: HashMap::new(),
             full_setup_tags: Vec::new(),
         }
     }
@@ -250,6 +260,10 @@ impl ProvisioningCatalog for AnsibleRuntime {
         &self.tag_groups
     }
 
+    fn order_constraints(&self) -> &HashMap<String, Vec<String>> {
+        &self.order_constraints
+    }
+
     fn full_setup_tags(&self) -> &[String] {
         &self.full_setup_tags
     }
@@ -267,12 +281,13 @@ impl ProvisioningCatalog for AnsibleRuntime {
     }
 }
 
-/// Tag catalog: role→tags, tag→role, tag_groups, and full_setup_tags.
+/// Tag catalog: role→tags, tag→role, tag_groups, order_constraints, and full_setup_tags.
 #[derive(Default)]
 struct TagCatalog {
     tags_by_role: HashMap<String, Vec<String>>,
     tag_to_role: HashMap<String, String>,
     tag_groups: HashMap<String, Vec<String>>,
+    order_constraints: HashMap<String, Vec<String>>,
     full_setup_tags: Vec<String>,
 }
 
@@ -295,6 +310,29 @@ fn load_catalog(playbook_path: &Path) -> Result<TagCatalog, Box<dyn std::error::
                             .entry(group_name.to_string())
                             .or_default()
                             .extend(group_tags);
+                    }
+                }
+            }
+            if let Some(order) = vars.get("execution_order").and_then(|v| v.as_mapping()) {
+                for (k, v) in order {
+                    let Some(target) = k.as_str() else {
+                        continue;
+                    };
+                    if let Some(mapping) = v.as_mapping() {
+                        let after_key = serde_yaml::Value::String("after".to_string());
+                        if let Some(after) = mapping.get(&after_key)
+                            && let Some(seq) = after.as_sequence()
+                        {
+                            let constraints: Vec<String> = seq
+                                .iter()
+                                .filter_map(|t| t.as_str().map(|s| s.to_string()))
+                                .collect();
+                            catalog
+                                .order_constraints
+                                .entry(target.to_string())
+                                .or_default()
+                                .extend(constraints);
+                        }
                     }
                 }
             }
@@ -336,7 +374,54 @@ fn load_catalog(playbook_path: &Path) -> Result<TagCatalog, Box<dyn std::error::
         }
     }
 
+    validate_catalog(&catalog)?;
+
     Ok(catalog)
+}
+
+fn validate_catalog(catalog: &TagCatalog) -> Result<(), Box<dyn std::error::Error>> {
+    let atomic_tags: HashSet<String> = catalog.tag_to_role.keys().cloned().collect();
+
+    for composite_name in catalog.tag_groups.keys() {
+        if atomic_tags.contains(composite_name) {
+            return Err(format!(
+                "composite tag '{composite_name}' conflicts with an atomic tag of the same name"
+            )
+            .into());
+        }
+    }
+
+    for (composite_name, members) in &catalog.tag_groups {
+        for member in members {
+            if !atomic_tags.contains(member) {
+                return Err(format!(
+                    "composite tag '{composite_name}' references unknown atomic tag '{member}'"
+                )
+                .into());
+            }
+        }
+    }
+
+    for (target, prerequisites) in &catalog.order_constraints {
+        if !atomic_tags.contains(target) {
+            return Err(format!("order constraint references unknown atomic tag '{target}'").into());
+        }
+
+        for prerequisite in prerequisites {
+            if !atomic_tags.contains(prerequisite) {
+                return Err(format!(
+                    "order constraint for '{target}' references unknown atomic tag '{prerequisite}'"
+                )
+                .into());
+            }
+        }
+    }
+
+    let all_units: Vec<ExecutionUnit> =
+        atomic_tags.iter().cloned().map(ExecutionUnit::atomic).collect();
+    let _ = execution_order::order_units(all_units, &catalog.order_constraints)?;
+
+    Ok(())
 }
 #[cfg(test)]
 mod tests {
@@ -443,6 +528,7 @@ mod tests {
             tags_by_role: HashMap::new(),
             tag_to_role: HashMap::new(),
             tag_groups: HashMap::new(),
+            order_constraints: HashMap::new(),
             full_setup_tags: Vec::new(),
         };
 
@@ -480,6 +566,7 @@ mod tests {
             tags_by_role: HashMap::new(),
             tag_to_role: HashMap::new(),
             tag_groups: HashMap::new(),
+            order_constraints: HashMap::new(),
             full_setup_tags: Vec::new(),
         };
 
@@ -494,13 +581,35 @@ mod tests {
         let playbook_path = dir.path().join("playbook.yml");
         fs::write(
             &playbook_path,
-            "- name: first\n  vars:\n    tag_groups:\n      rust: [\"rust-platform\"]\n- name: second\n  vars:\n    tag_groups:\n      rust: [\"rust-tools\"]\n",
+            "- name: first\n  vars:\n    tag_groups:\n      rust: [\"rust-platform\"]\n  roles:\n    - { role: rust, tags: [\"rust-platform\"] }\n- name: second\n  vars:\n    tag_groups:\n      rust: [\"rust-tools\"]\n  roles:\n    - { role: rust, tags: [\"rust-tools\"] }\n",
         )?;
 
         let catalog = load_catalog(playbook_path.as_path())?;
         assert_eq!(
             catalog.tag_groups.get("rust"),
             Some(&vec!["rust-platform".to_string(), "rust-tools".to_string()])
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_load_catalog_reads_tag_groups_and_order() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempdir()?;
+        let playbook_path = dir.path().join("playbook.yml");
+        fs::write(
+            &playbook_path,
+            "- name: setup\n  vars:\n    tag_groups:\n      rust: [\"rust-platform\", \"rust-tools\"]\n    execution_order:\n      rust-tools:\n        after:\n          - rust-platform\n  roles:\n    - { role: rust, tags: [\"rust-platform\", \"rust-tools\"] }\n",
+        )?;
+
+        let catalog = load_catalog(playbook_path.as_path())?;
+        assert_eq!(
+            catalog.tag_groups.get("rust"),
+            Some(&vec!["rust-platform".to_string(), "rust-tools".to_string()])
+        );
+        assert_eq!(
+            catalog.order_constraints.get("rust-tools"),
+            Some(&vec!["rust-platform".to_string()])
         );
 
         Ok(())

--- a/src/provisioning/ansible_runtime.rs
+++ b/src/provisioning/ansible_runtime.rs
@@ -8,14 +8,19 @@
 use std::collections::{HashMap, HashSet};
 use std::env;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::{Command, Output, Stdio};
 
 use crate::error::AppError;
 use crate::provisioning::catalog::ProvisioningCatalog;
 use crate::provisioning::execution_order;
 use crate::provisioning::execution_plan::ExecutionUnit;
 use crate::provisioning::role_configs::RoleConfigLocator;
-use crate::provisioning::runner::ProvisioningRunner;
+
+/// Playbook execution contract for provisioning flows.
+pub trait ProvisioningRunner {
+    /// Run the provisioning playbook for a profile with a tag set.
+    fn run_playbook(&self, profile: &str, tags: &[String], verbose: bool) -> Result<(), AppError>;
+}
 
 const ANSIBLE_PLAYBOOK_BIN_ENV: &str = "ANSIBLE_PLAYBOOK_BIN";
 const PIPX_HOME_ENV: &str = "PIPX_HOME";
@@ -187,29 +192,57 @@ impl AnsibleRuntime {
 
         Ok(cmd)
     }
+
+    pub(crate) fn run_playbook_captured(
+        &self,
+        profile: &str,
+        tags: &[String],
+        verbose: bool,
+    ) -> Result<Output, AppError> {
+        let mut cmd = self.build_command(profile, tags, verbose)?;
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        cmd.output().map_err(command_spawn_error)
+    }
+
+    fn run_playbook_inherited(
+        &self,
+        profile: &str,
+        tags: &[String],
+        verbose: bool,
+    ) -> Result<(), AppError> {
+        let mut cmd = self.build_command(profile, tags, verbose)?;
+        cmd.stdout(Stdio::inherit());
+        cmd.stderr(Stdio::inherit());
+
+        let status = cmd.status().map_err(command_spawn_error)?;
+
+        if status.success() {
+            return Ok(());
+        }
+
+        Err(command_exit_error(status.code()))
+    }
 }
 
 impl ProvisioningRunner for AnsibleRuntime {
     fn run_playbook(&self, profile: &str, tags: &[String], verbose: bool) -> Result<(), AppError> {
-        let mut cmd = self.build_command(profile, tags, verbose)?;
+        self.run_playbook_inherited(profile, tags, verbose)
+    }
+}
 
-        cmd.stdout(Stdio::inherit());
-        cmd.stderr(Stdio::inherit());
+fn command_spawn_error(error: std::io::Error) -> AppError {
+    AppError::AnsibleExecution {
+        message: format!("failed to run ansible-playbook: {error}"),
+        exit_code: None,
+    }
+}
 
-        let status = cmd.status().map_err(|e| AppError::AnsibleExecution {
-            message: format!("failed to run ansible-playbook: {e}"),
-            exit_code: None,
-        })?;
-
-        if !status.success() {
-            let code = status.code();
-            return Err(AppError::AnsibleExecution {
-                message: format!("ansible-playbook exited with code {}", code.unwrap_or(-1)),
-                exit_code: code,
-            });
-        }
-
-        Ok(())
+fn command_exit_error(exit_code: Option<i32>) -> AppError {
+    AppError::AnsibleExecution {
+        message: format!("ansible-playbook exited with code {}", exit_code.unwrap_or(-1)),
+        exit_code,
     }
 }
 

--- a/src/provisioning/catalog.rs
+++ b/src/provisioning/catalog.rs
@@ -8,6 +8,9 @@ pub trait ProvisioningCatalog {
     /// Get all configured tag groups.
     fn tag_groups(&self) -> &HashMap<String, Vec<String>>;
 
+    /// Get ordering constraints keyed by tag.
+    fn order_constraints(&self) -> &HashMap<String, Vec<String>>;
+
     /// Get full setup tags for the create flow.
     fn full_setup_tags(&self) -> &[String];
 

--- a/src/provisioning/execution_order.rs
+++ b/src/provisioning/execution_order.rs
@@ -1,0 +1,230 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::error::AppError;
+use crate::provisioning::execution_plan::ExecutionUnit;
+
+fn selected_index_map(units: &[ExecutionUnit]) -> HashMap<String, usize> {
+    units.iter().enumerate().map(|(index, unit)| (unit.name.clone(), index)).collect()
+}
+
+fn selected_names(units: &[ExecutionUnit]) -> HashSet<String> {
+    units.iter().map(|unit| unit.name.clone()).collect()
+}
+
+fn build_graph(
+    selected: &HashSet<String>,
+    order_constraints: &HashMap<String, Vec<String>>,
+) -> (HashMap<String, Vec<String>>, HashMap<String, usize>) {
+    let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
+    let mut indegree: HashMap<String, usize> =
+        selected.iter().map(|tag| (tag.clone(), 0)).collect();
+
+    for (target, prerequisites) in order_constraints {
+        if !selected.contains(target) {
+            continue;
+        }
+
+        for prerequisite in prerequisites {
+            if !selected.contains(prerequisite) {
+                continue;
+            }
+
+            dependents.entry(prerequisite.clone()).or_default().push(target.clone());
+            *indegree.entry(target.clone()).or_default() += 1;
+        }
+    }
+
+    (dependents, indegree)
+}
+
+fn cycle_path(
+    node: &str,
+    dependents: &HashMap<String, Vec<String>>,
+    visiting: &mut Vec<String>,
+    visited: &mut HashSet<String>,
+) -> Option<Vec<String>> {
+    if let Some(position) = visiting.iter().position(|current| current == node) {
+        let mut cycle = visiting[position..].to_vec();
+        cycle.push(node.to_string());
+        return Some(cycle);
+    }
+
+    if !visited.insert(node.to_string()) {
+        return None;
+    }
+
+    visiting.push(node.to_string());
+    if let Some(next_nodes) = dependents.get(node) {
+        for next in next_nodes {
+            if let Some(cycle) = cycle_path(next, dependents, visiting, visited) {
+                return Some(cycle);
+            }
+        }
+    }
+    visiting.pop();
+    None
+}
+
+fn detect_cycle(dependents: &HashMap<String, Vec<String>>) -> Option<Vec<String>> {
+    let mut visited = HashSet::new();
+    for node in dependents.keys() {
+        let mut visiting = Vec::new();
+        if let Some(cycle) = cycle_path(node, dependents, &mut visiting, &mut visited) {
+            return Some(cycle);
+        }
+    }
+    None
+}
+
+pub fn order_units(
+    units: Vec<ExecutionUnit>,
+    order_constraints: &HashMap<String, Vec<String>>,
+) -> Result<Vec<ExecutionUnit>, AppError> {
+    let index_map = selected_index_map(&units);
+    let selected = selected_names(&units);
+    let (dependents, mut indegree) = build_graph(&selected, order_constraints);
+
+    let mut remaining: HashMap<String, ExecutionUnit> =
+        units.into_iter().map(|unit| (unit.name.clone(), unit)).collect();
+    let mut ordered = Vec::with_capacity(remaining.len());
+
+    while !remaining.is_empty() {
+        let mut ready: Vec<String> = indegree
+            .iter()
+            .filter_map(|(name, degree)| (*degree == 0).then_some(name.clone()))
+            .collect();
+        ready.sort_by_key(|name| index_map.get(name).copied().unwrap_or(usize::MAX));
+
+        if ready.is_empty() {
+            if let Some(cycle) = detect_cycle(&dependents) {
+                return Err(AppError::InvalidExecutionOrder(format!(
+                    "cycle detected: {}",
+                    cycle.join(" -> ")
+                )));
+            }
+
+            return Err(AppError::InvalidExecutionOrder(
+                "no executable units remain after applying order constraints".to_string(),
+            ));
+        }
+
+        for name in ready {
+            if let Some(unit) = remaining.remove(&name) {
+                ordered.push(unit);
+                indegree.remove(&name);
+                if let Some(dependent_names) = dependents.get(&name) {
+                    for dependent in dependent_names {
+                        if let Some(value) = indegree.get_mut(dependent) {
+                            *value = value.saturating_sub(1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(ordered)
+}
+
+pub fn layer_units(
+    units: Vec<ExecutionUnit>,
+    order_constraints: &HashMap<String, Vec<String>>,
+) -> Result<Vec<Vec<ExecutionUnit>>, AppError> {
+    let index_map = selected_index_map(&units);
+    let selected = selected_names(&units);
+    let (dependents, mut indegree) = build_graph(&selected, order_constraints);
+
+    let mut remaining: HashMap<String, ExecutionUnit> =
+        units.into_iter().map(|unit| (unit.name.clone(), unit)).collect();
+    let mut layers = Vec::new();
+
+    while !remaining.is_empty() {
+        let mut ready: Vec<String> = indegree
+            .iter()
+            .filter_map(|(name, degree)| (*degree == 0).then_some(name.clone()))
+            .collect();
+        ready.sort_by_key(|name| index_map.get(name).copied().unwrap_or(usize::MAX));
+
+        if ready.is_empty() {
+            if let Some(cycle) = detect_cycle(&dependents) {
+                return Err(AppError::InvalidExecutionOrder(format!(
+                    "cycle detected: {}",
+                    cycle.join(" -> ")
+                )));
+            }
+
+            return Err(AppError::InvalidExecutionOrder(
+                "no executable units remain after applying order constraints".to_string(),
+            ));
+        }
+
+        let mut layer = Vec::with_capacity(ready.len());
+        for name in ready {
+            if let Some(unit) = remaining.remove(&name) {
+                layer.push(unit);
+                indegree.remove(&name);
+                if let Some(dependent_names) = dependents.get(&name) {
+                    for dependent in dependent_names {
+                        if let Some(value) = indegree.get_mut(dependent) {
+                            *value = value.saturating_sub(1);
+                        }
+                    }
+                }
+            }
+        }
+        layers.push(layer);
+    }
+
+    Ok(layers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unit(name: &str) -> ExecutionUnit {
+        ExecutionUnit::atomic(name)
+    }
+
+    #[test]
+    fn orders_selected_units() {
+        let units = vec![unit("tools"), unit("platform")];
+        let mut constraints = HashMap::new();
+        constraints.insert("tools".to_string(), vec!["platform".to_string()]);
+
+        let ordered = order_units(units, &constraints).unwrap();
+        assert_eq!(
+            ordered.into_iter().map(|unit| unit.name).collect::<Vec<_>>(),
+            vec!["platform", "tools"]
+        );
+    }
+
+    #[test]
+    fn layers_selected_units() {
+        let units = vec![unit("platform"), unit("tools"), unit("shell")];
+        let mut constraints = HashMap::new();
+        constraints.insert("tools".to_string(), vec!["platform".to_string()]);
+
+        let layers = layer_units(units, &constraints).unwrap();
+        assert_eq!(layers.len(), 2);
+        assert_eq!(
+            layers[0].iter().map(|unit| unit.name.clone()).collect::<Vec<_>>(),
+            vec!["platform", "shell"]
+        );
+        assert_eq!(
+            layers[1].iter().map(|unit| unit.name.clone()).collect::<Vec<_>>(),
+            vec!["tools"]
+        );
+    }
+
+    #[test]
+    fn detects_cycles() {
+        let units = vec![unit("platform"), unit("tools")];
+        let mut constraints = HashMap::new();
+        constraints.insert("platform".to_string(), vec!["tools".to_string()]);
+        constraints.insert("tools".to_string(), vec!["platform".to_string()]);
+
+        let result = order_units(units, &constraints);
+        assert!(matches!(result, Err(AppError::InvalidExecutionOrder(_))));
+    }
+}

--- a/src/provisioning/execution_plan.rs
+++ b/src/provisioning/execution_plan.rs
@@ -2,23 +2,78 @@
 
 use crate::provisioning::profile::Profile;
 
-/// An execution plan describes the ordered sequence of ansible tags to run.
+/// A normalized execution unit with the display name and ansible tags to run.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionUnit {
+    pub name: String,
+    pub ansible_tags: Vec<String>,
+}
+
+impl ExecutionUnit {
+    pub fn new(name: impl Into<String>, ansible_tags: Vec<String>) -> Self {
+        Self { name: name.into(), ansible_tags }
+    }
+
+    pub fn atomic(tag: impl Into<String>) -> Self {
+        let name = tag.into();
+        Self { name: name.clone(), ansible_tags: vec![name] }
+    }
+}
+
+/// An execution plan describes the ordered sequence of execution units to run.
 #[derive(Debug, Clone)]
 pub struct ExecutionPlan {
     pub profile: Profile,
-    pub tags: Vec<String>,
+    pub units: Vec<ExecutionUnit>,
+    pub verbose: bool,
+}
+
+/// A layered execution plan used by create for parallel execution.
+#[derive(Debug, Clone)]
+pub struct LayeredExecutionPlan {
+    pub profile: Profile,
+    pub layers: Vec<Vec<ExecutionUnit>>,
     pub verbose: bool,
 }
 
 impl ExecutionPlan {
-    /// Construct a plan for a full environment creation.
-    pub fn full_setup(profile: Profile, tags: Vec<String>, verbose: bool) -> Self {
-        Self { profile, tags, verbose }
+    /// Construct a plan for a single make invocation.
+    pub fn make(profile: Profile, units: Vec<ExecutionUnit>, verbose: bool) -> Self {
+        Self { profile, units, verbose }
     }
 
-    /// Construct a plan for a single make invocation.
-    pub fn make(profile: Profile, tags: Vec<String>, verbose: bool) -> Self {
-        Self { profile, tags, verbose }
+    pub fn unit_names(&self) -> Vec<String> {
+        self.units.iter().map(|unit| unit.name.clone()).collect()
+    }
+
+    pub fn ansible_tags(&self) -> Vec<String> {
+        self.units.iter().flat_map(|unit| unit.ansible_tags.clone()).collect()
+    }
+}
+
+impl LayeredExecutionPlan {
+    /// Construct a plan for a full environment creation.
+    pub fn full_setup(profile: Profile, layers: Vec<Vec<ExecutionUnit>>, verbose: bool) -> Self {
+        Self { profile, layers, verbose }
+    }
+
+    pub fn layer_count(&self) -> usize {
+        self.layers.len()
+    }
+
+    pub fn running_units(&self) -> Vec<String> {
+        self.layers.iter().flat_map(|layer| layer.iter().map(|unit| unit.name.clone())).collect()
+    }
+
+    pub fn all_units(&self) -> Vec<ExecutionUnit> {
+        self.layers.iter().flat_map(|layer| layer.iter().cloned()).collect()
+    }
+
+    pub fn ansible_tags(&self) -> Vec<String> {
+        self.layers
+            .iter()
+            .flat_map(|layer| layer.iter().flat_map(|unit| unit.ansible_tags.clone()))
+            .collect()
     }
 }
 
@@ -27,22 +82,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn full_setup_contains_all_tags() {
-        let test_tags = vec!["tag1".to_string(), "tag2".to_string()];
-        let plan = ExecutionPlan::full_setup(Profile::Macbook, test_tags.clone(), true);
+    fn make_contains_provided_units() {
+        let units = vec![ExecutionUnit::new("tag1", vec!["tag1".to_string()])];
+        let plan = ExecutionPlan::make(Profile::Macbook, units.clone(), true);
+
         assert_eq!(plan.profile, Profile::Macbook);
         assert!(plan.verbose);
-
-        assert_eq!(plan.tags, test_tags);
+        assert_eq!(plan.units, units);
     }
 
     #[test]
-    fn make_contains_provided_tags() {
-        let tags = vec!["tag1".to_string(), "tag2".to_string()];
-        let plan = ExecutionPlan::make(Profile::MacMini, tags, false);
+    fn layered_full_setup_contains_layers() {
+        let layers = vec![vec![ExecutionUnit::new("tag1", vec!["tag1".to_string()])]];
+        let plan = LayeredExecutionPlan::full_setup(Profile::MacMini, layers.clone(), false);
 
         assert_eq!(plan.profile, Profile::MacMini);
         assert!(!plan.verbose);
-        assert_eq!(plan.tags, vec!["tag1".to_string(), "tag2".to_string()]);
+        assert_eq!(plan.layers, layers);
     }
 }

--- a/src/provisioning/execution_plan.rs
+++ b/src/provisioning/execution_plan.rs
@@ -52,9 +52,14 @@ impl ExecutionPlan {
 }
 
 impl LayeredExecutionPlan {
+    /// Construct a layered execution plan.
+    pub fn new(profile: Profile, layers: Vec<Vec<ExecutionUnit>>, verbose: bool) -> Self {
+        Self { profile, layers, verbose }
+    }
+
     /// Construct a plan for a full environment creation.
     pub fn full_setup(profile: Profile, layers: Vec<Vec<ExecutionUnit>>, verbose: bool) -> Self {
-        Self { profile, layers, verbose }
+        Self::new(profile, layers, verbose)
     }
 
     pub fn layer_count(&self) -> usize {

--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -3,7 +3,7 @@ pub mod assets;
 pub mod catalog;
 pub mod execution_order;
 pub mod execution_plan;
+pub mod playbook_execution;
 pub mod profile;
 pub mod role_configs;
-pub mod runner;
 pub mod tag_selection;

--- a/src/provisioning/mod.rs
+++ b/src/provisioning/mod.rs
@@ -1,6 +1,7 @@
 pub mod ansible_runtime;
 pub mod assets;
 pub mod catalog;
+pub mod execution_order;
 pub mod execution_plan;
 pub mod profile;
 pub mod role_configs;

--- a/src/provisioning/playbook_execution.rs
+++ b/src/provisioning/playbook_execution.rs
@@ -1,0 +1,93 @@
+use std::thread;
+
+use crate::error::AppError;
+use crate::provisioning::ansible_runtime::AnsibleRuntime;
+use crate::provisioning::execution_plan::ExecutionUnit;
+
+/// Run a layered provisioning plan and emit compact layer progress.
+pub(crate) fn run_layered_playbook(
+    runtime: &AnsibleRuntime,
+    profile: &str,
+    layers: &[Vec<ExecutionUnit>],
+    verbose: bool,
+) -> Result<(), AppError> {
+    for (layer_index, layer) in layers.iter().enumerate() {
+        let layer_number = layer_index + 1;
+        println!("Layer {layer_number}/{}:", layers.len());
+        println!(
+            "  Running: {}",
+            layer.iter().map(|unit| unit.name.as_str()).collect::<Vec<_>>().join(", ")
+        );
+
+        let mut results = Vec::with_capacity(layer.len());
+        thread::scope(|scope| {
+            let mut handles = Vec::with_capacity(layer.len());
+            for unit in layer {
+                let unit_name = unit.name.clone();
+                let unit_tags = unit.ansible_tags.clone();
+                handles.push(scope.spawn(move || {
+                    (unit_name, run_playbook_summarized(runtime, profile, &unit_tags, verbose))
+                }));
+            }
+
+            for handle in handles {
+                results.push(handle.join().expect("layer execution thread panicked"));
+            }
+        });
+
+        if let Some((failed_unit, error)) =
+            results.into_iter().find_map(|(name, result)| result.err().map(|err| (name, err)))
+        {
+            eprintln!("Failed at layer {layer_number}/{}: {failed_unit}: {error}", layers.len());
+            return Err(error);
+        }
+
+        println!("  ✓ Completed");
+    }
+
+    Ok(())
+}
+
+pub(crate) fn run_playbook_summarized(
+    runtime: &AnsibleRuntime,
+    profile: &str,
+    tags: &[String],
+    verbose: bool,
+) -> Result<(), AppError> {
+    let output = runtime.run_playbook_captured(profile, tags, verbose)?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let exit_code = output.status.code();
+    let summary = capture_failure_summary(&output.stdout, &output.stderr);
+
+    Err(AppError::AnsibleExecution {
+        message: match summary {
+            Some(line) => format!(
+                "ansible-playbook failed{}; reason: {line}",
+                exit_code.map(|code| format!(" with exit code {code}")).unwrap_or_default()
+            ),
+            None => format!(
+                "ansible-playbook failed{}",
+                exit_code.map(|code| format!(" with exit code {code}")).unwrap_or_default()
+            ),
+        },
+        exit_code,
+    })
+}
+
+fn capture_failure_summary(stdout: &[u8], stderr: &[u8]) -> Option<String> {
+    let stdout = String::from_utf8_lossy(stdout);
+    let stderr = String::from_utf8_lossy(stderr);
+
+    stdout
+        .lines()
+        .chain(stderr.lines())
+        .map(str::trim)
+        .find(|line| {
+            line.starts_with("fatal:") || line.contains("cannot rehash") || line.contains("FAILED!")
+        })
+        .map(ToOwned::to_owned)
+}

--- a/src/provisioning/playbook_execution.rs
+++ b/src/provisioning/playbook_execution.rs
@@ -26,7 +26,10 @@ pub(crate) fn run_layered_playbook(
                 let unit_name = unit.name.clone();
                 let unit_tags = unit.ansible_tags.clone();
                 handles.push(scope.spawn(move || {
-                    (unit_name, run_playbook_summarized(runtime, profile, &unit_tags, verbose))
+                    (
+                        unit_name.clone(),
+                        run_playbook_summarized(runtime, profile, &unit_name, &unit_tags, verbose),
+                    )
                 }));
             }
 
@@ -51,6 +54,7 @@ pub(crate) fn run_layered_playbook(
 pub(crate) fn run_playbook_summarized(
     runtime: &AnsibleRuntime,
     profile: &str,
+    label: &str,
     tags: &[String],
     verbose: bool,
 ) -> Result<(), AppError> {
@@ -62,6 +66,7 @@ pub(crate) fn run_playbook_summarized(
 
     let exit_code = output.status.code();
     let summary = capture_failure_summary(&output.stdout, &output.stderr);
+    emit_captured_output(label, &output.stdout, &output.stderr);
 
     Err(AppError::AnsibleExecution {
         message: match summary {
@@ -76,6 +81,21 @@ pub(crate) fn run_playbook_summarized(
         },
         exit_code,
     })
+}
+
+fn emit_captured_output(label: &str, stdout: &[u8], stderr: &[u8]) {
+    let stdout = String::from_utf8_lossy(stdout);
+    let stderr = String::from_utf8_lossy(stderr);
+
+    if !stdout.trim().is_empty() {
+        eprintln!("--- {label} stdout ---");
+        eprintln!("{}", stdout.trim_end());
+    }
+
+    if !stderr.trim().is_empty() {
+        eprintln!("--- {label} stderr ---");
+        eprintln!("{}", stderr.trim_end());
+    }
 }
 
 fn capture_failure_summary(stdout: &[u8], stderr: &[u8]) -> Option<String> {

--- a/src/provisioning/runner.rs
+++ b/src/provisioning/runner.rs
@@ -1,7 +1,0 @@
-use crate::error::AppError;
-
-/// Playbook execution contract for provisioning flows.
-pub trait ProvisioningRunner {
-    /// Run the provisioning playbook for a profile with a tag set.
-    fn run_playbook(&self, profile: &str, tags: &[String], verbose: bool) -> Result<(), AppError>;
-}

--- a/src/provisioning/tag_selection.rs
+++ b/src/provisioning/tag_selection.rs
@@ -1,18 +1,80 @@
 //! Tag resolution and validation from catalog sources.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 
-/// Resolve a CLI tag argument into the concrete tags to run.
+use crate::error::AppError;
+use crate::provisioning::execution_plan::ExecutionUnit;
+
+/// Resolve a CLI tag argument list into normalized execution units.
 ///
-/// If the tag matches a group name, returns the expanded list.
-/// Otherwise returns the tag as-is.
-pub fn resolve_tags(tag: &str, tag_groups: &HashMap<String, Vec<String>>) -> Vec<String> {
-    if let Some(group) = tag_groups.get(tag) { group.clone() } else { vec![tag.to_string()] }
+/// Tag groups absorb any selected atomic tags they contain.
+pub fn normalize_requested_tags(
+    tags: &[String],
+    tag_groups: &HashMap<String, Vec<String>>,
+    atomic_tags: &HashSet<String>,
+) -> Result<Vec<ExecutionUnit>, AppError> {
+    let mut selected: Vec<ExecutionUnit> = Vec::new();
+
+    for tag in tags {
+        if let Some(group_members) = tag_groups.get(tag) {
+            validate_group_members(tag, group_members, atomic_tags)?;
+
+            if selected.iter().any(|unit| unit.name == *tag) {
+                continue;
+            }
+
+            let composite_members_set: HashSet<String> = group_members.iter().cloned().collect();
+            selected.retain(|unit| {
+                if unit
+                    .ansible_tags
+                    .iter()
+                    .all(|atomic_tag| composite_members_set.contains(atomic_tag))
+                {
+                    return false;
+                }
+                true
+            });
+
+            selected.push(ExecutionUnit::new(tag.clone(), group_members.clone()));
+            continue;
+        }
+
+        if !atomic_tags.contains(tag) {
+            return Err(AppError::InvalidTag(tag.clone()));
+        }
+
+        if selected.iter().any(|unit| unit.ansible_tags.iter().any(|atomic_tag| atomic_tag == tag))
+        {
+            continue;
+        }
+
+        selected.push(ExecutionUnit::new(tag.clone(), vec![tag.clone()]));
+    }
+
+    Ok(selected)
+}
+
+fn validate_group_members(
+    group_name: &str,
+    members: &[String],
+    atomic_tags: &HashSet<String>,
+) -> Result<(), AppError> {
+    for member in members {
+        if !atomic_tags.contains(member) {
+            return Err(AppError::Config(format!(
+                "tag group '{group_name}' references unknown atomic tag '{member}'"
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provisioning::execution_plan::ExecutionUnit;
 
     fn test_groups() -> HashMap<String, Vec<String>> {
         let mut groups = HashMap::new();
@@ -23,15 +85,53 @@ mod tests {
         groups
     }
 
-    #[test]
-    fn resolves_group_tag() {
-        let tags = resolve_tags("rust", &test_groups());
-        assert_eq!(tags, vec!["rust-platform", "rust-tools"]);
+    fn test_atoms() -> HashSet<String> {
+        ["rust-platform", "rust-tools", "shell"].into_iter().map(String::from).collect()
     }
 
     #[test]
-    fn resolves_single_tag() {
-        let tags = resolve_tags("shell", &test_groups());
-        assert_eq!(tags, vec!["shell"]);
+    fn normalizes_group_tag() {
+        let units =
+            normalize_requested_tags(&["rust".to_string()], &test_groups(), &test_atoms()).unwrap();
+        assert_eq!(
+            units,
+            vec![ExecutionUnit::new(
+                "rust",
+                vec!["rust-platform".to_string(), "rust-tools".to_string()]
+            )]
+        );
+    }
+
+    #[test]
+    fn composite_absorbs_member_tags() {
+        let units = normalize_requested_tags(
+            &[
+                "rust".to_string(),
+                "rust-platform".to_string(),
+                "shell".to_string(),
+                "rust-tools".to_string(),
+            ],
+            &test_groups(),
+            &test_atoms(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            units,
+            vec![
+                ExecutionUnit::new(
+                    "rust",
+                    vec!["rust-platform".to_string(), "rust-tools".to_string()]
+                ),
+                ExecutionUnit::new("shell", vec!["shell".to_string()])
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_tag() {
+        let result =
+            normalize_requested_tags(&["missing".to_string()], &test_groups(), &test_atoms());
+        assert!(matches!(result, Err(AppError::InvalidTag(_))));
     }
 }

--- a/src/test_support/provisioning.rs
+++ b/src/test_support/provisioning.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::error::AppError;
+use crate::provisioning::ansible_runtime::ProvisioningRunner;
 use crate::provisioning::catalog::ProvisioningCatalog;
 use crate::provisioning::role_configs::RoleConfigLocator;
-use crate::provisioning::runner::ProvisioningRunner;
 
 pub struct FakeProvisioningPort {
     pub roles_with_config: Vec<String>,

--- a/src/test_support/provisioning.rs
+++ b/src/test_support/provisioning.rs
@@ -14,6 +14,7 @@ pub struct FakeProvisioningPort {
     pub all_tags: Vec<String>,
     pub tags_by_role: HashMap<String, Vec<String>>,
     pub tag_groups: HashMap<String, Vec<String>>,
+    pub order_constraints: HashMap<String, Vec<String>>,
     pub full_setup_tags: Vec<String>,
     pub events: RefCell<Vec<String>>,
 }
@@ -27,6 +28,7 @@ impl FakeProvisioningPort {
             all_tags: Vec::new(),
             tags_by_role: HashMap::new(),
             tag_groups: HashMap::new(),
+            order_constraints: HashMap::new(),
             full_setup_tags: Vec::new(),
             events: RefCell::new(Vec::new()),
         }
@@ -47,6 +49,10 @@ impl ProvisioningCatalog for FakeProvisioningPort {
 
     fn tag_groups(&self) -> &HashMap<String, Vec<String>> {
         &self.tag_groups
+    }
+
+    fn order_constraints(&self) -> &HashMap<String, Vec<String>> {
+        &self.order_constraints
     }
 
     fn full_setup_tags(&self) -> &[String] {

--- a/tests/cli/make.rs
+++ b/tests/cli/make.rs
@@ -1,1 +1,32 @@
 //! CLI contract tests for the `make` command.
+
+use crate::harness::TestContext;
+use predicates::prelude::*;
+use std::os::unix::fs::PermissionsExt;
+
+#[test]
+fn make_accepts_multiple_tags_and_expands_composites() {
+    let ctx = TestContext::new();
+
+    let ansible_mock = r#"#!/bin/bash
+echo "PLAY RECAP *********************************************************************"
+echo "localhost                  : ok=10   changed=5    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   "
+"#;
+
+    let mocks_dir = ctx.work_dir().join(".local/pipx/venvs/ansible/bin");
+    std::fs::create_dir_all(&mocks_dir).unwrap();
+    let ansible_path = mocks_dir.join("ansible-playbook");
+
+    std::fs::write(&ansible_path, ansible_mock).unwrap();
+    std::fs::set_permissions(&ansible_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    ctx.cli()
+        .env("HOME", ctx.work_dir())
+        .env("ANSIBLE_PLAYBOOK_BIN", &ansible_path)
+        .args(["make", "rust", "rust-platform", "rust-tools", "shell", "--verbose"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Running units: rust, shell"))
+        .stdout(predicate::str::contains("rust => rust-platform,rust-tools"))
+        .stdout(predicate::str::contains("shell => shell"));
+}

--- a/tests/cli/make.rs
+++ b/tests/cli/make.rs
@@ -23,10 +23,12 @@ echo "localhost                  : ok=10   changed=5    unreachable=0    failed=
     ctx.cli()
         .env("HOME", ctx.work_dir())
         .env("ANSIBLE_PLAYBOOK_BIN", &ansible_path)
-        .args(["make", "rust", "rust-platform", "rust-tools", "shell", "--verbose"])
+        .args(["make", "rust-platform", "rust-tools", "shell", "--verbose"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Running units: rust, shell"))
-        .stdout(predicate::str::contains("rust => rust-platform,rust-tools"))
-        .stdout(predicate::str::contains("shell => shell"));
+        .stdout(predicate::str::contains("Layer 1/2:"))
+        .stdout(predicate::str::contains("Layer 2/2:"))
+        .stdout(predicate::str::contains("Running: rust-platform, shell"))
+        .stdout(predicate::str::contains("Running: rust-tools"))
+        .stdout(predicate::str::contains("✓ Completed successfully!"));
 }

--- a/tests/cli/make.rs
+++ b/tests/cli/make.rs
@@ -32,3 +32,29 @@ echo "localhost                  : ok=10   changed=5    unreachable=0    failed=
         .stdout(predicate::str::contains("Running: rust-tools"))
         .stdout(predicate::str::contains("✓ Completed successfully!"));
 }
+
+#[test]
+fn make_prints_ansible_output_on_failure() {
+    let ctx = TestContext::new();
+
+    let ansible_mock = r#"#!/bin/bash
+echo "PLAY [nodejs-tools] *******************************************************"
+echo "fatal: [localhost]: FAILED! => {\"msg\": \"boom\"}" >&2
+echo "mock stdout line"
+exit 2
+"#;
+
+    ctx.create_mock_command("ansible-playbook", ansible_mock);
+    let ansible_path = ctx.work_dir().join("ansible-playbook");
+
+    ctx.cli()
+        .env("ANSIBLE_PLAYBOOK_BIN", &ansible_path)
+        .args(["make", "nodejs-tools"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--- nodejs-tools stdout ---"))
+        .stderr(predicate::str::contains("mock stdout line"))
+        .stderr(predicate::str::contains("--- nodejs-tools stderr ---"))
+        .stderr(predicate::str::contains("fatal: [localhost]: FAILED!"))
+        .stderr(predicate::str::contains("ansible-playbook failed with exit code 2"));
+}

--- a/tests/library/owner_exports.rs
+++ b/tests/library/owner_exports.rs
@@ -1,13 +1,26 @@
 //! Verify public API surfaces remain accessible.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[test]
 fn provisioning_tag_resolution_is_public() {
-    let mut groups = HashMap::new();
-    groups.insert("rust".to_string(), vec!["rust-platform".to_string(), "rust-tools".to_string()]);
-    let tags = mev::provisioning::tag_selection::resolve_tags("rust", &groups);
-    assert_eq!(tags, vec!["rust-platform", "rust-tools"]);
+    let mut composite_tags = HashMap::new();
+    composite_tags
+        .insert("rust".to_string(), vec!["rust-platform".to_string(), "rust-tools".to_string()]);
+
+    let atomic_tags: HashSet<String> =
+        ["rust-platform", "rust-tools", "shell"].into_iter().map(String::from).collect();
+
+    let units = mev::provisioning::tag_selection::normalize_requested_tags(
+        &["rust".to_string(), "shell".to_string()],
+        &composite_tags,
+        &atomic_tags,
+    )
+    .unwrap();
+
+    assert_eq!(units.len(), 2);
+    assert_eq!(units[0].name, "rust");
+    assert_eq!(units[1].name, "shell");
 }
 
 #[test]


### PR DESCRIPTION
…execution

- Refactored the `create` command to support layered execution of tasks based on defined execution order.
- Introduced `ExecutionUnit` struct to encapsulate task details and facilitate execution.
- Added `execution_order` module to manage task dependencies and validate execution constraints.
- Updated `make` command to accept multiple tags and expanded composite tags resolution.
- Enhanced error handling for invalid execution orders and unknown tags.
- Modified Ansible playbook to define execution order for specific tools.
- Improved test coverage for tag resolution and command execution.