### PR TITLE
Add mev binary action and improve setup workflows

### DIFF
--- a/.github/actions/download-mev-binary/action.yml
+++ b/.github/actions/download-mev-binary/action.yml
@@ -1,0 +1,20 @@
+name: Download mev binary
+description: Download the mev binary built earlier in the workflow run
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download mev binary
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: mev-${{ runner.os }}-${{ runner.arch }}
+        path: ${{ runner.temp }}/mev-bin
+
+    - name: Verify mev binary
+      shell: bash
+      run: |
+        set -euo pipefail
+        binary_path="$RUNNER_TEMP/mev-bin/mev"
+        chmod +x "$binary_path"
+        test -x "$binary_path"
+        "$binary_path" --version

--- a/.github/workflows/setup-brew-formulae.yml
+++ b/.github/workflows/setup-brew-formulae.yml
@@ -15,8 +15,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
@@ -24,4 +24,5 @@ jobs:
       - name: Run Homebrew formulae setup for common
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ github.token }}
-        run: mise exec -- just run make brew-formulae
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make brew-formulae

--- a/.github/workflows/setup-bun.yml
+++ b/.github/workflows/setup-bun.yml
@@ -15,14 +15,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
       - name: Run bun-platform setup
-        run: mise exec -- just run make bun-platform
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make bun-platform
 
       - name: Verify Bun after bun-platform setup
         run: |
@@ -30,7 +31,8 @@ jobs:
           bun --revision
 
       - name: Run bun-tools setup
-        run: mise exec -- just run make bun-tools
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make bun-tools
 
       - name: Verify Bun after bun-tools setup
         run: |

--- a/.github/workflows/setup-go.yml
+++ b/.github/workflows/setup-go.yml
@@ -15,11 +15,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
       - name: Setup go
-        run: mise exec -- just run make go
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make go

--- a/.github/workflows/setup-ide.yml
+++ b/.github/workflows/setup-ide.yml
@@ -15,20 +15,24 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
       - name: Setup VSCode configuration
-        run: mise exec -- just run make vscode
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make vscode
 
       - name: Setup Antigravity configuration
-        run: mise exec -- just run make antigravity
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make antigravity
 
       - name: Setup Zed configuration
-        run: mise exec -- just run make zed
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make zed
 
       - name: Setup Xcode configuration
-        run: mise exec -- just run make xcode
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make xcode

--- a/.github/workflows/setup-nodejs.yml
+++ b/.github/workflows/setup-nodejs.yml
@@ -15,17 +15,20 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
       - name: Run nodejs-platform setup
-        run: mise exec -- just run make nodejs-platform
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make nodejs-platform
 
       - name: Run nodejs-tools setup
-        run: mise exec -- just run make nodejs-tools
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make nodejs-tools
 
       - name: Setup Node.js LLM Tools
-        run: mise exec -- just run make coder
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make coder

--- a/.github/workflows/setup-nvim.yml
+++ b/.github/workflows/setup-nvim.yml
@@ -22,7 +22,9 @@ jobs:
         uses: ./.github/actions/setup-ansible
 
       - name: Setup Neovim configuration
+        shell: bash
         run: |
+          set -euo pipefail
           "$RUNNER_TEMP/mev-bin/mev" make nvim
 
       - name: Verify Neovim symlinks

--- a/.github/workflows/setup-nvim.yml
+++ b/.github/workflows/setup-nvim.yml
@@ -15,14 +15,15 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
       - name: Setup Neovim configuration
-        run: mise exec -- just run make nvim
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make nvim
 
       - name: Verify Neovim symlinks
         shell: bash

--- a/.github/workflows/setup-python.yml
+++ b/.github/workflows/setup-python.yml
@@ -15,14 +15,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
       - name: Run python-platform setup
-        run: mise exec -- just run make python-platform
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make python-platform
 
       - name: Run python-tools setup
-        run: mise exec -- just run make python-tools
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make python-tools

--- a/.github/workflows/setup-ruby.yml
+++ b/.github/workflows/setup-ruby.yml
@@ -15,11 +15,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
       - name: Setup ruby
-        run: mise exec -- just run make ruby
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make ruby

--- a/.github/workflows/setup-rust.yml
+++ b/.github/workflows/setup-rust.yml
@@ -15,11 +15,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
       - name: Setup rust
-        run: mise exec -- just run make rust
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make rust

--- a/.github/workflows/setup-system.yml
+++ b/.github/workflows/setup-system.yml
@@ -15,30 +15,36 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build
+      - name: Download mev binary
+        uses: ./.github/actions/download-mev-binary
 
       - name: Setup Ansible environment
         uses: ./.github/actions/setup-ansible
 
       - name: Setup Git configuration
-        run: mise exec -- just run make git
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make git
 
       - name: Setup GitHub CLI configuration
