### PR TITLE
feat: add statusline configuration for Claude Code, Codex, and Antigr…

### DIFF
--- a/src/assets/ansible/roles/coder/config/global/antigravity-cli/settings.json
+++ b/src/assets/ansible/roles/coder/config/global/antigravity-cli/settings.json
@@ -1,5 +1,9 @@
 {
   "colorScheme": "light",
   "enableTelemetry": false,
-  "enableTerminalSandbox": false
+  "enableTerminalSandbox": false,
+  "statusLine": {
+    "type": "command",
+    "command": "~/.gemini/antigravity-cli/statusline.sh"
+  }
 }

--- a/src/assets/ansible/roles/coder/config/global/antigravity-cli/statusline.sh
+++ b/src/assets/ansible/roles/coder/config/global/antigravity-cli/statusline.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -u
+
+input="$(cat)"
+
+jq_get() {
+  jq -r "$1 // empty" <<<"$input" 2>/dev/null
+}
+
+YELLOW=$'\033[33m'
+BLUE=$'\033[34m'
+ORANGE=$'\033[38;5;208m'
+PURPLE=$'\033[38;5;141m'
+GREEN=$'\033[32m'
+RED=$'\033[31m'
+RESET=$'\033[0m'
+
+# Color a "used percentage" by threshold: <75 green, <90 yellow, else red.
+color_used() {
+  awk -v p="$1" -v g="$GREEN" -v y="$YELLOW" -v r="$RED" 'BEGIN {
+    if (p == "") exit 1
+    if (p < 75) printf "%s", g
+    else if (p < 90) printf "%s", y
+    else printf "%s", r
+  }' 2>/dev/null
+}
+
+model="$(jq_get '.model.display_name // .model.id')"
+dir="$(jq_get '.workspace.current_dir')"
+[ -z "$dir" ] && dir="$(jq_get '.cwd')"
+
+ctx_remaining="$(jq_get '.context_window.remaining_percentage')"
+ctx_used="$(jq_get '.context_window.used_percentage')"
+
+# Quota is reported as remaining_fraction per named bucket; show weekly buckets as used %.
+gemini_remaining="$(jq_get '.quota["gemini-weekly"].remaining_fraction')"
+third_party_remaining="$(jq_get '.quota["3p-weekly"].remaining_fraction')"
+
+branch="-"
+dirty=""
+if [ -n "$dir" ] && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  branch="$(git -C "$dir" branch --show-current 2>/dev/null)"
+  [ -z "$branch" ] && branch="$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)"
+
+  staged="$(git -C "$dir" diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')"
+  modified="$(git -C "$dir" diff --name-only 2>/dev/null | wc -l | tr -d ' ')"
+  untracked="$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')"
+
+  [ "${staged:-0}" -gt 0 ] && dirty="${dirty}+${staged}"
+  [ "${modified:-0}" -gt 0 ] && dirty="${dirty}~${modified}"
+  [ "${untracked:-0}" -gt 0 ] && dirty="${dirty}?${untracked}"
+fi
+
+ctx_text="--"
+if [ -n "$ctx_remaining" ]; then
+  ctx_text="${ctx_remaining%.*}% left"
+elif [ -n "$ctx_used" ]; then
+  ctx_text="${ctx_used%.*}% used"
+fi
+
+# Build a colored "<label> N%" segment from a remaining_fraction (1.0 = unused).
+quota_segment() {
+  local label="$1" frac="$2" pct col
+  [ -z "$frac" ] && return 1
+  pct="$(awk -v f="$frac" 'BEGIN { printf "%.0f", (1 - f) * 100 }' 2>/dev/null)" || return 1
+  col="$(color_used "$pct")" || col="$RED"
+  printf '%s%s %s%%%s' "$col" "$label" "$pct" "$RESET"
+}
+
+limit_text=""
+seg="$(quota_segment gemini "$gemini_remaining")" && limit_text="$seg"
+seg="$(quota_segment 3p "$third_party_remaining")" && limit_text="${limit_text:+$limit_text / }$seg"
+[ -z "$limit_text" ] && limit_text="${RED}limit --${RESET}"
+
+# Model display name embeds reasoning strength, e.g. "Gemini 3.5 Flash (Medium)".
+effort=""
+case "$model" in
+  *\(*\)) effort="${model##*\(}"; effort="effort:${effort%\)}" ;;
+esac
+model_name="${model%% (*}"
+
+model_part="${YELLOW}${model_name:-model?}${RESET}"
+ctx_part="${ORANGE}ctx ${ctx_text}${RESET}"
+branch_part="${BLUE}${branch}${dirty:+ [$dirty]}${RESET}"
+
+echo "${model_part} | ${ctx_part} | ${branch_part}"
+echo "${PURPLE}${effort:-effort:default}${RESET} | ${limit_text}"

