### PR TITLE
Add TOON skill and standardize agent skill deployment

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ The pnpm role uses `src/assets/ansible/roles/pnpm/config/global/global-packages.
 The pipx role uses `src/assets/ansible/roles/pipx/config/global/tools.yml` to declare isolated Python applications by `package`, with optional `version`, `install_spec`, `inject`, and `post_install.argv` fields.
 The rust-cli role uses `src/assets/ansible/roles/rust_cli/config/global/tools.yml` to declare GitHub Release binaries.
 The Coder role stores each tool's configuration under its tool name and uses the deployed file's actual name.
+The Coder role stores agent skills once and deploys them to the interoperable `~/.agents/skills/` location plus tool-specific locations required by Claude Code and Antigravity.
 The system role uses `src/assets/ansible/roles/system/config/global/default_apps.yml` to declare default applications grouped by application bundle identifier.
 
 ### System Default Applications

--- a/src/assets/ansible/roles/coder/config/global/skills-targets.yml
+++ b/src/assets/ansible/roles/coder/config/global/skills-targets.yml
@@ -1,10 +1,13 @@
 ---
-tools:
-  codex:
-    skills_dir: ".codex/skills"
+targets:
+  agent-skills-standard:
+    skills_dir: ".agents/skills"
   claude:
     skills_dir: ".claude/skills"
-  agy-ide:
+  antigravity-ide:
     skills_dir: ".config/google/antigravity/skills"
-  agy:
+  antigravity-cli:
     skills_dir: ".gemini/antigravity-cli/skills"
+retired_targets:
+  codex:
+    skills_dir: ".codex/skills"

--- a/src/assets/ansible/roles/coder/config/global/skills/effective-prompting/agents/openai.yaml
+++ b/src/assets/ansible/roles/coder/config/global/skills/effective-prompting/agents/openai.yaml
@@ -1,5 +1,0 @@
----
-interface:
-  display_name: "Effective Prompter"
-  short_description: "Design prompts for goal-output alignment with minimal cognitive and maintenance load"
-  default_prompt: "Use $effective-prompting to design prompts for better effectiveness."

--- a/src/assets/ansible/roles/coder/config/global/skills/google-jules/agents/openai.yaml
+++ b/src/assets/ansible/roles/coder/config/global/skills/google-jules/agents/openai.yaml
@@ -1,5 +1,0 @@
----
-interface:
-  display_name: "Google Jules"
-  short_description: "Understand Jules before discussing Jules or Jules API"
-  default_prompt: "Use $google-jules to understand the Jules service model before discussing Jules or Jules API."

--- a/src/assets/ansible/roles/coder/config/global/skills/svo-cli-design/agents/openai.yaml
+++ b/src/assets/ansible/roles/coder/config/global/skills/svo-cli-design/agents/openai.yaml
@@ -1,5 +1,0 @@
----
-interface:
-  display_name: "SVO CLI Designer"
-  short_description: "Design CLI commands with SVO-first structure"
-  default_prompt: "Use $svo-cli-design to review this CLI proposal and produce SVO-first changes."

--- a/src/assets/ansible/roles/coder/config/global/skills/task-doc/agents/openai.yaml
+++ b/src/assets/ansible/roles/coder/config/global/skills/task-doc/agents/openai.yaml
@@ -1,5 +1,0 @@
----
-interface:
-  display_name: "Task Doc Writer"
-  short_description: "Organize requirements and tasks into task documents"
-  default_prompt: "Use $task-doc to organize this into a task document."

--- a/src/assets/ansible/roles/coder/config/global/skills/toon/SKILL.md
+++ b/src/assets/ansible/roles/coder/config/global/skills/toon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: toon
-description: Use the TOON CLI when inspecting or producing substantial or repeatedly handled JSON-compatible structured data such as JSON files, API responses, database rows, search results, and structured logs, to reduce cumulative agent-context tokens.
+description: Use the TOON CLI whenever a task inspects or produces JSON-compatible structured data such as JSON files, API responses, database rows, search results, and structured logs. This skill applies before that data enters agent context or is authored by the agent.
 ---
 
 # TOON
@@ -11,30 +11,15 @@ TOON is a temporary, lossless representation of the JSON data model for reducing
 
 JSON remains the canonical interchange and file format unless the task explicitly requires TOON.
 
-## Selection
-
-Use TOON when JSON-compatible structured data is substantial or will be handled repeatedly during the session, especially uniform arrays of objects.
-
-Judge benefit by repeated structure and expected cumulative context cost, not by a fixed row-count threshold. Small inputs can justify TOON when similar data will be read or produced repeatedly.
-
-Keep JSON or use another suitable format when the data is one-off and trivially small, deeply nested, non-uniform, an array of arrays, or already a simple table better represented as CSV.
-
-When the benefit is uncertain, compare token estimates without loading the source JSON into agent context:
-
-```sh
-mkdir -p .tmp
-toon input.json --stats -o .tmp/input.toon
-```
-
 ## Input Normalization
 
-TOON accepts one JSON value, not newline-delimited JSON (NDJSON/JSONL). Slurp NDJSON into an array before encoding it:
+TOON accepts one JSON value rather than newline-delimited JSON (NDJSON/JSONL), so NDJSON is slurped into an array before encoding:
 
 ```sh
 jq -s '.' events.ndjson | toon
 ```
 
-Reduce inputs to the required rows and fields before encoding when the task needs only part of the data:
+Inputs are reduced to the required rows and fields before encoding when the task needs only part of the data:
 
 ```sh
 jq '{items: [.items[] | {id, name, status}]}' response.json | toon
