### PR TITLE
Add branch deletion git alias

### DIFF
--- a/crates/mev-vcs/src/error.rs
+++ b/crates/mev-vcs/src/error.rs
@@ -20,6 +20,9 @@ pub enum VcsError {
     #[error("invalid submodule path: {0}")]
     InvalidSubmodulePath(String),
 
+    #[error("invalid branch deletion arguments: {0}")]
+    InvalidBranchDeletionArgs(String),
+
     #[error("{0}")]
     MissingRepository(String),
 

--- a/crates/mev-vcs/src/git/branches.rs
+++ b/crates/mev-vcs/src/git/branches.rs
@@ -12,6 +12,7 @@ const DEFAULT_CHECKOUT_BRANCH: &str = "main";
 /// before deletion. Without a separator, `main` is used.
 pub fn delete(tokens: &[String]) -> Result<(), VcsError> {
     let request = DeleteBranchesRequest::parse(tokens)?;
+    validate_checkout_branch_is_not_deleted(request.delete_branches, request.checkout_branch)?;
     let git = Git::default();
     git.checkout_branch(request.checkout_branch)?;
     git.pull()?;
@@ -66,6 +67,19 @@ impl<'a> DeleteBranchesRequest<'a> {
 
         Ok(Self { delete_branches: tokens, checkout_branch: DEFAULT_CHECKOUT_BRANCH })
     }
+}
+
+fn validate_checkout_branch_is_not_deleted(
+    delete_branches: &[String],
+    checkout_branch: &str,
+) -> Result<(), VcsError> {
+    if delete_branches.iter().any(|branch| branch == checkout_branch) {
+        return Err(VcsError::InvalidBranchDeletionArgs(format!(
+            "cannot delete the checkout branch '{checkout_branch}'"
+        )));
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -160,6 +174,34 @@ mod tests {
         let _guard = unsafe { env_mock::PathGuard::new(&bin_path)? };
 
         let result = delete(&["feature/a".to_string(), "--".to_string()]);
+
+        assert!(result.is_err());
+        assert!(!args_file.exists());
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn fails_before_git_commands_when_deleting_checkout_branch()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let args_file = temp_dir.path().join("git_args.txt");
+        let bin_path = env_mock::create_mock_bin(
+            "git",
+            &temp_dir,
+            &format!(
+                r#"#!/bin/sh
+                echo "$@" >> "{}"
+                exit 0
+            "#,
+                args_file.display()
+            ),
+        )?;
+
+        #[allow(unused_unsafe)]
+        let _guard = unsafe { env_mock::PathGuard::new(&bin_path)? };
+
+        let result = delete(&["main".to_string()]);
 
         assert!(result.is_err());
         assert!(!args_file.exists());

--- a/crates/mev-vcs/src/git/branches.rs
+++ b/crates/mev-vcs/src/git/branches.rs
@@ -1,0 +1,200 @@
+//! Local branch deletion workflow.
+
+use crate::error::VcsError;
+use crate::git::client::Git;
+
+const DEFAULT_CHECKOUT_BRANCH: &str = "main";
+
+/// Update the checkout branch, delete the requested local branches, and prune stale origin refs.
+///
+/// Tokens before a `--` separator are local branch names to delete. When a
+/// separator is present, the single token after it is the branch to checkout
+/// before deletion. Without a separator, `main` is used.
+pub fn delete(tokens: &[String]) -> Result<(), VcsError> {
+    let request = DeleteBranchesRequest::parse(tokens)?;
+    let git = Git::default();
+    git.checkout_branch(request.checkout_branch)?;
+    git.pull()?;
+    git.delete_branches(request.delete_branches)?;
+    git.prune_origin()?;
+    Ok(())
+}
+
+struct DeleteBranchesRequest<'a> {
+    delete_branches: &'a [String],
+    checkout_branch: &'a str,
+}
+
+impl<'a> DeleteBranchesRequest<'a> {
+    fn parse(tokens: &'a [String]) -> Result<Self, VcsError> {
+        match tokens.iter().position(|token| token == "--") {
+            Some(separator) => Self::parse_with_checkout_branch(tokens, separator),
+            None => Self::parse_default_checkout_branch(tokens),
+        }
+    }
+
+    fn parse_with_checkout_branch(
+        tokens: &'a [String],
+        separator: usize,
+    ) -> Result<Self, VcsError> {
+        let delete_branches = &tokens[..separator];
+        let checkout_branches = &tokens[separator + 1..];
+
+        if delete_branches.is_empty() {
+            return Err(VcsError::InvalidBranchDeletionArgs(
+                "at least one branch to delete is required before `--`".to_string(),
+            ));
+        }
+
+        match checkout_branches {
+            [checkout_branch] => Ok(Self { delete_branches, checkout_branch }),
+            [] => Err(VcsError::InvalidBranchDeletionArgs(
+                "checkout branch is required after `--`".to_string(),
+            )),
+            _ => Err(VcsError::InvalidBranchDeletionArgs(
+                "only one checkout branch is allowed after `--`".to_string(),
+            )),
+        }
+    }
+
+    fn parse_default_checkout_branch(tokens: &'a [String]) -> Result<Self, VcsError> {
+        if tokens.is_empty() {
+            return Err(VcsError::InvalidBranchDeletionArgs(
+                "at least one branch to delete is required".to_string(),
+            ));
+        }
+
+        Ok(Self { delete_branches: tokens, checkout_branch: DEFAULT_CHECKOUT_BRANCH })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testing::env_mock;
+    use serial_test::serial;
+    use std::fs;
+
+    #[test]
+    #[serial]
+    fn updates_main_deletes_branches_and_prunes_origin() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let args_file = temp_dir.path().join("git_args.txt");
+        let bin_path = env_mock::create_mock_bin(
+            "git",
+            &temp_dir,
+            &format!(
+                r#"#!/bin/sh
+                echo "$@" >> "{}"
+                exit 0
+            "#,
+                args_file.display()
+            ),
+        )?;
+
+        #[allow(unused_unsafe)]
+        let _guard = unsafe { env_mock::PathGuard::new(&bin_path)? };
+
+        delete(&["feature/a".to_string(), "feature/b".to_string()])?;
+
+        let git_cmds = fs::read_to_string(args_file)?;
+        let lines = git_cmds.lines().map(str::trim).collect::<Vec<_>>();
+        assert_eq!(
+            lines,
+            ["checkout main", "pull", "branch -D -- feature/a feature/b", "remote prune origin",]
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn updates_requested_branch_before_deleting_branches() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp_dir = tempfile::tempdir()?;
+        let args_file = temp_dir.path().join("git_args.txt");
+        let bin_path = env_mock::create_mock_bin(
+            "git",
+            &temp_dir,
+            &format!(
+                r#"#!/bin/sh
+                echo "$@" >> "{}"
+                exit 0
+            "#,
+                args_file.display()
+            ),
+        )?;
+
+        #[allow(unused_unsafe)]
+        let _guard = unsafe { env_mock::PathGuard::new(&bin_path)? };
+
+        delete(&["feature/a".to_string(), "--".to_string(), "develop".to_string()])?;
+
+        let git_cmds = fs::read_to_string(args_file)?;
+        let lines = git_cmds.lines().map(str::trim).collect::<Vec<_>>();
+        assert_eq!(
+            lines,
+            ["checkout develop", "pull", "branch -D -- feature/a", "remote prune origin",]
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn fails_before_git_commands_when_checkout_branch_is_missing()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let args_file = temp_dir.path().join("git_args.txt");
+        let bin_path = env_mock::create_mock_bin(
+            "git",
+            &temp_dir,
+            &format!(
+                r#"#!/bin/sh
+                echo "$@" >> "{}"
+                exit 0
+            "#,
+                args_file.display()
+            ),
+        )?;
+
+        #[allow(unused_unsafe)]
+        let _guard = unsafe { env_mock::PathGuard::new(&bin_path)? };
+
+        let result = delete(&["feature/a".to_string(), "--".to_string()]);
+
+        assert!(result.is_err());
+        assert!(!args_file.exists());
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn stops_before_delete_when_pull_fails() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = tempfile::tempdir()?;
+        let args_file = temp_dir.path().join("git_args.txt");
+        let bin_path = env_mock::create_mock_bin(
+            "git",
+            &temp_dir,
+            &format!(
+                r#"#!/bin/sh
+                echo "$@" >> "{}"
+                if [ "$1" = "pull" ]; then
+                    exit 1
+                fi
+                exit 0
+            "#,
+                args_file.display()
+            ),
+        )?;
+
+        #[allow(unused_unsafe)]
+        let _guard = unsafe { env_mock::PathGuard::new(&bin_path)? };
+
+        let result = delete(&["feature/a".to_string()]);
+
+        assert!(result.is_err());
+        let git_cmds = fs::read_to_string(args_file)?;
+        let lines = git_cmds.lines().map(str::trim).collect::<Vec<_>>();
+        assert_eq!(lines, ["checkout main", "pull"]);
+        Ok(())
+    }
+}

--- a/crates/mev-vcs/src/git/client.rs
+++ b/crates/mev-vcs/src/git/client.rs
@@ -91,6 +91,30 @@ impl Git {
         process::run_status(self.git_command(&args), &format!("git {}", args.join(" ")))
     }
 
+    pub fn checkout_branch(&self, branch: &str) -> Result<(), VcsError> {
+        process::run_status(
+            self.git_command(["checkout", branch]),
+            &format!("git checkout {branch}"),
+        )
+    }
+
+    pub fn pull(&self) -> Result<(), VcsError> {
+        process::run_status(self.git_command(["pull"]), "git pull")
+    }
+
+    pub fn delete_branches(&self, branches: &[String]) -> Result<(), VcsError> {
+        let mut args = vec!["branch".to_owned(), "-D".to_owned(), "--".to_owned()];
+        args.extend(branches.iter().cloned());
+        process::run_status(self.git_command(&args), &format!("git {}", args.join(" ")))
+    }
+
+    pub fn prune_origin(&self) -> Result<(), VcsError> {
+        process::run_status(
+            self.git_command(["remote", "prune", "origin"]),
+            "git remote prune origin",
+        )
+    }
+
     fn git_command<I, S>(&self, args: I) -> Command
     where
         I: IntoIterator<Item = S>,

--- a/crates/mev-vcs/src/git/client.rs
+++ b/crates/mev-vcs/src/git/client.rs
@@ -103,8 +103,8 @@ impl Git {
     }
 
     pub fn delete_branches(&self, branches: &[String]) -> Result<(), VcsError> {
-        let mut args = vec!["branch".to_owned(), "-D".to_owned(), "--".to_owned()];
-        args.extend(branches.iter().cloned());
+        let mut args = vec!["branch", "-D", "--"];
+        args.extend(branches.iter().map(String::as_str));
         process::run_status(self.git_command(&args), &format!("git {}", args.join(" ")))
     }
 

--- a/crates/mev-vcs/src/git/mod.rs
+++ b/crates/mev-vcs/src/git/mod.rs
@@ -1,9 +1,11 @@
 //! git CLI boundary: command execution and the procedures built on it.
 
+mod branches;
 pub mod client;
 mod clone;
 pub mod repo_ref;
 mod submodule;
 
+pub use branches::delete as delete_branches;
 pub use clone::clone as clone_repositories;
 pub use submodule::delete as delete_submodule;

--- a/src/assets/ansible/roles/git/config/global/.gitconfig
+++ b/src/assets/ansible/roles/git/config/global/.gitconfig
@@ -10,6 +10,7 @@
     co-m = checkout main
     b = branch
     br = branch
+    b-d = !mev internal git delete-branches
     cln = remote prune origin
     ft = fetch
 

--- a/src/cli/internal.rs
+++ b/src/cli/internal.rs
@@ -35,6 +35,7 @@ pub struct CloneArgs {
 }
 
 #[derive(Args)]
+#[command(dont_delimit_trailing_values = true)]
 pub struct DeleteBranchesArgs {
     /// Local branch names to delete, optionally followed by `-- <checkout-branch>`.
     #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
@@ -101,6 +102,30 @@ mod tests {
     struct ProbeCli {
         #[command(subcommand)]
         command: InternalCommand,
+    }
+
+    #[test]
+    fn delete_branches_preserves_checkout_separator() {
+        let matches = ProbeCli::command()
+            .try_get_matches_from([
+                "internal",
+                "git",
+                "delete-branches",
+                "feature/a",
+                "--",
+                "develop",
+            ])
+            .unwrap();
+
+        let args = matches
+            .subcommand_matches("git")
+            .and_then(|matches| matches.subcommand_matches("delete-branches"))
+            .and_then(|matches| matches.get_many::<String>("args"))
+            .unwrap()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+
+        assert_eq!(args, ["feature/a", "--", "develop"]);
     }
 
     #[test]

--- a/src/cli/internal.rs
+++ b/src/cli/internal.rs
@@ -19,6 +19,9 @@ pub enum GitCommand {
     /// Clone one or more repositories sequentially.
     Clone(CloneArgs),
 
+    /// Delete one or more local branches after updating main.
+    DeleteBranches(DeleteBranchesArgs),
+
     /// Delete a git submodule completely.
     DeleteSubmodule(DeleteSubmoduleArgs),
 }
@@ -27,6 +30,13 @@ pub enum GitCommand {
 pub struct CloneArgs {
     /// Repository URLs to clone in order, optionally mixed with `git clone` flags
     /// (e.g. `--depth 1`) that are applied to every clone.
+    #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
+    pub args: Vec<String>,
+}
+
+#[derive(Args)]
+pub struct DeleteBranchesArgs {
+    /// Local branch names to delete, optionally followed by `-- <checkout-branch>`.
     #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]
     pub args: Vec<String>,
 }
@@ -65,6 +75,9 @@ pub fn run(command: InternalCommand) -> Result<(), AppError> {
         InternalCommand::Git(GitCommand::Clone(args)) => {
             mev_vcs::git::clone_repositories(&args.args)
         }
+        InternalCommand::Git(GitCommand::DeleteBranches(args)) => {
+            mev_vcs::git::delete_branches(&args.args)
+        }
         InternalCommand::Git(GitCommand::DeleteSubmodule(args)) => {
             mev_vcs::git::delete_submodule(&args.submodule_path)
         }
@@ -96,6 +109,7 @@ mod tests {
             &["internal", "gh", "labels", "deploy", "--help"],
             &["internal", "gh", "labels", "reset", "--help"],
             &["internal", "git", "clone", "--help"],
+            &["internal", "git", "delete-branches", "--help"],
             &["internal", "git", "delete-submodule", "--help"],
         ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new branch deletion command that streamlines local branch management by supporting deletion of multiple branches, with optional checkout branch specification and automatic remote reference cleanup.
  * Added `b-d` git alias for quick access to the branch deletion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->