### PR TITLE
Refactor: consolidate execution plan, path resolution, and documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@
 | Application orchestration | `src/app/` | Use-case flow coordination and dependency composition |
 | Provisioning owner | `src/provisioning/` | Tag catalog, plan construction, playbook execution, role config deployment policy, provisioning assets resolution |
 | Identity owner | `src/identity/` | Identity model, identity persistence contract, Git identity contract and integrations |
-| Backup owner | `src/backup/` | Backup component resolution, system defaults backup, VSCode backup, backup integrations |
+| Backup owner | `src/backup/` | Backup component resolution, system defaults backup, code editor backup, backup integrations |
 | Update owner | `src/update/` | Version source contract and install script integration |
 | Shared kernel | `src/host_fs/` | Reusable host filesystem contract and std implementation |
 | Shared kernel | `src/error.rs` | Typed application error model |
@@ -31,6 +31,7 @@ src/
 ├── main.rs                # Binary entry point
 ├── lib.rs                 # Library root and public entrypoints
 ├── error.rs               # Shared typed errors
+├── config_dir.rs          # mev config directory path resolution
 ├── cli/                   # CLI boundary
 │   ├── mod.rs             # clap parser and top-level dispatch
 │   ├── create.rs
@@ -61,19 +62,15 @@ src/
 │       ├── locator.rs
 │       └── embedded.rs
 ├── identity/
-│   ├── identity.rs
+│   ├── model.rs
 │   ├── store.rs
 │   ├── git_config.rs
 │   ├── file_store.rs
 │   └── git_cli.rs
 ├── backup/
 │   ├── component.rs
-│   ├── system.rs
-│   ├── vscode.rs
-│   ├── macos_defaults_port.rs
-│   ├── macos_defaults_cli.rs
-│   ├── vscode_port.rs
-│   └── vscode_cli.rs
+│   ├── system/            # macOS defaults backup and defaults CLI integration
+│   └── code_editors.rs    # Editor extension/settings backup (VS Code, Antigravity IDE)
 ├── update/
 │   ├── version_source.rs
 │   └── install_script.rs

--- a/src/app/context.rs
+++ b/src/app/context.rs
@@ -6,6 +6,7 @@ use tempfile::TempDir;
 
 use crate::backup::code_editors::CodeEditorCli;
 use crate::backup::system::MacosDefaultsCli;
+use crate::config_dir;
 use crate::host_fs::std_fs::StdFs;
 use crate::identity::file_store::IdentityFileStore;
 use crate::identity::git_cli::GitCli;