@@ -42,25 +27,25 @@ jq '{items: [.items[] | {id, name, status}]}' response.json | toon
 
 ## Reading Structured Data
 
-Read the CLI's TOON output instead of first reading the source JSON into agent context.
+The workflow reads the CLI's TOON output instead of first reading the source JSON into agent context.
 
 ```sh
 toon large-response.json
 curl -fsSL https://api.example.com/items | toon
 ```
 
-Persist converted data under the project-root `.tmp/` directory:
+Converted data is persisted under the project-root `.tmp/` directory:
 
 ```sh
 mkdir -p .tmp
 toon large-response.json --stats -o .tmp/large-response.toon
 ```
 
-Do not read both the complete source JSON and its TOON representation unless comparison is required by the task.
+The complete source JSON and its TOON representation are not both read unless comparison is required by the task.
 
 ## Producing Structured Data
 
-For substantial or repeatedly produced JSON-compatible output, author TOON in the project-root `.tmp/` directory and decode it with strict validation into another temporary file:
+JSON-compatible output is authored as TOON in the project-root `.tmp/` directory and decoded with strict validation into another temporary file:
 
 ```sh
 mkdir -p .tmp
@@ -68,7 +53,7 @@ output="$(mktemp .tmp/generated.XXXXXX)"
 toon .tmp/generated.toon -o "$output"
 ```
 
-For stdin, specify decode direction explicitly:
+For stdin, decode direction is specified explicitly:
 
 ```sh
 mkdir -p .tmp
@@ -76,31 +61,31 @@ output="$(mktemp .tmp/generated.XXXXXX)"
 toon --decode -o "$output" < .tmp/generated.toon
 ```
 
-Validate the decoded JSON syntax:
+The decoded JSON syntax is validated:
 
 ```sh
 jq empty "$output"
 ```
 
-`jq empty` proves only that the output is valid JSON. Run task-specific checks for required values, counts, and schema before moving it.
+`jq empty` proves only that the output is valid JSON. Task-specific checks for required values, counts, and schema are run before moving it.
 
-Move the output to the required path only after all validation succeeds:
+The output is moved to the required path only after all validation succeeds:
 
 ```sh
 mv "$output" generated.json
 ```
 
-Treat the generated JSON as the deliverable unless the task explicitly requests TOON.
+The generated JSON is the deliverable unless the task explicitly requests TOON.
 
 ## Validation
 
 The `toon` command uses strict decoding by default. Strict decoding validates array counts, indentation, headers, and escaping.
 
-Always decode agent-authored TOON before using it as JSON. A decode failure means the TOON must be corrected.
+Agent-authored TOON is decoded before use as JSON. A decode failure means the TOON must be corrected.
 
-Never decode directly to the final output path. The CLI can leave partial JSON output when strict decoding fails. Use a new temporary output for each decode, then move it to the final path only after decode and JSON validation succeed.
+Decoding does not target the final output path directly. The CLI can leave partial JSON output when strict decoding fails. A new temporary output is used for each decode, and it is moved to the final path only after decode and JSON validation succeed.
 
-Do not use `--no-strict` to accept malformed agent-authored TOON. Surface missing CLI availability or conversion failures instead of silently falling back.
+`--no-strict` is not used to accept malformed agent-authored TOON. Missing CLI availability or conversion failures are surfaced instead of silently falling back.
 
 ## Required Syntax
 