--- a/src/assets/ansible/roles/coder/config/global/claude/settings.json
+++ b/src/assets/ansible/roles/coder/config/global/claude/settings.json
@@ -17,6 +17,7 @@
     "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1"
   },
   "permissions": {
+    "defaultMode": "acceptEdits",
     "allow": [
       "Bash(mv:*)",
       "Bash(mkdir:*)",
@@ -44,5 +45,12 @@
     "ask": ["Bash(rm:*)", "Bash(rmdir:*)", "Bash(rm -rf:*)", "Bash(rm -r:*)"]
   },
   "alwaysThinkingEnabled": false,
-  "model": "opus"
+  "model": "opus",
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh",
+    "padding": 1,
+    "refreshInterval": 5,
+    "hideVimModeIndicator": false
+  }
 }

--- a/src/assets/ansible/roles/coder/config/global/claude/statusline.sh
+++ b/src/assets/ansible/roles/coder/config/global/claude/statusline.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -u
+
+input="$(cat)"
+
+jq_get() {
+  jq -r "$1 // empty" <<<"$input" 2>/dev/null
+}
+
+YELLOW=$'\033[33m'
+BLUE=$'\033[34m'
+ORANGE=$'\033[38;5;208m'
+PURPLE=$'\033[38;5;141m'
+GREEN=$'\033[32m'
+RED=$'\033[31m'
+RESET=$'\033[0m'
+
+# Color a "used percentage" by threshold: <75 green, <90 yellow, else red.
+color_used() {
+  awk -v p="$1" -v g="$GREEN" -v y="$YELLOW" -v r="$RED" 'BEGIN {
+    if (p == "") exit 1
+    if (p < 75) printf "%s", g
+    else if (p < 90) printf "%s", y
+    else printf "%s", r
+  }' 2>/dev/null
+}
+
+model="$(jq_get '.model.display_name')"
+dir="$(jq_get '.workspace.current_dir')"
+[ -z "$dir" ] && dir="$(jq_get '.cwd')"
+
+ctx_remaining="$(jq_get '.context_window.remaining_percentage')"
+ctx_used="$(jq_get '.context_window.used_percentage')"
+duration_ms="$(jq_get '.cost.total_duration_ms')"
+five_h="$(jq_get '.rate_limits.five_hour.used_percentage')"
+week="$(jq_get '.rate_limits.seven_day.used_percentage')"
+effort="$(jq_get '.effort.level')"
+thinking="$(jq_get '.thinking.enabled')"
+
+branch="-"
+dirty=""
+if [ -n "$dir" ] && git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  branch="$(git -C "$dir" branch --show-current 2>/dev/null)"
+  [ -z "$branch" ] && branch="$(git -C "$dir" rev-parse --short HEAD 2>/dev/null)"
+
+  staged="$(git -C "$dir" diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')"
+  modified="$(git -C "$dir" diff --name-only 2>/dev/null | wc -l | tr -d ' ')"
+  untracked="$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d ' ')"
+
+  [ "${staged:-0}" -gt 0 ] && dirty="${dirty}+${staged}"
+  [ "${modified:-0}" -gt 0 ] && dirty="${dirty}~${modified}"
+  [ "${untracked:-0}" -gt 0 ] && dirty="${dirty}?${untracked}"
+fi
+
+mins=0
+[ -n "$duration_ms" ] && mins=$((duration_ms / 60000))
+
+ctx_text="--"
+if [ -n "$ctx_remaining" ]; then
+  ctx_text="${ctx_remaining%.*}% left"
+elif [ -n "$ctx_used" ]; then
+  ctx_text="${ctx_used%.*}% used"
+fi
+
+limit_segment() {
+  local label="$1" pct="$2" col
+  [ -z "$pct" ] && return 1
+  pct="$(printf '%.0f' "$pct" 2>/dev/null)" || return 1
+  col="$(color_used "$pct")" || col="$RED"
+  printf '%s%s %s%%%s' "$col" "$label" "$pct" "$RESET"
+}
+
+limit_text=""
+seg="$(limit_segment 5h "$five_h")" && limit_text="$seg"
+seg="$(limit_segment 7d "$week")" && limit_text="${limit_text:+$limit_text / }$seg"
+[ -z "$limit_text" ] && limit_text="${RED}limit --${RESET}"
+
+effort_text="effort:${effort:-default}"
+[ "$thinking" = "true" ] && effort_text="${effort_text} thinking"
+
+model_part="${YELLOW}${model:-model?}${RESET}"
+ctx_part="${ORANGE}ctx ${ctx_text}${RESET}"
+branch_part="${BLUE}${branch}${dirty:+ [$dirty]}${RESET}"
+
+echo "${model_part} | ${ctx_part} | ${branch_part}"
+echo "${PURPLE}${effort_text}${RESET} | ${limit_text} | ${mins}m"

