### PR TITLE
Support multiple targets for mev mk command

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,6 +17,7 @@ mev list                  # List available tags
 mev ls                    # Shorthand
 
 mev make rust             # Install and configure the Rust toolchain
+mev mk sh sys pipx -o     # Sequential execution (stops on error)
 mev make rust-cli         # Install Rust CLI binaries from GitHub Releases
 mev make bun              # Run Bun setup and global packages
 mev make b                # Shorthand

--- a/src/cli/make.rs
+++ b/src/cli/make.rs
@@ -7,8 +7,9 @@ use crate::provisioning::profile;
 
 #[derive(Args)]
 pub struct MakeArgs {
-    /// Ansible tag to run (e.g., rust, python, pipx, shell, br-c).
-    pub tag: String,
+    /// Ansible tags to run (e.g., rust, python, pipx, shell, br-c).
+    #[arg(required = true, num_args = 1..)]
+    pub tags: Vec<String>,
 
     /// Profile to use (global, macbook/mbk, mac-mini/mmn).
     #[arg(short = 'p', long, default_value = "global")]
@@ -25,5 +26,8 @@ pub struct MakeArgs {
 
 pub fn run(args: MakeArgs) -> Result<(), AppError> {
     let profile = profile::validate_profile(&args.profile)?;
-    crate::make(profile, &args.tag, args.overwrite, args.verbose)
+    for tag in args.tags {
+        crate::make(profile, &tag, args.overwrite, args.verbose)?;
+    }
+    Ok(())
 }

--- a/tests/cli/make.rs
+++ b/tests/cli/make.rs
@@ -159,6 +159,70 @@ fn make_rust_cli_and_alias_install_gh_before_running_owner_role() {
 }
 
 #[test]
+fn make_multiple_tags_executes_sequentially() {
+    let ctx = TestContext::new();
+    let ansible_path = install_ansible_recorder(&ctx);
+
+    ctx.cli()
+        .env("ANSIBLE_PLAYBOOK_BIN", &ansible_path)
+        .args(["make", "rust", "nodejs", "python"])
+        .assert()
+        .success();
+
+    let log = std::fs::read_to_string(ctx.work_dir().join("ansible-args.log")).unwrap();
+    let lines: Vec<&str> = log.lines().collect();
+
+    // rust (1 call)
+    // nodejs (2 calls: brew-formulae, nodejs)
+    // python (2 calls: brew-formulae, python)
+    // Total: 5 calls
+    assert_eq!(lines.len(), 5);
+    assert!(lines[0].contains("--tags rust"));
+    assert!(lines[1].contains("--tags brew-formulae"));
+    assert!(lines[1].contains(r#""brew_formula_tokens":["fnm"]"#));
+    assert!(lines[2].contains("--tags nodejs"));
+    assert!(lines[3].contains("--tags brew-formulae"));
+    assert!(lines[3].contains(r#""brew_formula_tokens":["uv"]"#));
+    assert!(lines[4].contains("--tags python"));
+}
+
+#[test]
+fn make_multiple_tags_stops_on_error() {
+    let ctx = TestContext::new();
+    let mocks_dir = ctx.work_dir().join(".local/pipx/venvs/ansible/bin");
+    std::fs::create_dir_all(&mocks_dir).unwrap();
+    let ansible_path = mocks_dir.join("ansible-playbook");
+
+    // Fails if "nodejs" tag is present
+    let recorder = r#"#!/bin/bash
+printf '%s\n' "$*" >> "$HOME/ansible-args.log"
+if [[ "$*" == *"--tags nodejs"* ]]; then
+    exit 1
+fi
+"#;
+    std::fs::write(&ansible_path, recorder).unwrap();
+    std::fs::set_permissions(&ansible_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    ctx.cli()
+        .env("ANSIBLE_PLAYBOOK_BIN", &ansible_path)
+        .args(["make", "rust", "nodejs", "python"])
+        .assert()
+        .failure();
+
+    let log = std::fs::read_to_string(ctx.work_dir().join("ansible-args.log")).unwrap();
+    let lines: Vec<&str> = log.lines().collect();
+
+    // 1. rust (success)
+    // 2. nodejs pre-phase (brew-formulae) (success)
+    // 3. nodejs (fails)
+    // python should not be executed.
+    assert_eq!(lines.len(), 3);
+    assert!(lines[0].contains("--tags rust"));
+    assert!(lines[1].contains("--tags brew-formulae"));
+    assert!(lines[2].contains("--tags nodejs"));
+}
+
+#[test]
 fn make_nodejs_installs_only_fnm_before_running_nodejs_role() {
     let ctx = TestContext::new();
     let ansible_path = install_ansible_recorder(&ctx);


### PR DESCRIPTION
This change allows specifying multiple targets for the `mev mk` (and `mev make`) command. Targets are executed in the order they are provided, and the process stops immediately if any target fails. All provided options like `--profile` or `--overwrite` are applied to every target in the sequence.

Fixes #930

---
*PR created automatically by Jules for task [17823024472678603985](https://jules.google.com/task/17823024472678603985) started by @akitorahayashi*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `make` command now accepts multiple tags for sequential execution
  * Execution stops on error and does not proceed to subsequent tags

* **Documentation**
  * Updated usage documentation with example command demonstrating sequential execution behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->