--- a/src/assets/ansible/roles/coder/config/global/skills/toon/SKILL.md
+++ b/src/assets/ansible/roles/coder/config/global/skills/toon/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: toon
+description: Use the TOON CLI when inspecting or producing substantial or repeatedly handled JSON-compatible structured data such as JSON files, API responses, database rows, search results, and structured logs, to reduce cumulative agent-context tokens.
+---
+
+# TOON
+
+## Purpose
+
+TOON is a temporary, lossless representation of the JSON data model for reducing the tokens required to read or produce structured data.
+
+JSON remains the canonical interchange and file format unless the task explicitly requires TOON.
+
+## Selection
+
+Use TOON when JSON-compatible structured data is substantial or will be handled repeatedly during the session, especially uniform arrays of objects.
+
+Judge benefit by repeated structure and expected cumulative context cost, not by a fixed row-count threshold. Small inputs can justify TOON when similar data will be read or produced repeatedly.
+
+Keep JSON or use another suitable format when the data is one-off and trivially small, deeply nested, non-uniform, an array of arrays, or already a simple table better represented as CSV.
+
+When the benefit is uncertain, compare token estimates without loading the source JSON into agent context:
+
+```sh
+mkdir -p .tmp
+toon input.json --stats -o .tmp/input.toon
+```
+
+## Input Normalization
+
+TOON accepts one JSON value, not newline-delimited JSON (NDJSON/JSONL). Slurp NDJSON into an array before encoding it:
+
+```sh
+jq -s '.' events.ndjson | toon
+```
+
+Reduce inputs to the required rows and fields before encoding when the task needs only part of the data:
+
+```sh
+jq '{items: [.items[] | {id, name, status}]}' response.json | toon
+```
+
+## Reading Structured Data
+
+Read the CLI's TOON output instead of first reading the source JSON into agent context.
+
+```sh
+toon large-response.json
+curl -fsSL https://api.example.com/items | toon
+```
+
+Persist converted data under the project-root `.tmp/` directory:
+
+```sh
+mkdir -p .tmp
+toon large-response.json --stats -o .tmp/large-response.toon
+```
+
+Do not read both the complete source JSON and its TOON representation unless comparison is required by the task.
+
+## Producing Structured Data
+
+For substantial or repeatedly produced JSON-compatible output, author TOON in the project-root `.tmp/` directory and decode it with strict validation into another temporary file:
+
+```sh
+mkdir -p .tmp
+output="$(mktemp .tmp/generated.XXXXXX)"
+toon .tmp/generated.toon -o "$output"
+```
+
+For stdin, specify decode direction explicitly:
+
+```sh
+mkdir -p .tmp
+output="$(mktemp .tmp/generated.XXXXXX)"
+toon --decode -o "$output" < .tmp/generated.toon
+```
+
+Validate the decoded JSON syntax:
+
+```sh
+jq empty "$output"
+```
+
+`jq empty` proves only that the output is valid JSON. Run task-specific checks for required values, counts, and schema before moving it.
+
+Move the output to the required path only after all validation succeeds:
+
+```sh
+mv "$output" generated.json
+```
+
+Treat the generated JSON as the deliverable unless the task explicitly requests TOON.
+
+## Validation
+
+The `toon` command uses strict decoding by default. Strict decoding validates array counts, indentation, headers, and escaping.
+
+Always decode agent-authored TOON before using it as JSON. A decode failure means the TOON must be corrected.
+
+Never decode directly to the final output path. The CLI can leave partial JSON output when strict decoding fails. Use a new temporary output for each decode, then move it to the final path only after decode and JSON validation succeed.
+
+Do not use `--no-strict` to accept malformed agent-authored TOON. Surface missing CLI availability or conversion failures instead of silently falling back.
+
+## Required Syntax
+
+Objects use `key: value`, and nesting uses two-space indentation:
+
+```toon
+user:
+  id: 1
+  name: Alice
+  active: true
+```
+
+Primitive arrays declare their element count:
+
+```toon
+tags[3]: rust,cli,macos
+```
+
+Uniform arrays of objects declare the row count and field order once:
+
+```toon
+users[2]{id,name,active}:
+  1,Alice,true
+  2,Bob,false
+```
+
+`[N]` is the array element count. `{fields}` defines the field order for every following row.
+
+Quote strings that could be interpreted as another type or contain structural characters:
+
+```toon
+version: "123"
+enabled: "true"
+note: "hello, world"
+```
+
+Rely on strict decoding rather than manually reasoning about uncommon syntax and escaping cases.

