### PR TITLE
feat: add AGENTS.md symlinks for Zed and Antigravity

### DIFF
--- a/src/assets/ansible/roles/editor/tasks/zed.yml
+++ b/src/assets/ansible/roles/editor/tasks/zed.yml
@@ -16,3 +16,11 @@
       dest: settings.json
     - src: keymap.json
       dest: keymap.json
+
+- name: "Symlink Zed AGENTS file"
+  ansible.builtin.file:
+    src: "{{ local_config_root }}/nodejs/global/coder/AGENTS.md"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/zed/AGENTS.md"
+    state: link
+    force: true
+    mode: "0644"

--- a/src/assets/ansible/roles/nodejs/tasks/coder.yml
+++ b/src/assets/ansible/roles/nodejs/tasks/coder.yml
@@ -74,6 +74,20 @@
     force: true
     mode: "0644"
 
+- name: "Ensure Antigravity configuration directory exists"
+  ansible.builtin.file:
+    path: "{{ ansible_facts['env']['HOME'] }}/.config/google/antigravity"
+    state: directory
+    mode: "0755"
+
+- name: "Symlink Antigravity AGENTS file"
+  ansible.builtin.file:
+    src: "{{ local_config_root }}/nodejs/global/coder/AGENTS.md"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.config/google/antigravity/AGENTS.md"
+    state: link
+    force: true
+    mode: "0644"
+
 - name: "Check if Gemini CLI is available"
   ansible.builtin.command: "fnm exec --using={{ nodejs_version }} -- which gemini"
   register: nodejs_gemini_cli_check


### PR DESCRIPTION
- Deploy AGENTS.md to Zed configuration directory (~/.config/zed/)
- Deploy AGENTS.md to Antigravity configuration directory (~/.config/google/antigravity/)
- Ensure consistent LLM agent rules across all IDEs and CLIs
- Antigravity IDE and CLI now share same agent skills configuration