@@ -31,17 +32,14 @@ pub struct AppContext {
 impl AppContext {
     /// Construct full context from a resolved provisioning assets directory.
     pub fn new(resolved_assets: ResolvedAnsibleDir) -> Result<Self, Box<dyn std::error::Error>> {
-        let home_dir =
-            dirs::home_dir().ok_or_else(|| "could not resolve home directory".to_string())?;
-        let local_config_root = home_dir.join(".config").join("mev").join("roles");
+        let home_dir = config_dir::home()?;
+        let local_config_root = config_dir::roles_root(&home_dir);
         let (provisioning_asset_root, provisioning_asset_root_temp_dir) =
             resolved_assets.into_parts();
 
         Ok(Self {
             provisioning: AnsibleRuntime::new(&provisioning_asset_root, &local_config_root)?,
-            identity_store: IdentityFileStore::new(
-                home_dir.join(".config").join("mev").join("identity.json"),
-            ),
+            identity_store: IdentityFileStore::new(config_dir::identity_file(&home_dir)),
             version_source: InstallScriptVersionSource,
             git: GitCli::default(),
             host_fs: StdFs,
@@ -56,15 +54,12 @@ impl AppContext {
 
     /// Construct a lightweight identity-only context.
     pub fn for_identity() -> Result<Self, Box<dyn std::error::Error>> {
-        let home_dir =
-            dirs::home_dir().ok_or_else(|| "could not resolve home directory".to_string())?;
-        let local_config_root = home_dir.join(".config").join("mev").join("roles");
+        let home_dir = config_dir::home()?;
+        let local_config_root = config_dir::roles_root(&home_dir);
 
         Ok(Self {
             provisioning: AnsibleRuntime::empty(&local_config_root),
-            identity_store: IdentityFileStore::new(
-                home_dir.join(".config").join("mev").join("identity.json"),
-            ),
+            identity_store: IdentityFileStore::new(config_dir::identity_file(&home_dir)),
             version_source: InstallScriptVersionSource,
             git: GitCli::default(),
             host_fs: StdFs,

--- a/src/app/provisioning/create.rs
+++ b/src/app/provisioning/create.rs
@@ -8,8 +8,8 @@ use crate::provisioning::profile::Profile;
 use crate::provisioning::role_configs;
 use crate::provisioning::runner::{PlaybookVars, ProvisioningRunner};
 
-const CASK_PHASE_TAG: &str = "brew-cask";
-const FORMULA_PHASE_TAG: &str = "brew-formulae";
+const CASK_PHASE_TAG: &str = ExecutionPlan::CASK_PHASE_TAG;
+const FORMULA_PHASE_TAG: &str = ExecutionPlan::FORMULA_PHASE_TAG;
 
 /// Execute the `create` command: deploy configs and run full setup tags.
 pub fn execute(
@@ -30,7 +30,7 @@ pub fn execute(
         return Err(AppError::InvalidTag(names.join(", ")));
     }
 
-    let plan = ExecutionPlan::full_setup(
+    let plan = ExecutionPlan::new(
         profile,
         full_setup_tags.to_vec(),
         ctx.provisioning.tap_requirements(),
@@ -41,7 +41,7 @@ pub fn execute(
 
     println!();
     println!("mev: Creating {} environment", plan.profile);
-    let runs_full_formulae = plan.tags.iter().any(|tag| tag == FORMULA_PHASE_TAG);
+    let runs_full_formulae = plan.runs_full_formulae();
     let setup_tags: Vec<String> = if runs_full_formulae {
         plan.tags.iter().filter(|tag| tag.as_str() != FORMULA_PHASE_TAG).cloned().collect()
     } else {
@@ -56,16 +56,7 @@ pub fn execute(
     println!();
 
     // Deploy configs for roles about to be executed
-    let mut config_tags = plan.tags.clone();
-    if (!plan.tap_tokens.is_empty() || !plan.formula_tokens.is_empty())
-        && !runs_full_formulae
-        && !config_tags.iter().any(|tag| tag == FORMULA_PHASE_TAG)
-    {
-        config_tags.push(FORMULA_PHASE_TAG.to_string());
-    }
-    if !plan.cask_tokens.is_empty() && !config_tags.iter().any(|tag| tag == CASK_PHASE_TAG) {
-        config_tags.push(CASK_PHASE_TAG.to_string());
-    }
+    let config_tags = plan.config_deployment_tags();
     role_configs::deploy_for_tags(
         &config_tags,
         &ctx.host_fs,

--- a/src/app/provisioning/create.rs
+++ b/src/app/provisioning/create.rs
@@ -42,11 +42,7 @@ pub fn execute(
     println!();
     println!("mev: Creating {} environment", plan.profile);
     let runs_full_formulae = plan.runs_full_formulae();
-    let setup_tags: Vec<String> = if runs_full_formulae {
-        plan.tags.iter().filter(|tag| tag.as_str() != FORMULA_PHASE_TAG).cloned().collect()
-    } else {
-        plan.tags.clone()
-    };
+    let setup_tags = plan.execution_tags();
     let formula_phase_count = usize::from(
         runs_full_formulae || !plan.tap_tokens.is_empty() || !plan.formula_tokens.is_empty(),
     );

--- a/src/app/provisioning/make.rs
+++ b/src/app/provisioning/make.rs
@@ -42,11 +42,7 @@ pub fn execute(
 
     // Deploy configs for roles about to be executed
     let runs_full_formulae = plan.runs_full_formulae();
-    let configure_tags: Vec<String> = if runs_full_formulae {
-        plan.tags.iter().filter(|tag| tag.as_str() != FORMULA_PHASE_TAG).cloned().collect()
-    } else {
-        plan.tags.clone()
-    };
+    let configure_tags = plan.execution_tags();
     let config_tags = plan.config_deployment_tags();
     role_configs::deploy_for_tags(
         &config_tags,

--- a/src/app/provisioning/make.rs
+++ b/src/app/provisioning/make.rs
@@ -9,8 +9,8 @@ use crate::provisioning::role_configs;
 use crate::provisioning::runner::{PlaybookVars, ProvisioningRunner};
 use crate::provisioning::tag_selection;
 
-const CASK_PHASE_TAG: &str = "brew-cask";
-const FORMULA_PHASE_TAG: &str = "brew-formulae";
+const CASK_PHASE_TAG: &str = ExecutionPlan::CASK_PHASE_TAG;
+const FORMULA_PHASE_TAG: &str = ExecutionPlan::FORMULA_PHASE_TAG;
 
 /// Execute the `make` command: deploy configs and run specified tags.
 pub fn execute(
@@ -31,7 +31,7 @@ pub fn execute(
         }
     }
 
-    let plan = ExecutionPlan::make(
+    let plan = ExecutionPlan::new(
         profile,
         tags_to_run,
         ctx.provisioning.tap_requirements(),
@@ -41,22 +41,13 @@ pub fn execute(
     );
 
     // Deploy configs for roles about to be executed
-    let mut config_tags = plan.tags.clone();
-    let runs_full_formulae = plan.tags.iter().any(|tag| tag == FORMULA_PHASE_TAG);
+    let runs_full_formulae = plan.runs_full_formulae();
     let configure_tags: Vec<String> = if runs_full_formulae {
         plan.tags.iter().filter(|tag| tag.as_str() != FORMULA_PHASE_TAG).cloned().collect()
     } else {
         plan.tags.clone()
     };
-    if (!plan.tap_tokens.is_empty() || !plan.formula_tokens.is_empty())
-        && !runs_full_formulae
-        && !config_tags.iter().any(|tag| tag == FORMULA_PHASE_TAG)
-    {
-        config_tags.push(FORMULA_PHASE_TAG.to_string());
-    }
-    if !plan.cask_tokens.is_empty() && !config_tags.iter().any(|tag| tag == CASK_PHASE_TAG) {
-        config_tags.push(CASK_PHASE_TAG.to_string());
-    }
+    let config_tags = plan.config_deployment_tags();
     role_configs::deploy_for_tags(
         &config_tags,
         &ctx.host_fs,

--- a/src/config_dir.rs
+++ b/src/config_dir.rs
@@ -1,0 +1,43 @@
+//! Resolution of the mev config directory and its well-known entries.
+//!
+//! The config directory is `~/.config/mev/` — the project convention for macOS.
+//! Ansible roles reference `roles_root()` as the `local_config_root` extra var and
+//! expect `~/.config/mev/roles/`, so these paths must not change.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::AppError;
+
+/// Resolve `~/.config/mev/` from the resolved home directory.
+pub fn root(home_dir: &Path) -> PathBuf {
+    home_dir.join(".config").join("mev")
+}
+
+/// Resolve `~/.config/mev/identity.json` from the resolved home directory.
+pub fn identity_file(home_dir: &Path) -> PathBuf {
+    root(home_dir).join("identity.json")
+}
+
+/// Resolve `~/.config/mev/roles/` from the resolved home directory.
+pub fn roles_root(home_dir: &Path) -> PathBuf {
+    root(home_dir).join("roles")
+}
+
+/// Resolve the home directory or surface a typed configuration error.
+pub fn home() -> Result<PathBuf, AppError> {
+    dirs::home_dir()
+        .ok_or_else(|| AppError::Config("home directory could not be resolved".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entries_resolve_under_dot_config_mev() {
+        let home = Path::new("/Users/tester");
+        assert_eq!(root(home), PathBuf::from("/Users/tester/.config/mev"));
+        assert_eq!(identity_file(home), PathBuf::from("/Users/tester/.config/mev/identity.json"));
+        assert_eq!(roles_root(home), PathBuf::from("/Users/tester/.config/mev/roles"));
+    }
+}

--- a/src/identity/file_store.rs
+++ b/src/identity/file_store.rs
@@ -1,30 +1,13 @@
 //! Identity store adapter — JSON persistence on local disk.
 //!
-//! The config directory is `~/.config/` — the project convention for macOS.
-//! Ansible roles reference `local_config_root` as an extra var and expect
-//! `~/.config/mev/roles/`, so this path must not change.
+//! The identity file path is supplied by the caller; see `crate::config_dir`
+//! for resolution of the mev config directory and its entries.
 
 use std::path::{Path, PathBuf};
 
 use crate::error::AppError;
 use crate::identity::model::{Identity, IdentityScope};
 use crate::identity::store::{IdentityState, IdentityStore};
-
-fn dot_config_dir() -> Result<PathBuf, AppError> {
-    dirs::home_dir()
-        .map(|h| h.join(".config"))
-        .ok_or_else(|| AppError::Config("home directory could not be resolved".to_string()))
-}
-
-/// Default path to the mev identity configuration file.
-pub fn default_identity_path() -> Result<PathBuf, AppError> {
-    Ok(dot_config_dir()?.join("mev").join("identity.json"))
-}
-
-/// Default path to the local config root for deployed role configs.
-pub fn local_config_root() -> Result<PathBuf, AppError> {
-    Ok(dot_config_dir()?.join("mev").join("roles"))
-}
 
 pub struct IdentityFileStore {
     identity_path: PathBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub(crate) mod app;
 pub mod backup;
 pub mod cli;
+pub mod config_dir;
 pub mod error;
 pub mod host_fs;
 pub mod identity;

--- a/src/provisioning/execution_plan.rs
+++ b/src/provisioning/execution_plan.rs
@@ -42,13 +42,22 @@ impl ExecutionPlan {
         self.tags.iter().any(|tag| tag == Self::FORMULA_PHASE_TAG)
     }
 
+    /// Tags to run as discrete role steps, excluding the full formula phase tag, which
+    /// is dispatched separately as a brew phase rather than a role step.
+    pub fn execution_tags(&self) -> Vec<String> {
+        if self.runs_full_formulae() {
+            self.tags.iter().filter(|tag| *tag != Self::FORMULA_PHASE_TAG).cloned().collect()
+        } else {
+            self.tags.clone()
+        }
+    }
+
     /// Tags whose role configs must be deployed before execution: the plan tags plus
     /// the brew phase tags implied by required tokens that are not already selected.
     pub fn config_deployment_tags(&self) -> Vec<String> {
         let mut config_tags = self.tags.clone();
         if (!self.tap_tokens.is_empty() || !self.formula_tokens.is_empty())
             && !self.runs_full_formulae()
-            && !config_tags.iter().any(|tag| tag == Self::FORMULA_PHASE_TAG)
         {
             config_tags.push(Self::FORMULA_PHASE_TAG.to_string());
         }
@@ -125,5 +134,97 @@ mod tests {
         assert_eq!(plan.tap_tokens, vec!["editor/tap".to_string()]);
         assert_eq!(plan.formula_tokens, vec!["jq".to_string()]);
         assert_eq!(plan.cask_tokens, vec!["visual-studio-code".to_string(), "zed".to_string()]);
+    }
+
+    fn plan_with_tags(tags: Vec<String>) -> ExecutionPlan {
+        ExecutionPlan::new(
+            Profile::Global,
+            tags,
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            false,
+        )
+    }
+
+    #[test]
+    fn runs_full_formulae_detects_formula_phase_tag() {
+        let with =
+            plan_with_tags(vec!["zsh".to_string(), ExecutionPlan::FORMULA_PHASE_TAG.to_string()]);
+        assert!(with.runs_full_formulae());
+
+        let without = plan_with_tags(vec!["zsh".to_string()]);
+        assert!(!without.runs_full_formulae());
+    }
+
+    #[test]
+    fn execution_tags_excludes_formula_phase_tag_when_present() {
+        let plan = plan_with_tags(vec![
+            "zsh".to_string(),
+            ExecutionPlan::FORMULA_PHASE_TAG.to_string(),
+            "git".to_string(),
+        ]);
+        assert_eq!(plan.execution_tags(), vec!["zsh".to_string(), "git".to_string()]);
+    }
+
+    #[test]
+    fn execution_tags_returns_all_tags_without_formula_phase() {
+        let tags = vec!["zsh".to_string(), "git".to_string()];
+        let plan = plan_with_tags(tags.clone());
+        assert_eq!(plan.execution_tags(), tags);
+    }
+
+    #[test]
+    fn config_deployment_tags_appends_formula_phase_for_required_formulae() {
+        let mut formula_requirements = HashMap::new();
+        formula_requirements.insert("co".to_string(), vec!["jq".to_string()]);
+        let plan = ExecutionPlan::new(
+            Profile::Global,
+            vec!["co".to_string()],
+            &HashMap::new(),
+            &formula_requirements,
+            &HashMap::new(),
+            false,
+        );
+        assert_eq!(
+            plan.config_deployment_tags(),
+            vec!["co".to_string(), ExecutionPlan::FORMULA_PHASE_TAG.to_string()]
+        );
+    }
+
+    #[test]
+    fn config_deployment_tags_appends_cask_phase_for_required_casks() {
+        let mut cask_requirements = HashMap::new();
+        cask_requirements.insert("vscode".to_string(), vec!["visual-studio-code".to_string()]);
+        let plan = ExecutionPlan::new(
+            Profile::Global,
+            vec!["vscode".to_string()],
+            &HashMap::new(),
+            &HashMap::new(),
+            &cask_requirements,
+            false,
+        );
+        assert_eq!(
+            plan.config_deployment_tags(),
+            vec!["vscode".to_string(), ExecutionPlan::CASK_PHASE_TAG.to_string()]
+        );
+    }
+
+    #[test]
+    fn config_deployment_tags_skips_formula_phase_when_full_formulae_runs() {
+        let mut formula_requirements = HashMap::new();
+        formula_requirements.insert("co".to_string(), vec!["jq".to_string()]);
+        let plan = ExecutionPlan::new(
+            Profile::Global,
+            vec!["co".to_string(), ExecutionPlan::FORMULA_PHASE_TAG.to_string()],
+            &HashMap::new(),
+            &formula_requirements,
+            &HashMap::new(),
+            false,
+        );
+        assert_eq!(
+            plan.config_deployment_tags(),
+            vec!["co".to_string(), ExecutionPlan::FORMULA_PHASE_TAG.to_string()]
+        );
     }
 }

--- a/src/provisioning/execution_plan.rs
+++ b/src/provisioning/execution_plan.rs
@@ -16,8 +16,13 @@ pub struct ExecutionPlan {
 }
 
 impl ExecutionPlan {
-    /// Construct a plan for a full environment creation.
-    pub fn full_setup(
+    /// Brew formula installation phase tag.
+    pub const FORMULA_PHASE_TAG: &str = "brew-formulae";
+    /// Brew cask installation phase tag.
+    pub const CASK_PHASE_TAG: &str = "brew-cask";
+
+    /// Resolve brew token requirements for the given tags into an execution plan.
+    pub fn new(
         profile: Profile,
         tags: Vec<String>,
         tap_requirements: &HashMap<String, Vec<String>>,
@@ -31,19 +36,28 @@ impl ExecutionPlan {
         Self { profile, tap_tokens, formula_tokens, cask_tokens, tags, verbose }
     }
 
-    /// Construct a plan for a single make invocation.
-    pub fn make(
-        profile: Profile,
-        tags: Vec<String>,
-        tap_requirements: &HashMap<String, Vec<String>>,
-        formula_requirements: &HashMap<String, Vec<String>>,
-        cask_requirements: &HashMap<String, Vec<String>>,
-        verbose: bool,
-    ) -> Self {
-        let tap_tokens = required_tokens(&tags, tap_requirements);
-        let formula_tokens = required_tokens(&tags, formula_requirements);
-        let cask_tokens = required_tokens(&tags, cask_requirements);
-        Self { profile, tap_tokens, formula_tokens, cask_tokens, tags, verbose }
+    /// Whether the plan runs the full brew formulae phase (all configured formulae)
+    /// rather than only the tokens required by selected tags.
+    pub fn runs_full_formulae(&self) -> bool {
+        self.tags.iter().any(|tag| tag == Self::FORMULA_PHASE_TAG)
+    }
+
+    /// Tags whose role configs must be deployed before execution: the plan tags plus
+    /// the brew phase tags implied by required tokens that are not already selected.
+    pub fn config_deployment_tags(&self) -> Vec<String> {
+        let mut config_tags = self.tags.clone();
+        if (!self.tap_tokens.is_empty() || !self.formula_tokens.is_empty())
+            && !self.runs_full_formulae()
+            && !config_tags.iter().any(|tag| tag == Self::FORMULA_PHASE_TAG)
+        {
+            config_tags.push(Self::FORMULA_PHASE_TAG.to_string());
+        }
+        if !self.cask_tokens.is_empty()
+            && !config_tags.iter().any(|tag| tag == Self::CASK_PHASE_TAG)
+        {
+            config_tags.push(Self::CASK_PHASE_TAG.to_string());
+        }
+        config_tags
     }
 }
 
@@ -67,9 +81,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn full_setup_contains_all_tags() {
+    fn preserves_profile_verbose_and_tags() {
         let test_tags = vec!["tag1".to_string(), "tag2".to_string()];
-        let plan = ExecutionPlan::full_setup(
+        let plan = ExecutionPlan::new(
             Profile::Macbook,
             test_tags.clone(),
             &HashMap::new(),
@@ -87,27 +101,7 @@ mod tests {
     }
 
     #[test]
-    fn make_contains_provided_tags() {
-        let tags = vec!["tag1".to_string(), "tag2".to_string()];
-        let plan = ExecutionPlan::make(
-            Profile::MacMini,
-            tags,
-            &HashMap::new(),
-            &HashMap::new(),
-            &HashMap::new(),
-            false,
-        );
-
-        assert_eq!(plan.profile, Profile::MacMini);
-        assert!(!plan.verbose);
-        assert!(plan.tap_tokens.is_empty());
-        assert!(plan.formula_tokens.is_empty());
-        assert!(plan.cask_tokens.is_empty());
-        assert_eq!(plan.tags, vec!["tag1".to_string(), "tag2".to_string()]);
-    }
-
-    #[test]
-    fn make_deduplicates_brew_tokens_in_tag_order() {
+    fn deduplicates_brew_tokens_in_tag_order() {
         let tags = vec!["vscode".to_string(), "co".to_string(), "zed".to_string()];
         let mut tap_requirements = HashMap::new();
         tap_requirements.insert("zed".to_string(), vec!["editor/tap".to_string()]);
@@ -119,7 +113,7 @@ mod tests {
         cask_requirements.insert("co".to_string(), vec!["visual-studio-code".to_string()]);
         cask_requirements.insert("zed".to_string(), vec!["zed".to_string()]);
 
-        let plan = ExecutionPlan::make(
+        let plan = ExecutionPlan::new(
             Profile::Global,
             tags,
             &tap_requirements,


### PR DESCRIPTION
Behavior-preserving refactors to localized technical debt:

- Collapse identical ExecutionPlan::full_setup/make into ExecutionPlan::new, moving phase-tag reasoning into methods (runs_full_formulae, config_deployment_tags)
- Extract mev config root resolution into dedicated config_dir module, centralizing ~/.config/mev/identity.json and ~/.config/mev/roles paths
- Remove dead helpers from identity/file_store.rs (default_identity_path, local_config_root, dot_config_dir)
- Correct docs/architecture.md Package Structure tree to actual layout (identity/model.rs, backup/code_editors.rs, backup/system/mod.rs, config_dir.rs)

All tests pass, linting clean. No CLI/storage/output changes. Resolves duplicated config-tag augmentation and path construction across create.rs/make.rs/context.rs without modifying behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated configuration directory path management and resolution
  * Enhanced execution plan construction with streamlined phase tag handling
  * Improved module organization for cleaner code structure

* **Documentation**
  * Updated architecture documentation to reflect revised module boundaries and component responsibilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->