--- a/src/assets/ansible/roles/coder/tasks/main.yml
+++ b/src/assets/ansible/roles/coder/tasks/main.yml
@@ -101,7 +101,7 @@
 
 - name: "Load agent skills targets"
   ansible.builtin.set_fact:
-    coder_skills_targets: "{{ lookup('file', local_config_root + '/coder/global/skills-targets.yml') | from_yaml }}"
+    coder_skills_target_config: "{{ lookup('file', local_config_root + '/coder/global/skills-targets.yml') | from_yaml }}"
 
 - name: "Discover global agent skills"
   ansible.builtin.find:
@@ -123,7 +123,7 @@
     path: "{{ ansible_facts['env']['HOME'] }}/{{ item.value.skills_dir }}"
     state: directory
     mode: "0755"
-  loop: "{{ coder_skills_targets.tools | dict2items }}"
+  loop: "{{ coder_skills_target_config.targets | dict2items }}"
 
 - name: "Find deployed agent skill links"
   ansible.builtin.find:
@@ -131,7 +131,7 @@
     file_type: link
     depth: 1
   register: coder_deployed_skill_links
-  loop: "{{ coder_skills_targets.tools | dict2items }}"
+  loop: "{{ coder_skills_target_config.targets | dict2items }}"
 
 - name: "Remove stale managed agent skill links"
   ansible.builtin.file:
@@ -142,11 +142,39 @@
     - (item.lnk_target | default('')).startswith(coder_skills_source_root ~ '/')
     - item.path | basename not in coder_skills
 
+- name: "Inspect retired agent skills directories"
+  ansible.builtin.stat:
+    path: "{{ ansible_facts['env']['HOME'] }}/{{ item.value.skills_dir }}"
+  register: coder_retired_skills_directory_stats
+  loop: "{{ coder_skills_target_config.retired_targets | dict2items }}"
+
+- name: "Find retired agent skill links"
+  ansible.builtin.find:
+    paths: "{{ item.stat.path }}"
+    file_type: link
+    depth: 1
+  register: coder_retired_skill_links
+  loop: "{{ coder_retired_skills_directory_stats.results }}"
+  when:
+    - item.stat.isdir | default(false)
+
+- name: "Remove retired managed agent skill links"
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: >-
+    {{ coder_retired_skill_links.results
+       | selectattr('files', 'defined')
+       | map(attribute='files')
+       | flatten }}
+  when:
+    - (item.lnk_target | default('')).startswith(coder_skills_source_root ~ '/')
+
 - name: "Inspect deployed agent skill paths"
   ansible.builtin.stat:
     path: "{{ ansible_facts['env']['HOME'] }}/{{ item.1.value.skills_dir }}/{{ item.0 }}"
   register: coder_deployed_skill_stats
-  loop: "{{ coder_skills | product(coder_skills_targets.tools | dict2items) | list }}"
+  loop: "{{ coder_skills | product(coder_skills_target_config.targets | dict2items) | list }}"
 
 - name: "Reject agent skill file conflicts"
   ansible.builtin.fail:
@@ -187,10 +215,10 @@
     - not (item.skipped | default(false))
     - item.matched | default(0) | int == 0
 
-- name: "Deploy global agent skills to all tools"
+- name: "Deploy global agent skills to targets"
   ansible.builtin.file:
     src: "{{ coder_skills_source_root }}/{{ item.0 }}"
     dest: "{{ ansible_facts['env']['HOME'] }}/{{ item.1.value.skills_dir }}/{{ item.0 }}"
     state: link
     force: true
-  loop: "{{ coder_skills | product(coder_skills_targets.tools | dict2items) | list }}"
+  loop: "{{ coder_skills | product(coder_skills_target_config.targets | dict2items) | list }}"

--- a/src/assets/ansible/roles/pnpm/config/global/global-packages.json
+++ b/src/assets/ansible/roles/pnpm/config/global/global-packages.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "@github/copilot": "latest",
-    "@marp-team/marp-cli": "latest"
+    "@marp-team/marp-cli": "latest",
+    "@toon-format/cli": "latest"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration documentation specifying persistent agent skills storage location.
  * Added TOON workflow documentation for lossless, token-reducing JSON data representation.

* **Chores**
  * Reorganized skill target configuration structure and added support for retired skill targets.
  * Added TOON CLI as a global dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->