--- a/src/assets/ansible/roles/coder/config/global/codex/config.toml
+++ b/src/assets/ansible/roles/coder/config/global/codex/config.toml
@@ -9,6 +9,18 @@ approval_policy = "on-request"
 # Options: "read-only", "workspace-write", "danger-full-access"
 sandbox_mode = "danger-full-access"
 
+[tui]
+status_line = [
+  "model-with-reasoning",
+  "context-remaining",
+  "context-window-size",
+  "git-branch",
+  "branch-changes",
+  "five-hour-limit",
+  "weekly-limit",
+]
+status_line_use_colors = true
+
 [analytics]
 enabled = false
 

--- a/src/assets/ansible/roles/coder/tasks/main.yml
+++ b/src/assets/ansible/roles/coder/tasks/main.yml
@@ -106,12 +106,14 @@
     force: true
   loop:
     - { src: "{{ local_config_root }}/coder/global/claude/settings.json", dest: ".claude/settings.json" }
+    - { src: "{{ local_config_root }}/coder/global/claude/statusline.sh", dest: ".claude/statusline.sh" }
     - { src: "{{ coder_generated_root }}/AGENTS.md", dest: ".claude/CLAUDE.md" }
     - { src: "{{ local_config_root }}/coder/global/codex/config.toml", dest: ".codex/config.toml" }
     - { src: "{{ coder_generated_root }}/AGENTS.md", dest: ".codex/AGENTS.md" }
     - { src: "{{ coder_generated_root }}/AGENTS.md", dest: ".config/zed/AGENTS.md" }
     - { src: "{{ coder_generated_root }}/AGENTS.md", dest: ".gemini/GEMINI.md" }
     - { src: "{{ local_config_root }}/coder/global/antigravity-cli/settings.json", dest: ".gemini/antigravity-cli/settings.json" }
+    - { src: "{{ local_config_root }}/coder/global/antigravity-cli/statusline.sh", dest: ".gemini/antigravity-cli/statusline.sh" }
 
 - name: "Load agent skills targets"
   ansible.builtin.set_fact:


### PR DESCRIPTION
…avity CLI

- Add statusline.sh for Claude Code: 2-line display with colored model (yellow), ctx remaining (orange), git branch+dirty (blue), effort (purple), and rate limits with threshold coloring (green/yellow/red)
- Add statusline.sh for Antigravity CLI: same layout and color scheme; adapts to quota.remaining_fraction payload shape and extracts reasoning strength from model display name
- Configure Claude Code settings.json with statusLine command block and permissions.defaultMode: acceptEdits
- Configure Codex config.toml with tui.status_line in model→ctx→branch→ limit order
- Add Ansible symlink tasks for both statusline.sh files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status line displays to CLI tools showing real-time context window usage, Git branch status, rate limit information, and model details.
  * Status lines now render with color-coded utilization indicators and effort metrics across multiple CLI interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->