-        run: mise exec -- just run make gh
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make gh
 
       - name: Setup shell configuration
-        run: mise exec -- just run make shell
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make shell
         
       - name: Test shell aliases functionality
         shell: zsh {0}
         run: |
           set -euo pipefail
+          export PATH="$RUNNER_TEMP/mev-bin:${PATH}"
           source ~/.zshrc
           mk --version
 
       - name: Setup SSH configuration
-        run: mise exec -- just run make ssh
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make ssh
 
       - name: Apply macOS system defaults
-        run: mise exec -- just run make system
+        run: |
+          "$RUNNER_TEMP/mev-bin/mev" make system

--- a/.github/workflows/verify-ansible-setup.yml
+++ b/.github/workflows/verify-ansible-setup.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/verify-ansible-setup.yml'
       - '.github/actions/setup-build/**'
       - '.github/actions/setup-ansible/**'
+      - '.github/actions/download-mev-binary/**'
   pull_request:
     branches: [ "main" ]
     paths:
@@ -17,6 +18,7 @@ on:
       - '.github/workflows/verify-ansible-setup.yml'
       - '.github/actions/setup-build/**'
       - '.github/actions/setup-ansible/**'
+      - '.github/actions/download-mev-binary/**'
   workflow_dispatch:
     inputs:
       target:
@@ -56,6 +58,20 @@ jobs:
       setup_ide: ${{ steps.filter.outputs.setup_ide }}
       setup_system: ${{ steps.filter.outputs.setup_system }}
       setup_brew_formulae: ${{ steps.filter.outputs.setup_brew_formulae }}
+      any_setup: >-
+        ${{
+          steps.filter.outputs.all_setups == 'true' ||
+          steps.filter.outputs.setup_python == 'true' ||
+          steps.filter.outputs.setup_nodejs == 'true' ||
+          steps.filter.outputs.setup_bun == 'true' ||
+          steps.filter.outputs.setup_ruby == 'true' ||
+          steps.filter.outputs.setup_rust == 'true' ||
+          steps.filter.outputs.setup_go == 'true' ||
+          steps.filter.outputs.setup_nvim == 'true' ||
+          steps.filter.outputs.setup_ide == 'true' ||
+          steps.filter.outputs.setup_system == 'true' ||
+          steps.filter.outputs.setup_brew_formulae == 'true'
+        }}
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -73,6 +89,7 @@ jobs:
               - 'src/assets/ansible/ansible.cfg'
               - '.github/actions/setup-build/**'
               - '.github/actions/setup-ansible/**'
+              - '.github/actions/download-mev-binary/**'
             setup_python:
               - 'src/assets/ansible/roles/python/**'
               - '.github/workflows/setup-python.yml'
@@ -108,8 +125,47 @@ jobs:
               - 'src/assets/ansible/roles/brew/**'
               - '.github/workflows/setup-brew-formulae.yml'
 
-  setup-python:
+  build-mev:
+    name: Build mev binary
     needs: changes
+    runs-on: macos-15
+    permissions:
+      contents: read
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.any_setup == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build
+
+      - name: Build mev binary
+        run: cargo build --release --locked
+
+      - name: Prepare mev binary artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/mev-artifact"
+          cp target/release/mev "$RUNNER_TEMP/mev-artifact/mev"
+          chmod +x "$RUNNER_TEMP/mev-artifact/mev"
+
+      - name: Upload mev binary artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mev-${{ runner.os }}-${{ runner.arch }}
+          path: ${{ runner.temp }}/mev-artifact/mev
+          if-no-files-found: error
+          retention-days: 1
+
+  setup-python:
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |
@@ -119,7 +175,9 @@ jobs:
     uses: ./.github/workflows/setup-python.yml
 
   setup-nodejs:
-    needs: changes
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |
@@ -129,7 +187,9 @@ jobs:
     uses: ./.github/workflows/setup-nodejs.yml
 
   setup-bun:
-    needs: changes
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |
@@ -139,7 +199,9 @@ jobs:
     uses: ./.github/workflows/setup-bun.yml
 
   setup-ruby:
-    needs: changes
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |
@@ -149,7 +211,9 @@ jobs:
     uses: ./.github/workflows/setup-ruby.yml
 
   setup-rust:
-    needs: changes
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |
@@ -159,7 +223,9 @@ jobs:
     uses: ./.github/workflows/setup-rust.yml
 
   setup-go:
-    needs: changes
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |
@@ -169,7 +235,9 @@ jobs:
     uses: ./.github/workflows/setup-go.yml
 
   setup-nvim:
-    needs: changes
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |
@@ -179,7 +247,9 @@ jobs:
     uses: ./.github/workflows/setup-nvim.yml
 
   setup-ide:
-    needs: changes
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |
@@ -189,7 +259,9 @@ jobs:
     uses: ./.github/workflows/setup-ide.yml
 
   setup-system:
-    needs: changes
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |
@@ -199,7 +271,9 @@ jobs:
     uses: ./.github/workflows/setup-system.yml
 
   setup-brew-formulae:
-    needs: changes
+    needs:
+      - changes
+      - build-mev
     permissions:
       contents: read
     if: |

--- a/src/assets/ansible/roles/brew/tasks/cask.yml
+++ b/src/assets/ansible/roles/brew/tasks/cask.yml
@@ -39,10 +39,11 @@
 
 - name: "Install selected cask packages"
   community.general.homebrew_cask:
-    name: "{{ item }}"
+    name: "{{ brew_requested_cask_tokens }}"
     state: present
-  loop: "{{ brew_requested_cask_tokens }}"
-  when: brew_cask_tokens is defined
+  when:
+    - brew_cask_tokens is defined
+    - brew_requested_cask_tokens | length > 0
 
 - name: "Install global cask packages"
   ansible.builtin.command:

--- a/src/assets/ansible/roles/brew/tasks/cask.yml
+++ b/src/assets/ansible/roles/brew/tasks/cask.yml
@@ -32,18 +32,21 @@
 
 - name: "Reject unknown selected cask tokens"
   ansible.builtin.fail:
-    msg: "Unknown Homebrew cask tokens: {{ brew_requested_cask_tokens | difference(brew_available_cask_tokens) | join(', ') }}"
+    msg: >-
+      Unknown Homebrew cask tokens:
+      {{ brew_requested_cask_tokens | default([]) | difference(brew_available_cask_tokens | default([])) | join(', ') }}
   when:
     - brew_cask_tokens is defined
-    - (brew_requested_cask_tokens | difference(brew_available_cask_tokens) | length) > 0
+    - (brew_requested_cask_tokens | default([]) | difference(brew_available_cask_tokens | default([])) | length) > 0
 
 - name: "Install selected cask packages"
   community.general.homebrew_cask:
-    name: "{{ brew_requested_cask_tokens }}"
+    name: "{{ item }}"
     state: present
+  loop: "{{ brew_requested_cask_tokens | default([]) }}"
   when:
     - brew_cask_tokens is defined
-    - brew_requested_cask_tokens | length > 0
+    - brew_requested_cask_tokens | default([]) | length > 0
 
 - name: "Install global cask packages"
   ansible.builtin.command:

--- a/src/assets/ansible/roles/brew/tasks/formulae.yml
+++ b/src/assets/ansible/roles/brew/tasks/formulae.yml
@@ -39,23 +39,27 @@
 
 - name: "Reject unknown selected tap tokens"
   ansible.builtin.fail:
-    msg: "Unknown Homebrew tap tokens: {{ brew_requested_tap_tokens | difference(brew_available_tap_tokens) | join(', ') }}"
+    msg: >-
+      Unknown Homebrew tap tokens:
+      {{ brew_requested_tap_tokens | default([]) | difference(brew_available_tap_tokens | default([])) | join(', ') }}
   when:
     - brew_formula_tokens is defined or brew_tap_tokens is defined
-    - (brew_requested_tap_tokens | difference(brew_available_tap_tokens) | length) > 0
+    - (brew_requested_tap_tokens | default([]) | difference(brew_available_tap_tokens | default([])) | length) > 0
 
 - name: "Reject unknown selected formula tokens"
   ansible.builtin.fail:
-    msg: "Unknown Homebrew formula tokens: {{ brew_requested_formula_tokens | difference(brew_available_formula_tokens) | join(', ') }}"
+    msg: >-
+      Unknown Homebrew formula tokens:
+      {{ brew_requested_formula_tokens | default([]) | difference(brew_available_formula_tokens | default([])) | join(', ') }}
   when:
     - brew_formula_tokens is defined or brew_tap_tokens is defined
-    - (brew_requested_formula_tokens | difference(brew_available_formula_tokens) | length) > 0
+    - (brew_requested_formula_tokens | default([]) | difference(brew_available_formula_tokens | default([])) | length) > 0
 
 - name: "Install selected Homebrew taps"
   community.general.homebrew_tap:
     name: "{{ item }}"
     state: present
-  loop: "{{ brew_requested_tap_tokens }}"
+  loop: "{{ brew_requested_tap_tokens | default([]) }}"
   when: brew_formula_tokens is defined or brew_tap_tokens is defined
 
 - name: "Install selected formulae packages"
@@ -64,7 +68,7 @@
     state: present
   when:
     - brew_formula_tokens is defined or brew_tap_tokens is defined
-    - brew_requested_formula_tokens | length > 0
+    - brew_requested_formula_tokens | default([]) | length > 0
 
 - name: "Install global formulae packages"
   ansible.builtin.command:

--- a/src/assets/ansible/roles/brew/tasks/formulae.yml
+++ b/src/assets/ansible/roles/brew/tasks/formulae.yml
@@ -60,10 +60,11 @@
 
 - name: "Install selected formulae packages"
   community.general.homebrew:
-    name: "{{ item }}"
+    name: "{{ brew_requested_formula_tokens }}"
     state: present
-  loop: "{{ brew_requested_formula_tokens }}"
-  when: brew_formula_tokens is defined or brew_tap_tokens is defined
+  when:
+    - brew_formula_tokens is defined or brew_tap_tokens is defined
+    - brew_requested_formula_tokens | length > 0
 
 - name: "Install global formulae packages"
   ansible.builtin.command:

--- a/src/assets/ansible/roles/editor/tasks/antigravity-ide.yml
+++ b/src/assets/ansible/roles/editor/tasks/antigravity-ide.yml
@@ -29,9 +29,15 @@
   ansible.builtin.set_fact:
     editor_antigravity_ide_extensions: "{{ (editor_antigravity_ide_extensions_content.content | b64decode | from_json).extensions }}"
 
+- name: "Read installed Antigravity IDE extensions"
+  ansible.builtin.command: "agy-ide --list-extensions"
+  register: editor_antigravity_ide_installed_extensions
+  changed_when: false
+
 - name: "Install Antigravity IDE extensions"
-  ansible.builtin.command: "agy-ide --install-extension {{ item }} --force"
+  ansible.builtin.command: "agy-ide --install-extension {{ item }}"
   loop: "{{ editor_antigravity_ide_extensions }}"
+  when: item not in editor_antigravity_ide_installed_extensions.stdout_lines
   changed_when: true
 
 - name: "Ensure Antigravity IDE agent skills parent directory exists"

--- a/src/assets/ansible/roles/editor/tasks/antigravity-ide.yml
+++ b/src/assets/ansible/roles/editor/tasks/antigravity-ide.yml
@@ -37,7 +37,7 @@
 - name: "Install Antigravity IDE extensions"
   ansible.builtin.command: "agy-ide --install-extension {{ item }}"
   loop: "{{ editor_antigravity_ide_extensions }}"
-  when: item not in editor_antigravity_ide_installed_extensions.stdout_lines
+  when: item | lower not in editor_antigravity_ide_installed_extensions.stdout_lines | map('lower') | list
   changed_when: true
 
 - name: "Ensure Antigravity IDE agent skills parent directory exists"

--- a/src/assets/ansible/roles/editor/tasks/vscode.yml
+++ b/src/assets/ansible/roles/editor/tasks/vscode.yml
@@ -37,6 +37,5 @@
 - name: "Install VS Code extensions"
   ansible.builtin.command: "code --install-extension {{ item }}"
   loop: "{{ editor_vscode_extensions }}"
-  when: item not in editor_vscode_installed_extensions.stdout_lines
+  when: item | lower not in editor_vscode_installed_extensions.stdout_lines | map('lower') | list
   changed_when: true
-  ignore_errors: true # noqa: ignore-errors

--- a/src/assets/ansible/roles/editor/tasks/vscode.yml
+++ b/src/assets/ansible/roles/editor/tasks/vscode.yml
@@ -29,8 +29,14 @@
   ansible.builtin.set_fact:
     editor_vscode_extensions: "{{ (editor_vscode_extensions_content.content | b64decode | from_json).extensions }}"
 
+- name: "Read installed VS Code extensions"
+  ansible.builtin.command: "code --list-extensions"
+  register: editor_vscode_installed_extensions
+  changed_when: false
+
 - name: "Install VS Code extensions"
-  ansible.builtin.command: "code --install-extension {{ item }} --force"
+  ansible.builtin.command: "code --install-extension {{ item }}"
   loop: "{{ editor_vscode_extensions }}"
-  register: editor_vscode_install_result
-  changed_when: "'was successfully installed' in editor_vscode_install_result.stdout"
+  when: item not in editor_vscode_installed_extensions.stdout_lines
+  changed_when: true
+  ignore_errors: true # noqa: ignore-errors


### PR DESCRIPTION
Provide a composite action that downloads and verifies the mev artifact and
add a build-mev job to build/upload the binary for workflows to consume. Switch setup workflows to download and invoke the mev binary from RUNNER_TEMP
for make targets. Fix Ansible roles to skip installs when token lists are
empty and avoid re-installing VS Code/Antigravity extensions, tightening changed_when/ignore_errors. Ensure mk is reachable in shell tests by adding
the mev bin dir to PATH.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MEV binary build and download mechanism for CI/CD workflows.

* **Chores**
  * Optimized workflow setup by using precompiled binaries instead of build-time compilation.
  * Improved IDE extension installation to avoid unnecessary reinstalls of already-installed extensions.
  * Enhanced Homebrew package installation efficiency with bulk operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->